### PR TITLE
Remove old roundtable_aiohttp_bot Dockerfile comment

### DIFF
--- a/project_templates/roundtable_aiohttp_bot/example/Dockerfile
+++ b/project_templates/roundtable_aiohttp_bot/example/Dockerfile
@@ -10,9 +10,6 @@
 # install-image
 #   Installs the app into the virtual environment.
 # runtime-image
-#   - Updates system packages using the scripts/install-runtime-packages.sh
-#     script (this technique prevents the apt-get cache from being added to the
-#     Docker layers).
 #   - Copies the virtual environment into place.
 #   - Runs a non-root user.
 #   - Sets up the entrypoint and port.

--- a/project_templates/roundtable_aiohttp_bot/{{cookiecutter.repo_name}}/Dockerfile
+++ b/project_templates/roundtable_aiohttp_bot/{{cookiecutter.repo_name}}/Dockerfile
@@ -10,9 +10,6 @@
 # install-image
 #   Installs the app into the virtual environment.
 # runtime-image
-#   - Updates system packages using the scripts/install-runtime-packages.sh
-#     script (this technique prevents the apt-get cache from being added to the
-#     Docker layers).
 #   - Copies the virtual environment into place.
 #   - Runs a non-root user.
 #   - Sets up the entrypoint and port.


### PR DESCRIPTION
The runtime-image build step does not run another script for
package installation.  Instead, all system packages should be
installed by scripts/install-base-packages.sh.  Update the
introductory comment accordingly.