### PR TITLE
Add lsst-sqre to the list of github orgs

### DIFF
--- a/project_templates/stack_package/cookiecutter.json
+++ b/project_templates/stack_package/cookiecutter.json
@@ -13,7 +13,7 @@
     "University of Illinois Board of Trustees",
     "University of Washington"
   ],
-  "github_org": ["lsst", "lsst-dm", "lsst-sims", "lsst-ts", "lsst-sqre-testing"],
+  "github_org": ["lsst", "lsst-dm", "lsst-sims", "lsst-ts", "lsst-sqre", "lsst-sqre-testing"],
   "base_package": [
     "base",
     "sconsUtils"


### PR DESCRIPTION
I think it's reasonable to start a stack package in the `lsst-sqre` org that eventually will migrate to the `lsst` org.