### PR TITLE
DM-21707: Detect untracked example files in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ python:
 install:
   - "pip install -r requirements.txt"
 script:
-  # Test the examples by rebuilding them and making sure they match the
-  # committed state (so that the repo is clean).
-  - "scons"
-  - "git diff --exit-code"
+  # The check command rebuilds all examples scons and ensures that generated
+  # examples match the committed state.
+  - "templatekit check"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 sudo: false
+dist: xenial
 language: python
 python:
-  - "3.6"
+  - "3.7.1"
 install:
   - "pip install -r requirements.txt"
 script:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-templatekit>=0.3.0,<0.4.0
+templatekit>=0.4.0,<0.5.0


### PR DESCRIPTION
- Use the new `templatekit check` command, available in templatekit 0.4.0. This command runs `scons` to regenerate examples, and then detect uncommitted state in the examples. The `templatekit check` command improves upon the previous testing strategy by also detecting untracked files. This can happen when a template is changed, but the template developer neglected to run `scons` locally and commit the resulting example. CI will now detect this.
- Also update Travis to Xenial and Python 3.7.