### PR TITLE
Switch to git diff --exit-code flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ script:
   # Test the examples by rebuilding them and making sure they match the
   # committed state (so that the repo is clean).
   - "scons"
-  - "git diff-files"
+  - "git diff --exit-code"


### PR DESCRIPTION
The `--exit-code` flag is necessary so that the git diff command returns a non-zero status code if scons-ing the examples produced changes.

However `git diff-files` produces "false positives" on Travis (possibly because of changed file ownership? or modification date metadata? not sure). However, git diff seems to just check if the
content has changed, which is exactly what we want.