### PR TITLE
DM-21528: Ensure templated content in nbreport and technote_rst YAML files is escaped

### DIFF
--- a/project_templates/nbreport/CHANGELOG.md
+++ b/project_templates/nbreport/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Change log
+
+## 2019-10-08
+
+- Template variables that are inserted into `nbreport.yaml` are now fully escaped.
+  This means that the report titles, for instance, can have characters like single and double quotes, and backslashes.

--- a/project_templates/nbreport/EXAMPLE-000/nbreport.yaml
+++ b/project_templates/nbreport/EXAMPLE-000/nbreport.yaml
@@ -1,4 +1,4 @@
-handle: EXAMPLE-000
-title: Report title
+handle: "EXAMPLE-000"
+title: "Report title"
 git_repo: https://github.com/org/repo
-ipynb: EXAMPLE-000.ipynb
+ipynb: "EXAMPLE-000.ipynb"

--- a/project_templates/nbreport/{{cookiecutter.handle}}/nbreport.yaml
+++ b/project_templates/nbreport/{{cookiecutter.handle}}/nbreport.yaml
@@ -1,5 +1,5 @@
-handle: {{ cookiecutter.handle }}
-title: {{ cookiecutter.title }}
+handle: "{{ cookiecutter.handle | escape_yaml_doublequoted }}"
+title: "{{ cookiecutter.title | escape_yaml_doublequoted }}"
 git_repo: {{ cookiecutter.git_repo }}{% if cookiecutter.git_repo_subdir %}
-git_repo_subdir: {{ cookiecutter.git_repo_subdir }}{% endif %}
-ipynb: {{ cookiecutter.handle }}.ipynb
+git_repo_subdir: "{{ cookiecutter.git_repo_subdir | escape_yaml_doublequoted }}"{% endif %}
+ipynb: "{{ cookiecutter.handle | escape_yaml_doublequoted }}.ipynb"

--- a/project_templates/technote_rst/CHANGELOG.md
+++ b/project_templates/technote_rst/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+## 2019-10-08
+
+- Template variables that are inserted into `metadata.yaml` are now fully escaped.
+  This means that titles, authors, and descriptions can have characters like single and double quotes, and backslashes.
+
 ## 2019-08-26
 
 - Add support for the Telescope & Site technote series (TSTN).

--- a/project_templates/technote_rst/cookiecutter.json
+++ b/project_templates/technote_rst/cookiecutter.json
@@ -42,6 +42,7 @@
     "*.bib"
   ],
   "_extensions": [
-    "jinja2_time.TimeExtension"
+    "jinja2_time.TimeExtension",
+    "templatekit.TemplatekitExtension"
   ]
 }

--- a/project_templates/technote_rst/testn-000/metadata.yaml
+++ b/project_templates/technote_rst/testn-000/metadata.yaml
@@ -3,21 +3,21 @@
 # document in git and kept up to date.
 
 # The series identifier. E.g. SQR, DMTN, SMTN, LDM, LSE, etc.
-series: 'TESTN'
+series: "TESTN"
 
 # Document number, as a string. It should be three digits, padded with leading zeros
-serial_number: '000'
+serial_number: "000"
 
 # Serial number of the document. E.g. SQR-001
 # NOTE: this field is *planned* for deprecation
-doc_id: 'TESTN-000'
+doc_id: "TESTN-000"
 
 # Title of the document, without the series/serial designation
-doc_title: 'Document Title'
+doc_title: "Document Title"
 
 # Author names, ordered as a list. Each author name should be formatted as 'First Last'
 authors:
-  - 'First Last'
+  - "First Last"
 
 # Current document revision date, YYYY-MM-DD
 # Only set this field if you need to manually fix the revision date;
@@ -34,10 +34,10 @@ authors:
 # doi: 10.5281/zenodo.#####
 
 # Copyright statement
-copyright: '2019, Association of Universities for Research in Astronomy'
+copyright: "2019, Association of Universities for Research in Astronomy"
 
 # Description. A short, 1-2 sentence statemement used by document indices.
-description: 'A short description of this document'
+description: "A short description of this document"
 
 # Abstract, if available
 # abstract: >
@@ -47,11 +47,11 @@ description: 'A short description of this document'
 #           You can have multiple paragraphs too.
 
 # URL where this document is published by Read the Docs. e.g. http://sqr-001.lsst.codes
