### PR TITLE
DM-16040: Remove unnecessary condition E251

### DIFF
--- a/project_templates/stack_package/CHANGELOG.md
+++ b/project_templates/stack_package/CHANGELOG.md
@@ -5,6 +5,9 @@
 - `doc/SConscript` and `doc/doxygen.conf.in` are no longer included in packages that don't use C++.
 - `conf.py` does not attempt to import a package if it doesn't not use Python.
 - The package homepage no longer refers to the (nonexistent) Python module.
+- The E251 rule exception is no longer included in `setup.cfg` since it is also not adopted by the [Python style guide](https://developer.lsst.io/python/style.html#exceptions-to-pep-8).
+
+([DM-15973](https://jira.lsstcorp.org/browse/DM-15973), [DM-16040](https://jira.lsstcorp.org/browse/DM-16040))
 
 ## 2018-07-13
 

--- a/project_templates/stack_package/example/setup.cfg
+++ b/project_templates/stack_package/example/setup.cfg
@@ -10,4 +10,4 @@ exclude =
 
 [tool:pytest]
 addopts = --flake8
-flake8-ignore = E133 E226 E228 E251 N802 N803 N806
+flake8-ignore = E133 E226 E228 N802 N803 N806

--- a/project_templates/stack_package/example_pythononly/setup.cfg
+++ b/project_templates/stack_package/example_pythononly/setup.cfg
@@ -10,4 +10,4 @@ exclude =
 
 [tool:pytest]
 addopts = --flake8
-flake8-ignore = E133 E226 E228 E251 N802 N803 N806
+flake8-ignore = E133 E226 E228 N802 N803 N806

--- a/project_templates/stack_package/example_subpackage/setup.cfg
+++ b/project_templates/stack_package/example_subpackage/setup.cfg
@@ -10,4 +10,4 @@ exclude =
 
 [tool:pytest]
 addopts = --flake8
-flake8-ignore = E133 E226 E228 E251 N802 N803 N806
+flake8-ignore = E133 E226 E228 N802 N803 N806

--- a/project_templates/stack_package/{{cookiecutter.package_name}}/setup.cfg
+++ b/project_templates/stack_package/{{cookiecutter.package_name}}/setup.cfg
@@ -10,4 +10,4 @@ exclude =
 
 [tool:pytest]
 addopts = --flake8
-flake8-ignore = E133 E226 E228 E251 N802 N803 N806
+flake8-ignore = E133 E226 E228 N802 N803 N806


### PR DESCRIPTION
The E251 rule exception is no longer included in `setup.cfg` since it is also not adopted by the [Python style guide](https://developer.lsst.io/python/style.html#exceptions-to-pep-8).

Implements #19 