### PR TITLE
DM-20692: Fix templating for subtasks and fields

### DIFF
--- a/file_templates/task_topic/lsst.example.ExampleCmdLineTask.rst
+++ b/file_templates/task_topic/lsst.example.ExampleCmdLineTask.rst
@@ -88,14 +88,14 @@ Output datasets
 Retargetable subtasks
 =====================
 
-.. lsst-task-config-subtasks:: lsst.pipe.tasks.processCcd.ProcessCcdTask
+.. lsst-task-config-subtasks:: lsst.example.ExampleCmdLineTask
 
 .. _lsst.example.ExampleCmdLineTask-configs:
 
 Configuration fields
 ====================
 
-.. lsst-task-config-fields:: lsst.pipe.tasks.processCcd.ProcessCcdTask
+.. lsst-task-config-fields:: lsst.example.ExampleCmdLineTask
 
 .. _lsst.example.ExampleCmdLineTask-examples:
 

--- a/file_templates/task_topic/lsst.example.ExampleTask.rst
+++ b/file_templates/task_topic/lsst.example.ExampleTask.rst
@@ -39,14 +39,14 @@ Python API summary
 Retargetable subtasks
 =====================
 
-.. lsst-task-config-subtasks:: lsst.pipe.tasks.processCcd.ProcessCcdTask
+.. lsst-task-config-subtasks:: lsst.example.ExampleTask
 
 .. _lsst.example.ExampleTask-configs:
 
 Configuration fields
 ====================
 
-.. lsst-task-config-fields:: lsst.pipe.tasks.processCcd.ProcessCcdTask
+.. lsst-task-config-fields:: lsst.example.ExampleTask
 
 .. _lsst.example.ExampleTask-examples:
 

--- a/file_templates/task_topic/{{cookiecutter.task_module}}.{{cookiecutter.task_class}}.rst.jinja
+++ b/file_templates/task_topic/{{cookiecutter.task_module}}.{{cookiecutter.task_class}}.rst.jinja
@@ -93,14 +93,14 @@ Output datasets
 Retargetable subtasks
 =====================
 
-.. lsst-task-config-subtasks:: lsst.pipe.tasks.processCcd.ProcessCcdTask
+.. lsst-task-config-subtasks:: {{ cookiecutter.task_module }}.{{ cookiecutter.task_class }}
 
 .. _{{ cookiecutter.task_module }}.{{ cookiecutter.task_class }}-configs:
 
 Configuration fields
 ====================
 
-.. lsst-task-config-fields:: lsst.pipe.tasks.processCcd.ProcessCcdTask
+.. lsst-task-config-fields:: {{ cookiecutter.task_module }}.{{ cookiecutter.task_class }}
 
 .. _{{ cookiecutter.task_module }}.{{ cookiecutter.task_class }}-examples:
 


### PR DESCRIPTION
This fixes the templating for the arguments to the `lsst-task-config-fields` and `lsst-task-config-subtasks` configuration fields.

This change automatically gets propagated to the Developer Guide: https://developer.lsst.io/stack/task-topic-type.html