-url: 'https://testn-000.lsst.io'
+url: "https://testn-000.lsst.io"
 
 # LSST Docushare URL, if authoritative versions of this are are stored there.
 # Leave as an empty string or comment out this key if there is no Docushare URL.
-docushare_url: ''
+docushare_url: ""
 
 # GitHub repo URL
-github_url: 'https://github.com/lsst-dm/testn-000'
+github_url: "https://github.com/lsst-dm/testn-000"

--- a/project_templates/technote_rst/{{cookiecutter.repo_name}}/metadata.yaml
+++ b/project_templates/technote_rst/{{cookiecutter.repo_name}}/metadata.yaml
@@ -3,21 +3,21 @@
 # document in git and kept up to date.
 
 # The series identifier. E.g. SQR, DMTN, SMTN, LDM, LSE, etc.
-series: '{{ cookiecutter.series }}'
+series: "{{ cookiecutter.series | escape_yaml_doublequoted }}"
 
 # Document number, as a string. It should be three digits, padded with leading zeros
-serial_number: '{{ cookiecutter.serial_number }}'
+serial_number: "{{ cookiecutter.serial_number | escape_yaml_doublequoted }}"
 
 # Serial number of the document. E.g. SQR-001
 # NOTE: this field is *planned* for deprecation
-doc_id: '{{ cookiecutter.series }}-{{ cookiecutter.serial_number }}'
+doc_id: "{{ cookiecutter.series | escape_yaml_doublequoted }}-{{ cookiecutter.serial_number | escape_yaml_doublequoted }}"
 
 # Title of the document, without the series/serial designation
-doc_title: '{{ cookiecutter.title }}'
+doc_title: "{{ cookiecutter.title | escape_yaml_doublequoted }}"
 
 # Author names, ordered as a list. Each author name should be formatted as 'First Last'
 authors:
-  - '{{ cookiecutter.first_author }}'
+  - "{{ cookiecutter.first_author | escape_yaml_doublequoted }}"
 
 # Current document revision date, YYYY-MM-DD
 # Only set this field if you need to manually fix the revision date;
@@ -34,10 +34,10 @@ authors:
 # doi: 10.5281/zenodo.#####
 
 # Copyright statement
-copyright: '{{ cookiecutter.copyright_year }}, {{ cookiecutter.copyright_holder }}'
+copyright: "{{ cookiecutter.copyright_year | escape_yaml_doublequoted }}, {{ cookiecutter.copyright_holder | escape_yaml_doublequoted }}"
 
 # Description. A short, 1-2 sentence statemement used by document indices.
-description: '{{ cookiecutter.description }}'
+description: "{{ cookiecutter.description | escape_yaml_doublequoted }}"
 
 # Abstract, if available
 # abstract: >
@@ -47,11 +47,11 @@ description: '{{ cookiecutter.description }}'
 #           You can have multiple paragraphs too.
 
 # URL where this document is published by Read the Docs. e.g. http://sqr-001.lsst.codes
-url: '{{ cookiecutter.url }}'
+url: "{{ cookiecutter.url | escape_yaml_doublequoted }}"
 
 # LSST Docushare URL, if authoritative versions of this are are stored there.
 # Leave as an empty string or comment out this key if there is no Docushare URL.
-docushare_url: '{{ cookiecutter.docushare_url }}'
+docushare_url: "{{ cookiecutter.docushare_url | escape_yaml_doublequoted }}"
 
 # GitHub repo URL
-github_url: 'https://github.com/{{ cookiecutter.github_namespace }}'
+github_url: "https://github.com/{{ cookiecutter.github_namespace | escape_yaml_doublequoted }}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-templatekit>=0.2.0,<0.3.0
+templatekit>=0.3.0,<0.4.0


### PR DESCRIPTION
This PR updates the templates repository to use Templatekit 0.3.0+. This new version (see https://templatekit.lsst.io/changelog.html) includes a new `escape_yaml_doublequoted` Jinja filter. With this filter, in tandem with double-quoted YAML strings, we can support arbitrary string content in YAML files. No longer will our templates break with quotes, for instance.

This PR specifically updates the nbreport and technote_rst templates to use the new filter.