### PR TITLE
Bump roundtable_aiohttp_bot setuptools dependency

### DIFF
--- a/project_templates/roundtable_aiohttp_bot/example/pyproject.toml
+++ b/project_templates/roundtable_aiohttp_bot/example/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-  "setuptools>=30.3.0",
+  "setuptools>=42",
   "wheel",
   "setuptools_scm[toml]>=3.4"
 ]

--- a/project_templates/roundtable_aiohttp_bot/{{cookiecutter.repo_name}}/pyproject.toml
+++ b/project_templates/roundtable_aiohttp_bot/{{cookiecutter.repo_name}}/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-  "setuptools>=30.3.0",
+  "setuptools>=42",
   "wheel",
   "setuptools_scm[toml]>=3.4"
 ]


### PR DESCRIPTION
The setuptools-scm documentation says that setuptools 42 or later
is required to use tools.setuptools_scm in pyproject.toml.