### PR TITLE
DM-14668: Remove version pinning from stack_package table file

### DIFF
--- a/project_templates/stack_package/CHANGELOG.md
+++ b/project_templates/stack_package/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Change log
+
+## 2018-06-04
+
+- Remove version pinning from `ups/{{package_name}}.table`.
+  Version pinning isn't used anymore since all packages are tagged together.
+  ([DM-14668](https://jira.lsstcorp.org/browse/DM-14668))

--- a/project_templates/stack_package/example/ups/example.table
+++ b/project_templates/stack_package/example/ups/example.table
@@ -1,13 +1,12 @@
-# For each dependency except python, list it here along with its minimum
-# version number.
-# Very common third-party packages (boost, python, swig, doxygen) 
-# and very low-level LSST packages can be assumed to be recursively
-# included by low-level LSST packages such as utils or daf_base.
-# Any other package whose interface is used should be listed explicitly
-# rather than assuming it will be included recursively.
-setupRequired(boost >= 1.47.0)
-setupRequired(utils >= 4.6.0.0)
-setupRequired(pex_exceptions >= 4.6.0.0)
+# List EUPS dependencies of this package here
+# - Common third-party packages (boost, python, doxygen) and low-level
+#   LSST packages can be assumed to be recursively included by low-level
+#   LSST packages such as utils or daf_base.
+# - Any package whose API is used should be listed explicitly
+#   rather than assuming it will be included recursively.
+setupRequired(boost)
+setupRequired(utils)
+setupRequired(pex_exceptions)
 setupRequired(ndarray)
 
 # The following is boilerplate for all packages.

--- a/project_templates/stack_package/example_pythononly/ups/example_pythononly.table
+++ b/project_templates/stack_package/example_pythononly/ups/example_pythononly.table
@@ -1,13 +1,12 @@
-# For each dependency except python, list it here along with its minimum
-# version number.
-# Very common third-party packages (boost, python, swig, doxygen) 
-# and very low-level LSST packages can be assumed to be recursively
-# included by low-level LSST packages such as utils or daf_base.
-# Any other package whose interface is used should be listed explicitly
-# rather than assuming it will be included recursively.
-setupRequired(boost >= 1.47.0)
-setupRequired(utils >= 4.6.0.0)
-setupRequired(pex_exceptions >= 4.6.0.0)
+# List EUPS dependencies of this package here
+# - Common third-party packages (boost, python, doxygen) and low-level
+#   LSST packages can be assumed to be recursively included by low-level
+#   LSST packages such as utils or daf_base.
+# - Any package whose API is used should be listed explicitly
+#   rather than assuming it will be included recursively.
+setupRequired(boost)
+setupRequired(utils)
+setupRequired(pex_exceptions)
 setupRequired(ndarray)
 
 # The following is boilerplate for all packages.

--- a/project_templates/stack_package/example_subpackage/ups/example_subpackage.table
+++ b/project_templates/stack_package/example_subpackage/ups/example_subpackage.table
@@ -1,13 +1,12 @@
-# For each dependency except python, list it here along with its minimum
-# version number.
-# Very common third-party packages (boost, python, swig, doxygen) 
-# and very low-level LSST packages can be assumed to be recursively
-# included by low-level LSST packages such as utils or daf_base.
-# Any other package whose interface is used should be listed explicitly
-# rather than assuming it will be included recursively.
-setupRequired(boost >= 1.47.0)
-setupRequired(utils >= 4.6.0.0)
-setupRequired(pex_exceptions >= 4.6.0.0)
+# List EUPS dependencies of this package here
+# - Common third-party packages (boost, python, doxygen) and low-level
+#   LSST packages can be assumed to be recursively included by low-level
+#   LSST packages such as utils or daf_base.
+# - Any package whose API is used should be listed explicitly
+#   rather than assuming it will be included recursively.
+setupRequired(boost)
+setupRequired(utils)
+setupRequired(pex_exceptions)
 setupRequired(ndarray)
 
 # The following is boilerplate for all packages.

--- a/project_templates/stack_package/{{cookiecutter.package_name}}/ups/{{cookiecutter.package_name}}.table
+++ b/project_templates/stack_package/{{cookiecutter.package_name}}/ups/{{cookiecutter.package_name}}.table
@@ -1,13 +1,12 @@
-# For each dependency except python, list it here along with its minimum
-# version number.
-# Very common third-party packages (boost, python, swig, doxygen) 
-# and very low-level LSST packages can be assumed to be recursively
-# included by low-level LSST packages such as utils or daf_base.
-# Any other package whose interface is used should be listed explicitly
-# rather than assuming it will be included recursively.
-setupRequired(boost >= 1.47.0)
-setupRequired(utils >= 4.6.0.0)
-setupRequired(pex_exceptions >= 4.6.0.0)
+# List EUPS dependencies of this package here
+# - Common third-party packages (boost, python, doxygen) and low-level
+#   LSST packages can be assumed to be recursively included by low-level
+#   LSST packages such as utils or daf_base.
+# - Any package whose API is used should be listed explicitly
+#   rather than assuming it will be included recursively.
+setupRequired(boost)
+setupRequired(utils)
+setupRequired(pex_exceptions)
 setupRequired(ndarray)
 
 # The following is boilerplate for all packages.


### PR DESCRIPTION
- Version pinning isn't used anymore since packages are always tagged together.

- Modernize comments in table file.