### PR TITLE
Correct TEXMFHOME setting in Makefile.

### DIFF
--- a/project_templates/technote_latex/testn-000/Makefile
+++ b/project_templates/technote_latex/testn-000/Makefile
@@ -11,7 +11,7 @@ ifneq "$(GITSTATUS)" ""
 	GITDIRTY = -dirty
 endif
 
-TEXMFHOME = lsst-texmf/texmf
+export TEXMFHOME ?= lsst-texmf/texmf
 
 $(DOCNAME).pdf: $(tex) meta.tex local.bib
 	xelatex $(DOCNAME)

--- a/project_templates/technote_latex/{{cookiecutter.series.lower()}}-{{cookiecutter.serial_number}}/Makefile
+++ b/project_templates/technote_latex/{{cookiecutter.series.lower()}}-{{cookiecutter.serial_number}}/Makefile
@@ -11,7 +11,7 @@ ifneq "$(GITSTATUS)" ""
 	GITDIRTY = -dirty
 endif
 
-TEXMFHOME = lsst-texmf/texmf
+export TEXMFHOME ?= lsst-texmf/texmf
 
 $(DOCNAME).pdf: $(tex) meta.tex local.bib
 	xelatex $(DOCNAME)


### PR DESCRIPTION
- Use ?= so the user can override on the command line if necessary.
- Need to use `export` or it isn't picked up by xelatex.