### PR TITLE
DM-14860: Add disableCc=True flag when uses_cpp is False

### DIFF
--- a/project_templates/stack_package/example_pythononly/SConstruct
+++ b/project_templates/stack_package/example_pythononly/SConstruct
@@ -1,3 +1,4 @@
 # -*- python -*-
 from lsst.sconsUtils import scripts
-scripts.BasicSConstruct("example_pythononly")
+# Python-only package
+scripts.BasicSConstruct("example_pythononly", disableCc=True)

--- a/project_templates/stack_package/{{cookiecutter.package_name}}/SConstruct
+++ b/project_templates/stack_package/{{cookiecutter.package_name}}/SConstruct
@@ -1,3 +1,9 @@
 # -*- python -*-
 from lsst.sconsUtils import scripts
+
+{%- if cookiecutter.uses_cpp == 'True' %}
 scripts.BasicSConstruct("{{ cookiecutter.package_name }}")
+{%- else %}
+# Python-only package
+scripts.BasicSConstruct("{{ cookiecutter.package_name }}", disableCc=True)
+{%- endif %}


### PR DESCRIPTION
This BasicSConstruct flag makes it easier to develop pure-python packages without needing cc compilers during build time.