### PR TITLE
Add TSTN technote series

### DIFF
--- a/project_templates/technote_latex/CHANGELOG.md
+++ b/project_templates/technote_latex/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 2019-08-26
+
+- Add support for the Telescope & Site technote series (TSTN).
+
 ## 2019-08-09
 
 - Adopt latexmk for building the PDF and for doing most of the cleanup.

--- a/project_templates/technote_latex/README.md
+++ b/project_templates/technote_latex/README.md
@@ -25,6 +25,7 @@ Choose the series that fits the document's purpose or aligns with the organizati
 - `SMTN` for Simulations Group technical notes. See [SMTN-000](https://smtn-000.lsst.io).
 - `SITCOMTN` for Systems Integration, Testing, and Commissioning notes.
 - `SQR` for SQuaRE technical notes. See [SQR-000](https://sqr-000.lsst.io).
+- `TSTN` for Telescope & Site technical notes.
 - `TESTN` for testing the technical system. *These notes may be purged at any time.*
 
 ### cookiecutter.serial_number
@@ -44,6 +45,7 @@ Choose a GitHub organization that matches the [series](#cookiecutter_series):
 - `lsst-sitcom` for the SITCOMTN series.
 - `lsst-sqre` for the SQuaRE SQR series.
 - `lsst-sqre-testing` for the TESTN series.
+- `lsst-tstn` for the TSTN series.
 
 ### cookiecutter.title
 

--- a/project_templates/technote_latex/cookiecutter.json
+++ b/project_templates/technote_latex/cookiecutter.json
@@ -15,6 +15,7 @@
     "SMTN",
     "SITCOMTN",
     "SQR",
+    "TSTN",
     "TESTN"
   ],
   "serial_number": "000",
@@ -26,6 +27,7 @@
     "lsst-sims",
     "lsst-sitcom",
     "lsst-sqre",
+    "lsst-tstn",
     "lsst-sqre-testing"
   ],
   "title": "Document Title",

--- a/project_templates/technote_latex/templatekit.yaml
+++ b/project_templates/technote_latex/templatekit.yaml
@@ -58,6 +58,12 @@ dialog_fields:
           series: "SQR"
           github_org: "lsst-sqre"
           org: "DM"
+      - label: "TSTN"
+        value: "tstn"
+        presets:
+          series: "TSTN"
+          github_org: "lsst-tstn"
+          org: "TS"
       - label: "Test"
         value: "test"
         presets:

--- a/project_templates/technote_rst/CHANGELOG.md
+++ b/project_templates/technote_rst/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 2019-08-26
+
+- Add support for the Telescope & Site technote series (TSTN).
+
 ## 2019-07-29
 
 - Add support for the ITTN technote series for LSST IT.

--- a/project_templates/technote_rst/README.md
+++ b/project_templates/technote_rst/README.md
@@ -30,6 +30,7 @@ Choose the series that fits the document's purpose or aligns with the organizati
 - `SMTN` for Simulations Group technical notes. See [SMTN-000](https://smtn-000.lsst.io).
 - `SITCOMTN` for Systems Integration, Testing, and Commissioning notes.
 - `SQR` for SQuaRE technical notes. See [SQR-000](https://sqr-000.lsst.io).
+- `TSTN` for Telescope & Site technical notes.
 - `TESTN` for testing the technical system. *These notes may be purged at any time.*
 
 ### cookiecutter.serial_number
@@ -57,6 +58,7 @@ Choose a GitHub organization that matches the [series](#cookiecutter_series):
 - `lsst-sims` for the Simulations Group's SMTN series.
 - `lsst-sitcom` for the SITCOMTN series.
 - `lsst-sqre` for the SQuaRE SQR series.
+- `lsst-tstn` for the TSTN series.
 - `lsst-sqre-testing` for the TESTN series.
 
 ### cookiecutter.github_namespace

--- a/project_templates/technote_rst/cookiecutter.json
+++ b/project_templates/technote_rst/cookiecutter.json
@@ -8,6 +8,7 @@
     "SMTN",
     "SITCOMTN",
     "SQR",
+    "TSTN",
     "TESTN"
   ],
   "serial_number": "000",
@@ -21,6 +22,7 @@
     "lsst-sims",
     "lsst-sitcom",
     "lsst-sqre",
+    "lsst-tstn",
     "lsst-sqre-testing"
   ],
   "github_namespace": "{{ cookiecutter.github_org }}/{{ cookiecutter.repo_name }}",

--- a/project_templates/technote_rst/templatekit.yaml
+++ b/project_templates/technote_rst/templatekit.yaml
@@ -40,6 +40,11 @@ dialog_fields:
         presets:
           series: "SQR"
           github_org: "lsst-sqre"
+      - label: "TSTN"
+        value: "tstn"
+        presets:
+          series: "tstn"
+          github_org: "lsst-tstn"
       - label: "Test"
         value: "test"
         presets:


### PR DESCRIPTION
This series was requested by @tribeiro for the T&S group. They have opted to use the new lsst-tstn org rather than add technotes to their lsst-ts org.