### PR TITLE
DM-20821: New templates for documenting scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Find these templates in the `file_templates` directory:
 - [config_topic](file_templates/config_topic)
 - [copyright](file_templates/copyright)
 - [license_gplv3](file_templates/license_gplv3)
+- [script_topic](file_templates/script_topic)
 - [stack_license_preamble_cpp](file_templates/stack_license_preamble_cpp)
 - [stack_license_preamble_py](file_templates/stack_license_preamble_py)
 - [stack_license_preamble_txt](file_templates/stack_license_preamble_txt)

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Find these templates in the `project_templates/` directory:
 **File templates** are either entire files or snippets you can add to files.
 Find these templates in the `file_templates` directory:
 
+- [argparse_script_topic](file_templates/argparse_script_topic)
 - [config_topic](file_templates/config_topic)
 - [copyright](file_templates/copyright)
 - [license_gplv3](file_templates/license_gplv3)

--- a/SConstruct
+++ b/SConstruct
@@ -14,4 +14,5 @@ SConscript([
     'file_templates/stack_license_preamble_cpp/SConscript',
     'file_templates/task_topic/SConscript',
     'file_templates/config_topic/SConscript',
+    'file_templates/script_topic/SConscript',
 ])

--- a/SConstruct
+++ b/SConstruct
@@ -15,4 +15,5 @@ SConscript([
     'file_templates/task_topic/SConscript',
     'file_templates/config_topic/SConscript',
     'file_templates/script_topic/SConscript',
+    'file_templates/argparse_script_topic/SConscript',
 ])

