### PR TITLE
DM-20821: Fix templatekit config for script templates

### DIFF
--- a/file_templates/argparse_script_topic/templatekit.yaml
+++ b/file_templates/argparse_script_topic/templatekit.yaml
@@ -2,7 +2,7 @@ name: "Script topic (argparse)"
 group: "Science Pipelines documentation"
 dialog_title: "Create a script topic"
 dialog_fields:
-  - key: "script_module"
+  - key: "module_name"
     label: "Module name"
     hint: "Namespace of the module containing the ArgumentParser constructor."
     component: "text"

--- a/file_templates/script_topic/templatekit.yaml
+++ b/file_templates/script_topic/templatekit.yaml
@@ -4,6 +4,5 @@ dialog_title: "Create a script topic"
 dialog_fields:
   - key: "script_name"
     label: "Command-line script"
-    hint: "Name of the command-line task, or blank if none."
+    hint: "Name of the command-line executable."
     component: "text"
-    optional: True


### PR DESCRIPTION
- Wrong cookiecutter.json key for argparse_script_topic
- The script_name is not optional