### PR TITLE
DM-15110: Various updates to the stack_package template

### DIFF
--- a/project_templates/stack_package/CHANGELOG.md
+++ b/project_templates/stack_package/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Change log
 
+## 2018-07-13
+
+- Deleted the `ups/*.build` file.
+  It turns out that this file is not used by the build system.
+
+- Added `pyList` argument to the `tests/Sconscript` file.
+  This enables auto file detection.
+
+- Updated the `setup.cfg` configuration file.
+  This adds the N806 flake8 exception and the `[tool:pytest]` section.
+
+- Updated the default `automodapi` usage in module documenation homepages.
+
+  - `no-main-docstr` is something we always want to use since the main docstring in `__init__.py` shouldn't be used, in favour of writing topics in the `doc/` directory.
+
+  - Most modules don't have interesting class inheritance, so it makes sense to default to `no-inheritance-diagram`.
+
+([DM-15110](https://jira.lsstcorp.org/browse/DM-15110))
+
 ## 2018-07-06
 
 - Add a `uses_python` configuration in `cookiecutter.json`.

--- a/project_templates/stack_package/README.md
+++ b/project_templates/stack_package/README.md
@@ -260,13 +260,6 @@ You shouldn't need to modify this file.
 Place all unit test modules in the `tests` directory.
 See the [Python Unit Testing](https://developer.lsst.io/python/testing.html) documentation in the Developer Guide for details.
 
-### ups/{{cookiecutter.package_name}}.build
-
-Example: [ups/example.build](example/ups/example.build).
-
-This file is used by EUPS.
-You shouldn't need to modify it.
-
 ### ups/{{cookiecutter.package_name}}.cfg
 
 Example: [ups/example.cfg](example/ups/example.cfg).

--- a/project_templates/stack_package/example/doc/lsst.example/index.rst
+++ b/project_templates/stack_package/example/doc/lsst.example/index.rst
@@ -34,3 +34,5 @@ Python API reference
 ====================
 
 .. automodapi:: lsst.example
+   :no-main-docstr:
+   :no-inheritance-diagram:

--- a/project_templates/stack_package/example/setup.cfg
+++ b/project_templates/stack_package/example/setup.cfg
@@ -1,9 +1,13 @@
 [flake8]
 max-line-length = 110
-ignore = E133, E226, E228, N802, N803
+ignore = E133, E226, E228, N802, N803, N806
 exclude =
   bin,
   doc,
   **/*/__init__.py,
   **/*/version.py,
   tests/.tests
+
+[tool:pytest]
+addopts = --flake8
+flake8-ignore = E133 E226 E228 E251 N802 N803 N806

--- a/project_templates/stack_package/example/tests/SConscript
+++ b/project_templates/stack_package/example/tests/SConscript
@@ -1,3 +1,3 @@
 # -*- python -*-
 from lsst.sconsUtils import scripts
-scripts.BasicSConscript.tests()
+scripts.BasicSConscript.tests(pyList=[])

--- a/project_templates/stack_package/example/ups/example.build
+++ b/project_templates/stack_package/example/ups/example.build
@@ -1,2 +1,0 @@
-@LSST BUILD@
-build_lsst @PRODUCT@ @VERSION@ @REPOVERSION@

--- a/project_templates/stack_package/example_dataonly/ups/example_dataonly.build
+++ b/project_templates/stack_package/example_dataonly/ups/example_dataonly.build
@@ -1,2 +1,0 @@
-@LSST BUILD@
-build_lsst @PRODUCT@ @VERSION@ @REPOVERSION@

--- a/project_templates/stack_package/example_pythononly/doc/lsst.example.pythononly/index.rst
+++ b/project_templates/stack_package/example_pythononly/doc/lsst.example.pythononly/index.rst
@@ -34,3 +34,5 @@ Python API reference
 ====================
 
 .. automodapi:: lsst.example.pythononly
+   :no-main-docstr:
+   :no-inheritance-diagram:

--- a/project_templates/stack_package/example_pythononly/setup.cfg
+++ b/project_templates/stack_package/example_pythononly/setup.cfg
@@ -1,9 +1,13 @@
 [flake8]
 max-line-length = 110
-ignore = E133, E226, E228, N802, N803
+ignore = E133, E226, E228, N802, N803, N806
 exclude =
   bin,
   doc,
   **/*/__init__.py,
   **/*/version.py,
   tests/.tests
+
+[tool:pytest]
+addopts = --flake8
+flake8-ignore = E133 E226 E228 E251 N802 N803 N806

--- a/project_templates/stack_package/example_pythononly/tests/SConscript
+++ b/project_templates/stack_package/example_pythononly/tests/SConscript
@@ -1,3 +1,3 @@
 # -*- python -*-
 from lsst.sconsUtils import scripts
-scripts.BasicSConscript.tests()
+scripts.BasicSConscript.tests(pyList=[])

--- a/project_templates/stack_package/example_pythononly/ups/example_pythononly.build
+++ b/project_templates/stack_package/example_pythononly/ups/example_pythononly.build
@@ -1,2 +1,0 @@
-@LSST BUILD@
-build_lsst @PRODUCT@ @VERSION@ @REPOVERSION@

--- a/project_templates/stack_package/example_subpackage/doc/lsst.example.subpackage/index.rst
+++ b/project_templates/stack_package/example_subpackage/doc/lsst.example.subpackage/index.rst
@@ -34,3 +34,5 @@ Python API reference
 ====================
 
 .. automodapi:: lsst.example.subpackage
+   :no-main-docstr:
+   :no-inheritance-diagram:

--- a/project_templates/stack_package/example_subpackage/setup.cfg
+++ b/project_templates/stack_package/example_subpackage/setup.cfg
@@ -1,9 +1,13 @@
 [flake8]
 max-line-length = 110
-ignore = E133, E226, E228, N802, N803
+ignore = E133, E226, E228, N802, N803, N806
 exclude =
   bin,
   doc,
   **/*/__init__.py,
   **/*/version.py,
   tests/.tests
+
+[tool:pytest]
+addopts = --flake8
+flake8-ignore = E133 E226 E228 E251 N802 N803 N806

--- a/project_templates/stack_package/example_subpackage/tests/SConscript
+++ b/project_templates/stack_package/example_subpackage/tests/SConscript
@@ -1,3 +1,3 @@
 # -*- python -*-
 from lsst.sconsUtils import scripts
-scripts.BasicSConscript.tests()
+scripts.BasicSConscript.tests(pyList=[])

--- a/project_templates/stack_package/example_subpackage/ups/example_subpackage.build
+++ b/project_templates/stack_package/example_subpackage/ups/example_subpackage.build
@@ -1,2 +1,0 @@
-@LSST BUILD@
-build_lsst @PRODUCT@ @VERSION@ @REPOVERSION@

--- a/project_templates/stack_package/{{cookiecutter.package_name}}/doc/{{cookiecutter.python_module}}/index.rst
+++ b/project_templates/stack_package/{{cookiecutter.package_name}}/doc/{{cookiecutter.python_module}}/index.rst
@@ -34,3 +34,5 @@ Python API reference
 ====================
 
 .. automodapi:: {{ cookiecutter.python_module }}
+   :no-main-docstr:
+   :no-inheritance-diagram:

--- a/project_templates/stack_package/{{cookiecutter.package_name}}/setup.cfg
+++ b/project_templates/stack_package/{{cookiecutter.package_name}}/setup.cfg
@@ -1,9 +1,13 @@
 [flake8]
 max-line-length = 110
-ignore = E133, E226, E228, N802, N803
+ignore = E133, E226, E228, N802, N803, N806
 exclude =
   bin,
   doc,
   **/*/__init__.py,
   **/*/version.py,
   tests/.tests
+
+[tool:pytest]
+addopts = --flake8
+flake8-ignore = E133 E226 E228 E251 N802 N803 N806

--- a/project_templates/stack_package/{{cookiecutter.package_name}}/tests/SConscript
+++ b/project_templates/stack_package/{{cookiecutter.package_name}}/tests/SConscript
@@ -1,3 +1,3 @@
 # -*- python -*-
 from lsst.sconsUtils import scripts
-scripts.BasicSConscript.tests()
+scripts.BasicSConscript.tests(pyList=[])

--- a/project_templates/stack_package/{{cookiecutter.package_name}}/ups/{{cookiecutter.package_name}}.build
+++ b/project_templates/stack_package/{{cookiecutter.package_name}}/ups/{{cookiecutter.package_name}}.build
@@ -1,2 +1,0 @@
-@LSST BUILD@
-build_lsst @PRODUCT@ @VERSION@ @REPOVERSION@


### PR DESCRIPTION
- Deleted the `ups/*.build` file.
  It turns out that this file is not used by the build system.

- Added `pyList` argument to the `tests/Sconscript` file.
  This enables auto file detection.

- Updated the `setup.cfg` configuration file.
  This adds the N806 flake8 exception and the `[tool:pytest]` section.

- Updated the default `automodapi` usage in module documenation homepages.

  - `no-main-docstr` is something we always want to use since the main docstring in `__init__.py` shouldn't be used, in favour of writing topics in the `doc/` directory.

  - Most modules don't have interesting class inheritance, so it makes sense to default to `no-inheritance-diagram`.