### PR TITLE
Update pytest to 4.2 and pytest-flake8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ install_requires = [
 # Test dependencies
 tests_require = [
     'pytest==3.4.1',
-    'pytest-flake8==0.9.1',
+    'pytest-flake8==1.0.4',
 ]
 tests_require += install_requires
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ install_requires = [
 
 # Test dependencies
 tests_require = [
-    'pytest==3.4.1',
+    'pytest==4.2.0',
     'pytest-flake8==1.0.4',
 ]
 tests_require += install_requires


### PR DESCRIPTION
This update is needed to avoid flake8 incompatibility issues with the previously pinned test dependencies.