### PR TITLE
DM-20839: Update technote_rst to documenteer 0.5 series

### DIFF
--- a/project_templates/technote_rst/CHANGELOG.md
+++ b/project_templates/technote_rst/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 2019-11-03
+
+- Update to the current versions of Documenteer, >=0.5.4, <0.6.
+
 ## 2019-10-21
 
 - Fix support for the TSTN series.

--- a/project_templates/technote_rst/testn-000/requirements.txt
+++ b/project_templates/technote_rst/testn-000/requirements.txt
@@ -1,1 +1,1 @@
-documenteer[technote]>=0.4.3,<0.5.0
+documenteer[technote]>=0.5.4,<0.6.0

--- a/project_templates/technote_rst/{{cookiecutter.repo_name}}/requirements.txt
+++ b/project_templates/technote_rst/{{cookiecutter.repo_name}}/requirements.txt
@@ -1,1 +1,1 @@
-documenteer[technote]>=0.4.3,<0.5.0
+documenteer[technote]>=0.5.4,<0.6.0


### PR DESCRIPTION
This keeps the reStructuredText technotes in step with the latest versions of Documenteer, but otherwise doesn't affect the user experience.

Documenteer 0.5.4 specifically solves a bug in the sidebar link for technotes.