### PR TITLE
Remove explicit --index-url settings

### DIFF
--- a/project_templates/roundtable_aiohttp_bot/example/requirements/dev.in
+++ b/project_templates/roundtable_aiohttp_bot/example/requirements/dev.in
@@ -5,8 +5,6 @@
 # After editing, update requirements/dev.txt by running:
 #     make update-deps
 
---index-url https://pypi.python.org/simple/
-
 pre-commit
 coverage[toml]
 flake8

--- a/project_templates/roundtable_aiohttp_bot/example/requirements/main.in
+++ b/project_templates/roundtable_aiohttp_bot/example/requirements/main.in
@@ -5,8 +5,6 @@
 # After editing, update requirements/main.txt by running:
 #     make update-deps
 
---index-url https://pypi.python.org/simple/
-
 safir
 aiohttp
 aiodns

--- a/project_templates/roundtable_aiohttp_bot/{{cookiecutter.repo_name}}/requirements/dev.in
+++ b/project_templates/roundtable_aiohttp_bot/{{cookiecutter.repo_name}}/requirements/dev.in
@@ -5,8 +5,6 @@
 # After editing, update requirements/dev.txt by running:
 #     make update-deps
 
---index-url https://pypi.python.org/simple/
-
 pre-commit
 coverage[toml]
 flake8

--- a/project_templates/roundtable_aiohttp_bot/{{cookiecutter.repo_name}}/requirements/main.in
+++ b/project_templates/roundtable_aiohttp_bot/{{cookiecutter.repo_name}}/requirements/main.in
@@ -5,8 +5,6 @@
 # After editing, update requirements/main.txt by running:
 #     make update-deps
 
---index-url https://pypi.python.org/simple/
-
 safir
 aiohttp
 aiodns


### PR DESCRIPTION
In the roundtable_aiohttp_bot template, don't explicitly set
--index-url in the requirements templates.  This potentially makes
the template fragile against changes in PyPI.  The frozen SHA-256
hashes should be sufficient to ensure explicitness.