### PR TITLE
Replace all /'s in Docker tag for roundtable_aiohttp_bot

### DIFF
--- a/project_templates/roundtable_aiohttp_bot/example/.github/workflows/ci.yaml
+++ b/project_templates/roundtable_aiohttp_bot/example/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Define the Docker tag
         id: vars
-        run: echo ::set-output name=tag::$(echo ${GITHUB_REF} | sed -E 's,refs/(heads|tags)/,,' | sed -E 's,/,-,')
+        run: echo ::set-output name=tag::$(echo ${GITHUB_REF} | sed -E 's,refs/(heads|tags)/,,' | sed -E 's,/,-,g')
 
       - name: Print the tag
         id: print

--- a/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/.github/workflows/ci.yaml
+++ b/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Define the Docker tag
         id: vars
-        run: echo ::set-output name=tag::$(echo ${GITHUB_REF} | sed -E 's,refs/(heads|tags)/,,' | sed -E 's,/,-,')
+        run: echo ::set-output name=tag::$(echo ${GITHUB_REF} | sed -E 's,refs/(heads|tags)/,,' | sed -E 's,/,-,g')
 
       - name: Print the tag
         id: print


### PR DESCRIPTION
The sed expression was only replacing the first /, which is
insufficient for u/<username> branch naming conventions.