### PR TITLE
DM-14076: Add currentmodule directive to module doc page in stack_package template

### DIFF
--- a/project_templates/stack_package/example/doc/lsst.example/index.rst
+++ b/project_templates/stack_package/example/doc/lsst.example/index.rst
@@ -1,3 +1,5 @@
+.. py:currentmodule:: lsst.example
+
 .. _lsst.example:
 
 ############

--- a/project_templates/stack_package/example_pythononly/doc/lsst.example.pythononly/index.rst
+++ b/project_templates/stack_package/example_pythononly/doc/lsst.example.pythononly/index.rst
@@ -1,3 +1,5 @@
+.. py:currentmodule:: lsst.example.pythononly
+
 .. _lsst.example.pythononly:
 
 #######################

--- a/project_templates/stack_package/example_subpackage/doc/lsst.example.subpackage/index.rst
+++ b/project_templates/stack_package/example_subpackage/doc/lsst.example.subpackage/index.rst
@@ -1,3 +1,5 @@
+.. py:currentmodule:: lsst.example.subpackage
+
 .. _lsst.example.subpackage:
 
 #######################

--- a/project_templates/stack_package/{{cookiecutter.package_name}}/doc/{{cookiecutter.python_module}}/index.rst
+++ b/project_templates/stack_package/{{cookiecutter.package_name}}/doc/{{cookiecutter.python_module}}/index.rst
@@ -1,3 +1,5 @@
+.. py:currentmodule:: {{ cookiecutter.python_module }}
+
 .. _{{ cookiecutter.python_module }}:
 
 {{ "#" * cookiecutter.python_module|length }}


### PR DESCRIPTION
The `py:currentmodule` directive enables writers to refer to APIs without specifying the full namespace.

*Note: content changes in `example*/` directories are all auto-generated but do demo the outcomes of the template change.*