### PR TITLE
DM-15422: Labels in task topic use full namespace

### DIFF
--- a/file_templates/task_topic/lsst.example.ExampleCmdLineTask.rst
+++ b/file_templates/task_topic/lsst.example.ExampleCmdLineTask.rst
@@ -12,7 +12,7 @@ ExampleCmdLineTask
 .. If there are many datasets, name the ones that people use more frequently.
 ``ExampleCmdLineTask`` is available as a :ref:`command-line task <pipe-tasks-command-line-tasks>`, :command:`exampleCmdLineTask.py`.
 
-.. _ExampleCmdLineTask-summary:
+.. _lsst.example.ExampleCmdLineTask-summary:
 
 Processing summary
 ==================
@@ -28,7 +28,7 @@ Processing summary
 
 #. Stores those results in this last step. (FIXME)
 
-.. ExampleCmdLineTask-cli:
+.. lsst.example.ExampleCmdLineTask-cli:
 
 exampleCmdLineTask.py command-line interface
 ============================================
@@ -51,14 +51,14 @@ Key options:
 
    See :ref:`command-line-task-argument-reference` for details and additional options.
 
-.. _ExampleCmdLineTask-api:
+.. _lsst.example.ExampleCmdLineTask-api:
 
 Python API summary
 ==================
 
 .. lsst-task-api-summary:: lsst.example.ExampleCmdLineTask
 
-.. _ExampleCmdLineTask-butler:
+.. _lsst.example.ExampleCmdLineTask-butler:
 
 Butler datasets
 ===============
@@ -66,7 +66,7 @@ Butler datasets
 When run as the ``exampleCmdLineTask.py`` command-line task, or directly through the `~lsst.example.ExampleCmdLineTask.runDataRef` method, ``ExampleCmdLineTask`` obtains datasets from the input Butler data repository and persists outputs to the output Butler data repository.
 Note that configurations for ``ExampleCmdLineTask``, and its subtasks, affect what datasets are persisted and what their content is.
 
-.. _ExampleCmdLineTask-butler-inputs:
+.. _lsst.example.ExampleCmdLineTask-butler-inputs:
 
 Input datasets
 --------------
@@ -74,7 +74,7 @@ Input datasets
 ``fixmeDatasetName``
     Brief description of the dataset.
 
-.. _ExampleCmdLineTask-butler-outputs:
+.. _lsst.example.ExampleCmdLineTask-butler-outputs:
 
 Output datasets
 ---------------
@@ -83,21 +83,21 @@ Output datasets
     Brief description of this output dataset.
 
 
-.. _ExampleCmdLineTask-subtasks:
+.. _lsst.example.ExampleCmdLineTask-subtasks:
 
 Retargetable subtasks
 =====================
 
 .. lsst-task-config-subtasks:: lsst.pipe.tasks.processCcd.ProcessCcdTask
 
-.. _ExampleCmdLineTask-configs:
+.. _lsst.example.ExampleCmdLineTask-configs:
 
 Configuration fields
 ====================
 
 .. lsst-task-config-fields:: lsst.pipe.tasks.processCcd.ProcessCcdTask
 
-.. _ExampleCmdLineTask-examples:
+.. _lsst.example.ExampleCmdLineTask-examples:
 
 Examples
 ========
@@ -107,7 +107,7 @@ Examples
 .. (such as one from a command-line context and another that uses the Python API)
 .. you can separate each example into a different subsection for clarity.
 
-.. _ExampleCmdLineTask-debug:
+.. _lsst.example.ExampleCmdLineTask-debug:
 
 Debugging
 =========

--- a/file_templates/task_topic/lsst.example.ExampleTask.rst
+++ b/file_templates/task_topic/lsst.example.ExampleTask.rst
@@ -11,7 +11,7 @@ ExampleTask
 .. If the task consumes or creates datasets, name those datasets here.
 .. If there are many datasets, name the ones that people use more frequently.
 
-.. _ExampleTask-summary:
+.. _lsst.example.ExampleTask-summary:
 
 Processing summary
 ==================
@@ -27,28 +27,28 @@ Processing summary
 
 #. Stores those results in this last step. (FIXME)
 
-.. _ExampleTask-api:
+.. _lsst.example.ExampleTask-api:
 
 Python API summary
 ==================
 
 .. lsst-task-api-summary:: lsst.example.ExampleTask
 
-.. _ExampleTask-subtasks:
+.. _lsst.example.ExampleTask-subtasks:
 
 Retargetable subtasks
 =====================
 
 .. lsst-task-config-subtasks:: lsst.pipe.tasks.processCcd.ProcessCcdTask
 
-.. _ExampleTask-configs:
+.. _lsst.example.ExampleTask-configs:
 
 Configuration fields
 ====================
 
 .. lsst-task-config-fields:: lsst.pipe.tasks.processCcd.ProcessCcdTask
 
