### PR TITLE
Enable show_error_codes for mypy

### DIFF
--- a/project_templates/roundtable_aiohttp_bot/example/setup.cfg
+++ b/project_templates/roundtable_aiohttp_bot/example/setup.cfg
@@ -47,6 +47,7 @@ max-line-length = 79
 disallow_untyped_defs = True
 disallow_incomplete_defs = True
 ignore_missing_imports = True
+show_error_codes = True
 strict_equality = True
 warn_redundant_casts = True
 warn_unreachable = True

--- a/project_templates/roundtable_aiohttp_bot/{{cookiecutter.repo_name}}/setup.cfg
+++ b/project_templates/roundtable_aiohttp_bot/{{cookiecutter.repo_name}}/setup.cfg
@@ -47,6 +47,7 @@ max-line-length = 79
 disallow_untyped_defs = True
 disallow_incomplete_defs = True
 ignore_missing_imports = True
+show_error_codes = True
 strict_equality = True
 warn_redundant_casts = True
 warn_unreachable = True


### PR DESCRIPTION
This provides the specific error code that can be used in a
type: ignore comment to suppress only that error.  That isn't
useful yet because flake8 will complain about those comments, but
that will be fixed in the next flake8 release and there's no harm
in ensuring this configuration setting is present in newly-created
bots.