### PR TITLE
Remove license key from setup.cfg

### DIFF
--- a/project_templates/roundtable_aiohttp_bot/example/setup.cfg
+++ b/project_templates/roundtable_aiohttp_bot/example/setup.cfg
@@ -5,7 +5,6 @@ author = Association of Universities for Research in Astronomy, Inc. (AURA)
 author_email = sqre-admin@lists.lsst.org
 long_description = file: README.rst, CHANGELOG.rst, LICENSE
 long_description_content_type = text/x-rst
-license = MIT
 url = https://github.com/lsst-sqre/example
 project_urls =
     Change log = https://github.com/lsst-sqre/example/master/blob/CHANGELOG.rst

--- a/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/setup.cfg
+++ b/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/setup.cfg
@@ -5,7 +5,6 @@ author = {{cookiecutter.copyright_holder}}
 author_email = sqre-admin@lists.lsst.org
 long_description = file: README.rst, CHANGELOG.rst, LICENSE
 long_description_content_type = text/x-rst
-license = MIT
 url = https://github.com/{{cookiecutter.github_org}}/{{cookiecutter.name}}
 project_urls =
     Change log = https://github.com/{{cookiecutter.github_org}}/{{cookiecutter.name}}/master/blob/CHANGELOG.rst


### PR DESCRIPTION
packaging.python.org says that standard licenses should be
indicated primarily via trove classifiers and the license field is
optional and intended for custom non-standard licenses.  Omit it
and rely on the trove classifiers, which avoids the question of what
the valid values for this field are.

Reference: https://packaging.python.org/guides/distributing-packages-using-setuptools/#license