### PR TITLE
Add --exit-code flag so unclean examples fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ script:
   # Test the examples by rebuilding them and making sure they match the
   # committed state (so that the repo is clean).
   - "scons"
-  - "git diff-files"
+  - "git diff --exit-code"


### PR DESCRIPTION
The `--exit-code` flag is necessary so that the git diff-files command returns a non-zero status code if  scons-ing the examples produced changes.