### PR TITLE
DM-22520: Add lsst-pipelinetask to module documentation template

### DIFF
--- a/file_templates/copyright/COPYRIGHT
+++ b/file_templates/copyright/COPYRIGHT
@@ -1,1 +1,1 @@
-Copyright 2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+Copyright 2020 Association of Universities for Research in Astronomy, Inc. (AURA)

--- a/project_templates/stack_package/CHANGELOG.md
+++ b/project_templates/stack_package/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log
 
+## 2020-01-06
+
+- Add a "Pipeline tasks" section to the module homepage template.
+
+[DM-22520](https://jira.lsstcorp.org/browse/DM-22520)
+
 ## 2019-11-07
 
 Added support for the [lsst-sitcom](https://github.com/lsst-sitcom) GitHub organization.

--- a/project_templates/stack_package/example/COPYRIGHT
+++ b/project_templates/stack_package/example/COPYRIGHT
@@ -1,1 +1,1 @@
-Copyright 2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+Copyright 2020 Association of Universities for Research in Astronomy, Inc. (AURA)

--- a/project_templates/stack_package/example/doc/lsst.example/index.rst
+++ b/project_templates/stack_package/example/doc/lsst.example/index.rst
@@ -36,6 +36,14 @@ You can find Jira issues for this module under the `example <https://jira.lsstco
 Task reference
 ==============
 
+.. _lsst.example-pipeline-tasks:
+
+Pipeline tasks
+--------------
+
+.. lsst-pipelinetasks::
+   :root: lsst.example
+
 .. _lsst.example-command-line-tasks:
 
 Command-line tasks

--- a/project_templates/stack_package/example_dataonly/COPYRIGHT
+++ b/project_templates/stack_package/example_dataonly/COPYRIGHT
@@ -1,1 +1,1 @@
-Copyright 2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+Copyright 2020 Association of Universities for Research in Astronomy, Inc. (AURA)

--- a/project_templates/stack_package/example_dds/COPYRIGHT
+++ b/project_templates/stack_package/example_dds/COPYRIGHT
@@ -1,1 +1,1 @@
-Copyright 2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+Copyright 2020 Association of Universities for Research in Astronomy, Inc. (AURA)

--- a/project_templates/stack_package/example_dds/doc/index.rst
+++ b/project_templates/stack_package/example_dds/doc/index.rst
@@ -36,6 +36,14 @@ You can find Jira issues for this module under the `example_dds <https://jira.ls
 Task reference
 ==============
 
+.. _lsst.example.dds-pipeline-tasks:
+
+Pipeline tasks
+--------------
+
+.. lsst-pipelinetasks::
+   :root: lsst.example.dds
+
 .. _lsst.example.dds-command-line-tasks:
 
 Command-line tasks

--- a/project_templates/stack_package/example_pythononly/COPYRIGHT
+++ b/project_templates/stack_package/example_pythononly/COPYRIGHT
@@ -1,1 +1,1 @@
-Copyright 2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+Copyright 2020 Association of Universities for Research in Astronomy, Inc. (AURA)

--- a/project_templates/stack_package/example_pythononly/doc/lsst.example.pythononly/index.rst
+++ b/project_templates/stack_package/example_pythononly/doc/lsst.example.pythononly/index.rst
@@ -36,6 +36,14 @@ You can find Jira issues for this module under the `example_pythononly <https://
 Task reference
 ==============
 
+.. _lsst.example.pythononly-pipeline-tasks:
+
+Pipeline tasks
+--------------
+
+.. lsst-pipelinetasks::
+   :root: lsst.example.pythononly
+
 .. _lsst.example.pythononly-command-line-tasks:
 
 Command-line tasks

--- a/project_templates/stack_package/example_standalone/COPYRIGHT
+++ b/project_templates/stack_package/example_standalone/COPYRIGHT
@@ -1,1 +1,1 @@
-Copyright 2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+Copyright 2020 Association of Universities for Research in Astronomy, Inc. (AURA)

--- a/project_templates/stack_package/example_standalone/doc/index.rst
+++ b/project_templates/stack_package/example_standalone/doc/index.rst
@@ -36,6 +36,14 @@ You can find Jira issues for this module under the `example_standalone <https://
 Task reference
 ==============
 
+.. _lsst.example.standalone-pipeline-tasks:
+
+Pipeline tasks
+--------------
+
+.. lsst-pipelinetasks::
+   :root: lsst.example.standalone
+
 .. _lsst.example.standalone-command-line-tasks:
 
 Command-line tasks

--- a/project_templates/stack_package/example_subpackage/COPYRIGHT
+++ b/project_templates/stack_package/example_subpackage/COPYRIGHT
@@ -1,1 +1,1 @@
-Copyright 2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+Copyright 2020 Association of Universities for Research in Astronomy, Inc. (AURA)

--- a/project_templates/stack_package/example_subpackage/doc/lsst.example.subpackage/index.rst
+++ b/project_templates/stack_package/example_subpackage/doc/lsst.example.subpackage/index.rst
@@ -36,6 +36,14 @@ You can find Jira issues for this module under the `example_subpackage <https://
 Task reference
 ==============
 
+.. _lsst.example.subpackage-pipeline-tasks:
+
+Pipeline tasks
+--------------
+
+.. lsst-pipelinetasks::
+   :root: lsst.example.subpackage
+
 .. _lsst.example.subpackage-command-line-tasks:
 
 Command-line tasks

--- a/project_templates/stack_package/{{cookiecutter.package_name}}/doc/{{cookiecutter.python_module}}/index.rst
+++ b/project_templates/stack_package/{{cookiecutter.package_name}}/doc/{{cookiecutter.python_module}}/index.rst
@@ -37,6 +37,14 @@ You can find Jira issues for this module under the `{{ cookiecutter.package_name
 Task reference
 ==============
 
+.. _{{ cookiecutter.python_module }}-pipeline-tasks:
+
+Pipeline tasks
+--------------
+
+.. lsst-pipelinetasks::
+   :root: {{ cookiecutter.python_module }}
+
 .. _{{ cookiecutter.python_module }}-command-line-tasks:
 
 Command-line tasks

--- a/project_templates/technote_aastex/testn-000/COPYRIGHT
+++ b/project_templates/technote_aastex/testn-000/COPYRIGHT
@@ -1,1 +1,1 @@
-Copyright 2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+Copyright 2020 Association of Universities for Research in Astronomy, Inc. (AURA)

--- a/project_templates/technote_latex/testn-000/COPYRIGHT
+++ b/project_templates/technote_latex/testn-000/COPYRIGHT
@@ -1,1 +1,1 @@
-Copyright 2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+Copyright 2020 Association of Universities for Research in Astronomy, Inc. (AURA)

--- a/project_templates/technote_rst/testn-000/COPYRIGHT
+++ b/project_templates/technote_rst/testn-000/COPYRIGHT
@@ -1,1 +1,1 @@
-Copyright 2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+Copyright 2020 Association of Universities for Research in Astronomy, Inc. (AURA)

--- a/project_templates/technote_rst/testn-000/metadata.yaml
+++ b/project_templates/technote_rst/testn-000/metadata.yaml
@@ -34,7 +34,7 @@ authors:
 # doi: 10.5281/zenodo.#####
 
 # Copyright statement
-copyright: "2019, Association of Universities for Research in Astronomy, Inc. (AURA)"
+copyright: "2020, Association of Universities for Research in Astronomy, Inc. (AURA)"
 
 # Description. A short, 1-2 sentence statemement used by document indices.
 description: "A short description of this document"


### PR DESCRIPTION
* Add `lsst-pipelinetask` to module documentation template
* Include automatic 2020 copyright updates.