-.. _ExampleTask-examples:
+.. _lsst.example.ExampleTask-examples:
 
 Examples
 ========
@@ -58,7 +58,7 @@ Examples
 .. (such as one from a command-line context and another that uses the Python API)
 .. you can separate each example into a different subsection for clarity.
 
-.. _ExampleTask-debug:
+.. _lsst.example.ExampleTask-debug:
 
 Debugging
 =========

--- a/file_templates/task_topic/{{cookiecutter.task_module}}.{{cookiecutter.task_class}}.rst.jinja
+++ b/file_templates/task_topic/{{cookiecutter.task_module}}.{{cookiecutter.task_class}}.rst.jinja
@@ -14,7 +14,7 @@
 ``{{ cookiecutter.task_class }}`` is available as a :ref:`command-line task <pipe-tasks-command-line-tasks>`, :command:`{{ cookiecutter.script_name }}`.
 {%- endif %}
 
-.. _{{ cookiecutter.task_class}}-summary:
+.. _{{ cookiecutter.task_module }}.{{ cookiecutter.task_class}}-summary:
 
 Processing summary
 ==================
@@ -31,7 +31,7 @@ Processing summary
 #. Stores those results in this last step. (FIXME)
 {%- if cookiecutter.script_name|length > 0 %}
 
-.. {{ cookiecutter.task_class}}-cli:
+.. {{ cookiecutter.task_module }}.{{ cookiecutter.task_class}}-cli:
 
 {{ cookiecutter.script_name }} command-line interface
 {{ "=" * (cookiecutter.script_name|length + 23) }}
@@ -55,7 +55,7 @@ Key options:
    See :ref:`command-line-task-argument-reference` for details and additional options.
 {%- endif %}
 
-.. _{{ cookiecutter.task_class }}-api:
+.. _{{ cookiecutter.task_module }}.{{ cookiecutter.task_class }}-api:
 
 Python API summary
 ==================
@@ -63,7 +63,7 @@ Python API summary
 .. lsst-task-api-summary:: {{ cookiecutter.task_module }}.{{ cookiecutter.task_class }}
 {%- if cookiecutter.script_name|length > 0 %}
 
-.. _{{ cookiecutter.task_class }}-butler:
+.. _{{ cookiecutter.task_module }}.{{ cookiecutter.task_class }}-butler:
 
 Butler datasets
 ===============
@@ -71,7 +71,7 @@ Butler datasets
 When run as the ``{{ cookiecutter.script_name }}`` command-line task, or directly through the `~{{ cookiecutter.task_module}}.{{ cookiecutter.task_class }}.runDataRef` method, ``{{ cookiecutter.task_class }}`` obtains datasets from the input Butler data repository and persists outputs to the output Butler data repository.
 Note that configurations for ``{{ cookiecutter.task_class }}``, and its subtasks, affect what datasets are persisted and what their content is.
 
-.. _{{ cookiecutter.task_class }}-butler-inputs:
+.. _{{ cookiecutter.task_module }}.{{ cookiecutter.task_class }}-butler-inputs:
 
 Input datasets
 --------------
@@ -79,7 +79,7 @@ Input datasets
 ``fixmeDatasetName``
     Brief description of the dataset.
 
-.. _{{ cookiecutter.task_class }}-butler-outputs:
+.. _{{ cookiecutter.task_module }}.{{ cookiecutter.task_class }}-butler-outputs:
 
 Output datasets
 ---------------
@@ -88,21 +88,21 @@ Output datasets
     Brief description of this output dataset.
 {% endif %}
 
-.. _{{ cookiecutter.task_class }}-subtasks:
+.. _{{ cookiecutter.task_module }}.{{ cookiecutter.task_class }}-subtasks:
 
 Retargetable subtasks
 =====================
 
 .. lsst-task-config-subtasks:: lsst.pipe.tasks.processCcd.ProcessCcdTask
 
-.. _{{ cookiecutter.task_class }}-configs:
+.. _{{ cookiecutter.task_module }}.{{ cookiecutter.task_class }}-configs:
 
 Configuration fields
 ====================
 
 .. lsst-task-config-fields:: lsst.pipe.tasks.processCcd.ProcessCcdTask
 
-.. _{{ cookiecutter.task_class }}-examples:
+.. _{{ cookiecutter.task_module }}.{{ cookiecutter.task_class }}-examples:
 
 Examples
 ========
@@ -112,7 +112,7 @@ Examples
 .. (such as one from a command-line context and another that uses the Python API)
 .. you can separate each example into a different subsection for clarity.
 
-.. _{{ cookiecutter.task_class }}-debug:
+.. _{{ cookiecutter.task_module }}.{{ cookiecutter.task_class }}-debug:
 
 Debugging
 =========


### PR DESCRIPTION
This will ensure that labels are unique even if there is a class name collision.