### PR TITLE
DM-21376: Add lsst-verification-and-validation org

### DIFF
--- a/project_templates/stack_package/CHANGELOG.md
+++ b/project_templates/stack_package/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log
 
+## 2019-09-20
+
+- Added support for the https://github.com/lsst/lsst-verification-and-validation GitHub organization.
+
+[DM-21376](https://jira.lsstcorp.org/browse/DM-21376)
+
 ## 2019-07-30
 
 - Added a "Script reference" section to link to script topic pages (see [script_topic](../../file_templates/script_topic) and [argparse_script_topic](../../file_templates/argparse_script_topic)).

--- a/project_templates/stack_package/cookiecutter.json
+++ b/project_templates/stack_package/cookiecutter.json
@@ -13,7 +13,14 @@
     "University of Illinois Board of Trustees",
     "University of Washington"
   ],
-  "github_org": ["lsst", "lsst-dm", "lsst-sims", "lsst-ts", "lsst-sqre", "lsst-sqre-testing"],
+  "github_org": [
+    "lsst",
+    "lsst-dm",
+    "lsst-sims",
+    "lsst-ts",
+    "lsst-sqre",
+    "lsst-sqre-testing",
+    "lsst-verification-and-validation"],
   "base_package": [
     "base",
     "sconsUtils"


### PR DESCRIPTION
Adds the `lsst-verification-and-validation` GitHub org to the `stack_package` configuration.