--- a/file_templates/argparse_script_topic/README.md
+++ b/file_templates/argparse_script_topic/README.md
@@ -1,0 +1,37 @@
+# argparse_script_topic
+
+**Documentation topic template for creating reference pages about an argparse-based Python script.**
+
+This documentation topic template is intended to create reference pages for [argparse](https://docs.python.org/3/library/argparse.html)-based Python scripts that are packaged with LSST software.
+It takes advantage of tooling to automatically extract documentation about the command-line interface from the code itself.
+For scripts that **aren't** built with `argparse`, use the more generic [script_topic](../script_topic) template instead.
+
+Script topic pages go in the `scripts/` subdirectory of the [module documentation directory](https://developer.lsst.io/stack/layout-of-doc-directory.html#module-documentation-directories) in the package that implements the task.
+These script pages are referenced from the [module documentation homepage](https://developer.lsst.io/stack/module-homepage-topic-type.html).
+The file itself is named after the executable script.
+For example, a script called `plotSkyMap.py` is documented in a file called `plotSkyMap.py.rst`.
+
+[More documentation is available in the DM Developer Guide.](https://developer.lsst.io/stack/argparse-script-topic-type.html)
+
+## Template variables
+
+### cookiecutter.module_name
+
+The Python module containing a function (called `build_argparser` by default) that generates the script's `argparse.ArgumentParser` instance.
+For example: `lsst.verify.bin.dispatchverify`.
+
+### cookiecutter.script_name
+
+The name of the command-line executable.
+For example: `dispatch_verify.py`.
+
+## Examples
+
+### exampleScript.py.rst
+
+[exampleScript.py.rst](exampleScript.py.rst) is an example of a script topic for a `argparse`-based script named `exampleScript.py` that is implemented in a module called `lsst.example.bin.examplescript`.
+
+## Related templates
+
+- [stack_package](../../project_templates/stack_package)
+- [script_topic](../script_topic)

--- a/file_templates/argparse_script_topic/SConscript
+++ b/file_templates/argparse_script_topic/SConscript
@@ -1,0 +1,8 @@
+from templatekit.builder import file_template_builder
+
+
+# Example with defaults
+env = Environment(BUILDERS={'FileTemplate': file_template_builder})
+env.FileTemplate(
+    'exampleScript.py.rst',
+    '{{cookiecutter.script_name}}.rst.jinja')

--- a/file_templates/argparse_script_topic/cookiecutter.json
+++ b/file_templates/argparse_script_topic/cookiecutter.json
@@ -1,0 +1,4 @@
+{
+  "module_name": "lsst.example.bin.examplescript",
+  "script_name": "exampleScript.py"
+}

--- a/file_templates/argparse_script_topic/exampleScript.py.rst
+++ b/file_templates/argparse_script_topic/exampleScript.py.rst
@@ -1,0 +1,3 @@
+.. autoprogram:: lsst.example.bin.examplescript:build_argparser()
+   :prog: exampleScript.py
+   :groups:

--- a/file_templates/argparse_script_topic/templatekit.yaml
+++ b/file_templates/argparse_script_topic/templatekit.yaml
@@ -1,0 +1,12 @@
+name: "Script topic (argparse)"
+group: "Science Pipelines documentation"
+dialog_title: "Create a script topic"
+dialog_fields:
+  - key: "script_module"
+    label: "Module name"
+    hint: "Namespace of the module containing the ArgumentParser constructor."
+    component: "text"
+  - key: "script_name"
+    label: "Script name"
+    hint: "Name of the command-line executable."
+    component: "text"

--- a/file_templates/argparse_script_topic/{{cookiecutter.script_name}}.rst.jinja
+++ b/file_templates/argparse_script_topic/{{cookiecutter.script_name}}.rst.jinja
@@ -1,0 +1,3 @@
+.. autoprogram:: {{ cookiecutter.module_name }}:build_argparser()
+   :prog: {{cookiecutter.script_name}}
+   :groups:

--- a/file_templates/script_topic/README.md
+++ b/file_templates/script_topic/README.md
@@ -1,0 +1,31 @@
+# script_topic
+
+**Documentation topic template for creating reference pages about scripts.**
+
+This documentation topic template is intended to work with any script and relies on manual documentation of a script's options and arguments.
+If the script is built with [argparse](https://docs.python.org/3/library/argparse.html), use the [argparse_script_topic](../argparse_script_topic) template instead to take advantage of automatic documentation tooling.
+
+Script topic pages go in the `scripts/` subdirectory of the [module documentation directory](https://developer.lsst.io/stack/layout-of-doc-directory.html#module-documentation-directories) in the package that implements the task.
+These script pages are referenced from the [module documentation homepage](https://developer.lsst.io/stack/module-homepage-topic-type.html).
+The file itself is named after the executable script.
+For example, a script called `runPipeline.sh` is documented in a file called `runPipeline.sh.rst`.
+
+[More documentation is available in the DM Developer Guide.](https://developer.lsst.io/stack/script-topic-type.html)
+
+## Template variables
+
+### cookiecutter.script_name
+
+The name of the command-line executable.
+For example: `runPipeline.sh`.
+
+## Examples
+
+### exampleScript.sh.rst
+
+[exampleScript.sh.rst](exampleScript.sh.rst) is an example of a script topic for a shell script named `exampleScript.sh`.
+
+## Related templates
+
+- [stack_package](../../project_templates/stack_package)
+- [argparse_script_topic](../argparse_script_topic)

--- a/file_templates/script_topic/SConscript
+++ b/file_templates/script_topic/SConscript
@@ -1,0 +1,8 @@
+from templatekit.builder import file_template_builder
+
+
+# Example with defaults
+env = Environment(BUILDERS={'FileTemplate': file_template_builder})
+env.FileTemplate(
+    'exampleScript.sh.rst',
+    '{{cookiecutter.script_name}}.rst.jinja')

--- a/file_templates/script_topic/cookiecutter.json
+++ b/file_templates/script_topic/cookiecutter.json
@@ -1,0 +1,3 @@
+{
+  "script_name": "exampleScript.sh"
+}

--- a/file_templates/script_topic/exampleScript.sh.rst
+++ b/file_templates/script_topic/exampleScript.sh.rst
@@ -1,0 +1,27 @@
+.. program:: exampleScript.sh
+
+################
+exampleScript.sh
+################
+
+.. Summary sentence that describes what the script does goes here.
+
+.. In additional paragraphs, add extra documentation.
+
+.. code-block:: text
+
+   Usage: exampleScript.sh [OPTIONS]... [ARGS]
+
+.. Positional arguments
+.. ====================
+.. 
+.. .. option:: fixme
+.. 
+..    FIXME description of a positional argument.
+
+Optional arguments
+==================
+
+.. option:: -h
+
+   Print the help message.

--- a/file_templates/script_topic/templatekit.yaml
+++ b/file_templates/script_topic/templatekit.yaml
@@ -1,0 +1,9 @@
+name: "Script topic (generic)"
+group: "Science Pipelines documentation"
+dialog_title: "Create a script topic"
+dialog_fields:
+  - key: "script_name"
+    label: "Command-line script"
+    hint: "Name of the command-line task, or blank if none."
+    component: "text"
+    optional: True

--- a/file_templates/script_topic/{{cookiecutter.script_name}}.rst.jinja
+++ b/file_templates/script_topic/{{cookiecutter.script_name}}.rst.jinja
@@ -1,0 +1,27 @@
+.. program:: {{cookiecutter.script_name}}
+
+{{ "#" * (cookiecutter.script_name|length) }}
+{{ cookiecutter.script_name }}
+{{ "#" * (cookiecutter.script_name|length) }}
+
+.. Summary sentence that describes what the script does goes here.
+
+.. In additional paragraphs, add extra documentation.
+
+.. code-block:: text
+
+   Usage: {{ cookiecutter.script_name }} [OPTIONS]... [ARGS]
+
+.. Positional arguments
+.. ====================
+.. 
+.. .. option:: fixme
+.. 
+..    FIXME description of a positional argument.
+
+Optional arguments
+==================
+
+.. option:: -h
+
+   Print the help message.

--- a/project_templates/stack_package/CHANGELOG.md
+++ b/project_templates/stack_package/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log
 
+## 2019-07-30
+
+- Added a "Script reference" section to link to script topic pages (see [script_topic](../../file_templates/script_topic) and [argparse_script_topic](../../file_templates/argparse_script_topic)).
+
+[DM-20821](https://jira.lsstcorp.org/browse/DM-20821)
+
 ## 2019-01-15
 
 - Added a new template variable, `cookiecutter.stack_name`.

--- a/project_templates/stack_package/example/doc/lsst.example/index.rst
+++ b/project_templates/stack_package/example/doc/lsst.example/index.rst
@@ -62,7 +62,17 @@ Configurations
    :root: lsst.example
    :toctree: configs
 
-.. _lsst.example-pyapi:
+.. .. _lsst.example-scripts:
+
+.. Script reference
+.. ================
+
+.. .. TODO: Add an item to this toctree for each script reference topic in the scripts subdirectory.
+
+.. .. toctree::
+..    :maxdepth: 1
+
+.. .. _lsst.example-pyapi:
 
 Python API reference
 ====================

--- a/project_templates/stack_package/example_pythononly/doc/lsst.example.pythononly/index.rst
+++ b/project_templates/stack_package/example_pythononly/doc/lsst.example.pythononly/index.rst
@@ -62,7 +62,17 @@ Configurations
    :root: lsst.example.pythononly
    :toctree: configs
 
-.. _lsst.example.pythononly-pyapi:
+.. .. _lsst.example.pythononly-scripts:
+
+.. Script reference
+.. ================
+
+.. .. TODO: Add an item to this toctree for each script reference topic in the scripts subdirectory.
+
+.. .. toctree::
+..    :maxdepth: 1
+
+.. .. _lsst.example.pythononly-pyapi:
 
 Python API reference
 ====================

--- a/project_templates/stack_package/example_standalone/doc/index.rst
+++ b/project_templates/stack_package/example_standalone/doc/index.rst
@@ -62,7 +62,17 @@ Configurations
    :root: lsst.example.standalone
    :toctree: configs
 
-.. _lsst.example.standalone-pyapi:
+.. .. _lsst.example.standalone-scripts:
+
+.. Script reference
+.. ================
+
+.. .. TODO: Add an item to this toctree for each script reference topic in the scripts subdirectory.
+
+.. .. toctree::
+..    :maxdepth: 1
+
+.. .. _lsst.example.standalone-pyapi:
 
 Python API reference
 ====================

--- a/project_templates/stack_package/example_subpackage/doc/lsst.example.subpackage/index.rst
+++ b/project_templates/stack_package/example_subpackage/doc/lsst.example.subpackage/index.rst
@@ -62,7 +62,17 @@ Configurations
    :root: lsst.example.subpackage
    :toctree: configs
 
-.. _lsst.example.subpackage-pyapi:
+.. .. _lsst.example.subpackage-scripts:
+
+.. Script reference
+.. ================
+
+.. .. TODO: Add an item to this toctree for each script reference topic in the scripts subdirectory.
+
+.. .. toctree::
+..    :maxdepth: 1
+
+.. .. _lsst.example.subpackage-pyapi:
 
 Python API reference
 ====================

--- a/project_templates/stack_package/{{cookiecutter.package_name}}/doc/{{cookiecutter.python_module}}/index.rst
+++ b/project_templates/stack_package/{{cookiecutter.package_name}}/doc/{{cookiecutter.python_module}}/index.rst
@@ -64,7 +64,17 @@ Configurations
    :toctree: configs
 {%- endif %}
 
-.. _{{ cookiecutter.python_module }}-pyapi:
+.. .. _{{ cookiecutter.python_module}}-scripts:
+
+.. Script reference
+.. ================
+
+.. .. TODO: Add an item to this toctree for each script reference topic in the scripts subdirectory.
+
+.. .. toctree::
+..    :maxdepth: 1
+
+.. .. _{{ cookiecutter.python_module }}-pyapi:
 
 Python API reference
 ====================


### PR DESCRIPTION
- `script_topic` is for documenting any kind of script, but manually.
- `argparse_script_topic` is for documenting argparse-based Python scripts.
- The module homepage template for stack pages now has a "Script reference" section.

This system for documenting scripts is demonstrated in lsst/verify/pull/45 and is also documented in lsst-dm/dm_dev_guide/pull/339