### PR TITLE
DM-16437: Stack package updates (base and utils dependencies, W504, gitignores)

### DIFF
--- a/project_templates/stack_package/CHANGELOG.md
+++ b/project_templates/stack_package/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 2018-11-02
+
+- Added `bin/` and `.coverage` to `.gitignore`.
+
 ## 2018-10-10
 
 - New "Task reference" section in the module homepages.

--- a/project_templates/stack_package/CHANGELOG.md
+++ b/project_templates/stack_package/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 2018-11-02
 
 - Added `bin/` and `.coverage` to `.gitignore`.
+- Added `base` as a default EUPS dependency.
+  This prevents packages that have not other dependencies from having errors about getting `lsstimport`.
+  Packages that add high-level dependencies can drop the explicit dependency on `base`.
 
 ## 2018-10-10
 

--- a/project_templates/stack_package/CHANGELOG.md
+++ b/project_templates/stack_package/CHANGELOG.md
@@ -7,6 +7,9 @@
   This prevents packages that have not other dependencies from having errors about getting `lsstimport`.
   Packages that add high-level dependencies can drop the explicit dependency on `base`.
 - Also add `utils` as a default EUPS dependency since it is necessary for unit tests, in most cases.
+- Marked W504 (line break after binary operator) as an ignored Flake8 rule.
+  This rule was introduced by pycodestyle 2.4.0, but is not part of the [DM Python Style Guide](https://developer.lsst.io/python/style.html).
+  See the post [Changes to baseline software versions](https://community.lsst.org/t/changes-to-baseline-software-versions/3366).
 
 [DM-16437](https://jira.lsstcorp.org/browse/DM-16437)
 

--- a/project_templates/stack_package/CHANGELOG.md
+++ b/project_templates/stack_package/CHANGELOG.md
@@ -1,11 +1,14 @@
 # Change log
 
-## 2018-11-02
+## 2018-11-05
 
 - Added `bin/` and `.coverage` to `.gitignore`.
 - Added `base` as a default EUPS dependency.
   This prevents packages that have not other dependencies from having errors about getting `lsstimport`.
   Packages that add high-level dependencies can drop the explicit dependency on `base`.
+- Also add `utils` as a default EUPS dependency since it is necessary for unit tests, in most cases.
+
+[DM-16437](https://jira.lsstcorp.org/browse/DM-16437)
 
 ## 2018-10-10
 

--- a/project_templates/stack_package/example/.gitignore
+++ b/project_templates/stack_package/example/.gitignore
@@ -11,9 +11,11 @@ config.log
 
 # Built by sconsUtils
 version.py
+bin/
 
 # Pytest
 tests/.tests
 pytest_session.txt
 .cache/
 .pytest_cache
+.coverage

--- a/project_templates/stack_package/example/setup.cfg
+++ b/project_templates/stack_package/example/setup.cfg
@@ -1,6 +1,6 @@
 [flake8]
 max-line-length = 110
-ignore = E133, E226, E228, N802, N803, N806
+ignore = E133, E226, E228, N802, N803, N806, W504
 exclude =
   bin,
   doc,
@@ -10,4 +10,4 @@ exclude =
 
 [tool:pytest]
 addopts = --flake8
-flake8-ignore = E133 E226 E228 N802 N803 N806
+flake8-ignore = E133 E226 E228 N802 N803 N806 W504

--- a/project_templates/stack_package/example/ups/example.table
+++ b/project_templates/stack_package/example/ups/example.table
@@ -1,9 +1,12 @@
 # List EUPS dependencies of this package here
 # - Common third-party packages (boost, python, doxygen) and low-level
-#   LSST packages can be assumed to be recursively included by low-level
+#   LSST packages can be assumed to be recursively included by
 #   LSST packages such as utils or daf_base.
 # - Any package whose API is used should be listed explicitly
 #   rather than assuming it will be included recursively.
+# - The base package provides lsstimport. You can remove this explicit
+#   dependency if this package also declares higher-level dependencies.
+setupRequired(base)
 setupRequired(sconsUtils)
 
 # The following is boilerplate for all packages.

--- a/project_templates/stack_package/example/ups/example.table
+++ b/project_templates/stack_package/example/ups/example.table
@@ -6,7 +6,10 @@
 #   rather than assuming it will be included recursively.
 # - The base package provides lsstimport. You can remove this explicit
 #   dependency if this package also declares higher-level dependencies.
+# - The utils package supports unit tests. This dependency can be removed
+#   if the package doesn't directly use its APIs in tests.
 setupRequired(base)
+setupRequired(utils)
 setupRequired(sconsUtils)
 
 # The following is boilerplate for all packages.

--- a/project_templates/stack_package/example_dataonly/.gitignore
+++ b/project_templates/stack_package/example_dataonly/.gitignore
@@ -11,9 +11,11 @@ config.log
 
 # Built by sconsUtils
 version.py
+bin/
 
 # Pytest
 tests/.tests
 pytest_session.txt
 .cache/
 .pytest_cache
+.coverage

--- a/project_templates/stack_package/example_dataonly/ups/example_dataonly.table
+++ b/project_templates/stack_package/example_dataonly/ups/example_dataonly.table
@@ -1,9 +1,12 @@
 # List EUPS dependencies of this package here
 # - Common third-party packages (boost, python, doxygen) and low-level
-#   LSST packages can be assumed to be recursively included by low-level
+#   LSST packages can be assumed to be recursively included by
 #   LSST packages such as utils or daf_base.
 # - Any package whose API is used should be listed explicitly
 #   rather than assuming it will be included recursively.
+# - The base package provides lsstimport. You can remove this explicit
+#   dependency if this package also declares higher-level dependencies.
+setupRequired(base)
 setupRequired(sconsUtils)
 
 # The following is boilerplate for all packages.

--- a/project_templates/stack_package/example_dataonly/ups/example_dataonly.table
+++ b/project_templates/stack_package/example_dataonly/ups/example_dataonly.table
@@ -6,7 +6,10 @@
 #   rather than assuming it will be included recursively.
 # - The base package provides lsstimport. You can remove this explicit
 #   dependency if this package also declares higher-level dependencies.
+# - The utils package supports unit tests. This dependency can be removed
+#   if the package doesn't directly use its APIs in tests.
 setupRequired(base)
+setupRequired(utils)
 setupRequired(sconsUtils)
 
 # The following is boilerplate for all packages.

--- a/project_templates/stack_package/example_pythononly/.gitignore
+++ b/project_templates/stack_package/example_pythononly/.gitignore
@@ -11,9 +11,11 @@ config.log
 
 # Built by sconsUtils
 version.py
+bin/
 
 # Pytest
 tests/.tests
 pytest_session.txt
 .cache/
 .pytest_cache
+.coverage

--- a/project_templates/stack_package/example_pythononly/setup.cfg
+++ b/project_templates/stack_package/example_pythononly/setup.cfg
@@ -1,6 +1,6 @@
 [flake8]
 max-line-length = 110
-ignore = E133, E226, E228, N802, N803, N806
+ignore = E133, E226, E228, N802, N803, N806, W504
 exclude =
   bin,
   doc,
@@ -10,4 +10,4 @@ exclude =
 
 [tool:pytest]
 addopts = --flake8
-flake8-ignore = E133 E226 E228 N802 N803 N806
+flake8-ignore = E133 E226 E228 N802 N803 N806 W504

--- a/project_templates/stack_package/example_pythononly/ups/example_pythononly.table
+++ b/project_templates/stack_package/example_pythononly/ups/example_pythononly.table
@@ -1,9 +1,12 @@
 # List EUPS dependencies of this package here
 # - Common third-party packages (boost, python, doxygen) and low-level
-#   LSST packages can be assumed to be recursively included by low-level
+#   LSST packages can be assumed to be recursively included by
 #   LSST packages such as utils or daf_base.
 # - Any package whose API is used should be listed explicitly
 #   rather than assuming it will be included recursively.
+# - The base package provides lsstimport. You can remove this explicit
+#   dependency if this package also declares higher-level dependencies.
+setupRequired(base)
 setupRequired(sconsUtils)
 
 # The following is boilerplate for all packages.

--- a/project_templates/stack_package/example_pythononly/ups/example_pythononly.table
+++ b/project_templates/stack_package/example_pythononly/ups/example_pythononly.table
@@ -6,7 +6,10 @@
 #   rather than assuming it will be included recursively.
 # - The base package provides lsstimport. You can remove this explicit
 #   dependency if this package also declares higher-level dependencies.
+# - The utils package supports unit tests. This dependency can be removed
+#   if the package doesn't directly use its APIs in tests.
 setupRequired(base)
+setupRequired(utils)
 setupRequired(sconsUtils)
 
 # The following is boilerplate for all packages.

--- a/project_templates/stack_package/example_subpackage/.gitignore
+++ b/project_templates/stack_package/example_subpackage/.gitignore
@@ -11,9 +11,11 @@ config.log
 
 # Built by sconsUtils
 version.py
+bin/
 
 # Pytest
 tests/.tests
 pytest_session.txt
 .cache/
 .pytest_cache
+.coverage

--- a/project_templates/stack_package/example_subpackage/setup.cfg
+++ b/project_templates/stack_package/example_subpackage/setup.cfg
@@ -1,6 +1,6 @@
 [flake8]
 max-line-length = 110
-ignore = E133, E226, E228, N802, N803, N806
+ignore = E133, E226, E228, N802, N803, N806, W504
 exclude =
   bin,
   doc,
@@ -10,4 +10,4 @@ exclude =
 
 [tool:pytest]
 addopts = --flake8
-flake8-ignore = E133 E226 E228 N802 N803 N806
+flake8-ignore = E133 E226 E228 N802 N803 N806 W504

--- a/project_templates/stack_package/example_subpackage/ups/example_subpackage.table
+++ b/project_templates/stack_package/example_subpackage/ups/example_subpackage.table
@@ -1,9 +1,12 @@
 # List EUPS dependencies of this package here
 # - Common third-party packages (boost, python, doxygen) and low-level
-#   LSST packages can be assumed to be recursively included by low-level
+#   LSST packages can be assumed to be recursively included by
 #   LSST packages such as utils or daf_base.
 # - Any package whose API is used should be listed explicitly
 #   rather than assuming it will be included recursively.
+# - The base package provides lsstimport. You can remove this explicit
+#   dependency if this package also declares higher-level dependencies.
+setupRequired(base)
 setupRequired(sconsUtils)
 
 # The following is boilerplate for all packages.

--- a/project_templates/stack_package/example_subpackage/ups/example_subpackage.table
+++ b/project_templates/stack_package/example_subpackage/ups/example_subpackage.table
@@ -6,7 +6,10 @@
 #   rather than assuming it will be included recursively.
 # - The base package provides lsstimport. You can remove this explicit
 #   dependency if this package also declares higher-level dependencies.
+# - The utils package supports unit tests. This dependency can be removed
+#   if the package doesn't directly use its APIs in tests.
 setupRequired(base)
+setupRequired(utils)
 setupRequired(sconsUtils)
 
 # The following is boilerplate for all packages.

--- a/project_templates/stack_package/{{cookiecutter.package_name}}/.gitignore
+++ b/project_templates/stack_package/{{cookiecutter.package_name}}/.gitignore
@@ -11,9 +11,11 @@ config.log
 
 # Built by sconsUtils
 version.py
+bin/
 
 # Pytest
 tests/.tests
 pytest_session.txt
 .cache/
 .pytest_cache
+.coverage

--- a/project_templates/stack_package/{{cookiecutter.package_name}}/setup.cfg
+++ b/project_templates/stack_package/{{cookiecutter.package_name}}/setup.cfg
@@ -1,6 +1,6 @@
 [flake8]
 max-line-length = 110
-ignore = E133, E226, E228, N802, N803, N806
+ignore = E133, E226, E228, N802, N803, N806, W504
 exclude =
   bin,
   doc,
@@ -10,4 +10,4 @@ exclude =
 
 [tool:pytest]
 addopts = --flake8
-flake8-ignore = E133 E226 E228 N802 N803 N806
+flake8-ignore = E133 E226 E228 N802 N803 N806 W504

--- a/project_templates/stack_package/{{cookiecutter.package_name}}/ups/{{cookiecutter.package_name}}.table
+++ b/project_templates/stack_package/{{cookiecutter.package_name}}/ups/{{cookiecutter.package_name}}.table
@@ -1,9 +1,12 @@
 # List EUPS dependencies of this package here
 # - Common third-party packages (boost, python, doxygen) and low-level
-#   LSST packages can be assumed to be recursively included by low-level
+#   LSST packages can be assumed to be recursively included by
 #   LSST packages such as utils or daf_base.
 # - Any package whose API is used should be listed explicitly
 #   rather than assuming it will be included recursively.
+# - The base package provides lsstimport. You can remove this explicit
+#   dependency if this package also declares higher-level dependencies.
+setupRequired(base)
 setupRequired(sconsUtils)
 
 # The following is boilerplate for all packages.

--- a/project_templates/stack_package/{{cookiecutter.package_name}}/ups/{{cookiecutter.package_name}}.table
+++ b/project_templates/stack_package/{{cookiecutter.package_name}}/ups/{{cookiecutter.package_name}}.table
@@ -6,7 +6,10 @@
 #   rather than assuming it will be included recursively.
 # - The base package provides lsstimport. You can remove this explicit
 #   dependency if this package also declares higher-level dependencies.
+# - The utils package supports unit tests. This dependency can be removed
+#   if the package doesn't directly use its APIs in tests.
 setupRequired(base)
+setupRequired(utils)
 setupRequired(sconsUtils)
 
 # The following is boilerplate for all packages.


### PR DESCRIPTION
- Added `bin/` and `.coverage` to `.gitignore`.
- Added `base` as a default EUPS dependency. This prevents packages that have not other dependencies from having errors about getting `lsstimport`.
  Packages that add high-level dependencies can drop the explicit dependency on `base`.
- Also add `utils` as a default EUPS dependency since it is necessary for unit tests.
- Marked W504 (line break after binary operator) as an ignored Flake8 rule. This rule was introduced by pycodestyle 2.4.0, but is not part of the [DM Python Style Guide](https://developer.lsst.io/python/style.html). See the post [Changes to baseline software versions](https://community.lsst.org/t/changes-to-baseline-software-versions/3366).