### PR TITLE
DM-20952: Adopt latexmk for the PDF build

### DIFF
--- a/project_templates/technote_latex/CHANGELOG.md
+++ b/project_templates/technote_latex/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+## 2019-08-09
+
+- Adopt latexmk for building the PDF and for doing most of the cleanup.
+  This improves the initial experience of starting a new latex document where running bibtex would fail because the document didn't have any citations yet.
+
 ## 2019-07-29
 
 - Add support for the ITTN technote series for LSST IT.

--- a/project_templates/technote_latex/testn-000/Makefile
+++ b/project_templates/technote_latex/testn-000/Makefile
@@ -14,30 +14,16 @@ endif
 export TEXMFHOME ?= lsst-texmf/texmf
 
 $(DOCNAME).pdf: $(tex) meta.tex local.bib
-	xelatex $(DOCNAME)
-	bibtex $(DOCNAME)
-	xelatex $(DOCNAME)
-	bibtex $(DOCNAME)
-	xelatex $(DOCNAME)
-	xelatex $(DOCNAME)
+	latexmk -bibtex -xelatex -f $(DOCNAME)
 
 acronyms.tex: $(tex) myacronyms.txt
 	$(TEXMFHOME)/../bin/generateAcronyms.py $(tex)
 
 .PHONY: clean
 clean:
-	rm -f $(DOCNAME).aux
+	latexmk -c
 	rm -f $(DOCNAME).bbl
-	rm -f $(DOCNAME).blg
-	rm -f $(DOCNAME).glg
-	rm -f $(DOCNAME).glo
-	rm -f $(DOCNAME).gls
-	rm -f $(DOCNAME).ist
-	rm -f $(DOCNAME).log
-	rm -f $(DOCNAME).out
 	rm -f $(DOCNAME).pdf
-	rm -f $(DOCNAME).rec
-	rm -f $(DOCNAME).toc
 	rm -f meta.tex
 
 .FORCE:

--- a/project_templates/technote_latex/{{cookiecutter.series.lower()}}-{{cookiecutter.serial_number}}/Makefile
+++ b/project_templates/technote_latex/{{cookiecutter.series.lower()}}-{{cookiecutter.serial_number}}/Makefile
@@ -14,30 +14,16 @@ endif
 export TEXMFHOME ?= lsst-texmf/texmf
 
 $(DOCNAME).pdf: $(tex) meta.tex local.bib
-	xelatex $(DOCNAME)
-	bibtex $(DOCNAME)
-	xelatex $(DOCNAME)
-	bibtex $(DOCNAME)
-	xelatex $(DOCNAME)
-	xelatex $(DOCNAME)
+	latexmk -bibtex -xelatex -f $(DOCNAME)
 
 acronyms.tex: $(tex) myacronyms.txt
 	$(TEXMFHOME)/../bin/generateAcronyms.py $(tex)
 
 .PHONY: clean
 clean:
-	rm -f $(DOCNAME).aux
+	latexmk -c
 	rm -f $(DOCNAME).bbl
-	rm -f $(DOCNAME).blg
-	rm -f $(DOCNAME).glg
-	rm -f $(DOCNAME).glo
-	rm -f $(DOCNAME).gls
-	rm -f $(DOCNAME).ist
-	rm -f $(DOCNAME).log
-	rm -f $(DOCNAME).out
 	rm -f $(DOCNAME).pdf
-	rm -f $(DOCNAME).rec
-	rm -f $(DOCNAME).toc
 	rm -f meta.tex
 
 .FORCE:


### PR DESCRIPTION
This improves the initial experience of starting a new latex document where running bibtex would fail because the document didn't have any citations yet.