### PR TITLE
DM-25056: Add support for the OPSTN technote series

### DIFF
--- a/project_templates/technote_latex/CHANGELOG.md
+++ b/project_templates/technote_latex/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2020-05-25
 
-- Add support for the OPSTN technote series.
+- Add support for the RTN technote series for operations.
 
 ## 2019-11-05
 

--- a/project_templates/technote_latex/CHANGELOG.md
+++ b/project_templates/technote_latex/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 2020-05-25
+
+- Add support for the OPSTN technote series.
+
 ## 2019-11-05
 
 Updated the AURA copyright to "Association of Universities for Research in Astronomy, Inc. (AURA)."

--- a/project_templates/technote_latex/README.md
+++ b/project_templates/technote_latex/README.md
@@ -40,7 +40,7 @@ Choose a GitHub organization that matches the [series](#cookiecutter_series):
 
 - `lsst-dm` for the DMTN series.
 - `LSST-IT` for the ITTN series.
-- `lsst-ops` for the OPSTN series.
+- `rubin-observatory` for the OPSTN series.
 - `lsst-pst` for the PSTN series.
 - `lsst-sims` for the Simulations Group's SMTN series.
 - `lsst-sitcom` for the SITCOMTN series.

--- a/project_templates/technote_latex/README.md
+++ b/project_templates/technote_latex/README.md
@@ -20,7 +20,7 @@ Choose the series that fits the document's purpose or aligns with the organizati
 
 - `DMTN` for Data Management technical notes. See [DMTN-000](https://dmtn-000.lsst.io).
 - `ITTN` for LSST IT technical notes.
-- `OPSTN` for LSST Operations technical notes.
+- `RTN` for Rubin Operations technical notes. Regardless of department.
 - `PSTN` for Project Science Team technical notes.
 - `SMTN` for Simulations Group technical notes. See [SMTN-000](https://smtn-000.lsst.io).
 - `SITCOMTN` for Systems Integration, Testing, and Commissioning notes.
@@ -40,7 +40,7 @@ Choose a GitHub organization that matches the [series](#cookiecutter_series):
 
 - `lsst-dm` for the DMTN series.
 - `LSST-IT` for the ITTN series.
-- `rubin-observatory` for the OPSTN series.
+- `rubin-observatory` for the RTN series.
 - `lsst-pst` for the PSTN series.
 - `lsst-sims` for the Simulations Group's SMTN series.
 - `lsst-sitcom` for the SITCOMTN series.

--- a/project_templates/technote_latex/README.md
+++ b/project_templates/technote_latex/README.md
@@ -20,7 +20,7 @@ Choose the series that fits the document's purpose or aligns with the organizati
 
 - `DMTN` for Data Management technical notes. See [DMTN-000](https://dmtn-000.lsst.io).
 - `ITTN` for LSST IT technical notes.
-- `RTN` for Rubin Operations technical notes. Regardless of department.
+- `RTN` for Rubin Observatory operations technical notes (all departments).
 - `PSTN` for Project Science Team technical notes.
 - `SMTN` for Simulations Group technical notes. See [SMTN-000](https://smtn-000.lsst.io).
 - `SITCOMTN` for Systems Integration, Testing, and Commissioning notes.

--- a/project_templates/technote_latex/cookiecutter.json
+++ b/project_templates/technote_latex/cookiecutter.json
@@ -22,7 +22,7 @@
   "github_org": [
     "lsst-dm",
     "LSST-IT",
-    "lsst-ops",
+    "rubin-observatory",
     "lsst-pst",
     "lsst-sims",
     "lsst-sitcom",

--- a/project_templates/technote_latex/cookiecutter.json
+++ b/project_templates/technote_latex/cookiecutter.json
@@ -10,7 +10,7 @@
   "series": [
     "DMTN",
     "ITTN",
-    "OPSTN",
+    "RTN",
     "PSTN",
     "SMTN",
     "SITCOMTN",

--- a/project_templates/technote_latex/templatekit.yaml
+++ b/project_templates/technote_latex/templatekit.yaml
@@ -27,13 +27,12 @@ dialog_fields:
           series: "ITTN"
           github_org: "LSST-IT"
           org: "PMO"
-      # Enable this feature if sqrbot can be added to the lsst-ops org.
-      # - label: "OPSTN"
-      #   value: "OPSTN"
-      #   presets:
-      #     series: "OPSTN"
-      #     github_org: "lsst-ops"
-      #     org: "ops"
+      - label: "OPSTN"
+        value: "OPSTN"
+        presets:
+          series: "OPSTN"
+          github_org: "rubin-observatory"
+          org: "ops"
       - label: "PSTN"
         value: "PSTN"
         presets:

--- a/project_templates/technote_latex/templatekit.yaml
+++ b/project_templates/technote_latex/templatekit.yaml
@@ -27,10 +27,10 @@ dialog_fields:
           series: "ITTN"
           github_org: "LSST-IT"
           org: "PMO"
-      - label: "OPSTN"
-        value: "OPSTN"
+      - label: "RTN"
+        value: "rtn"
         presets:
-          series: "OPSTN"
+          series: "RTN"
           github_org: "rubin-observatory"
           org: "ops"
       - label: "PSTN"

--- a/project_templates/technote_rst/CHANGELOG.md
+++ b/project_templates/technote_rst/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2020-05-25
 
-- Add support for the OPSTN technote series.
+- Add support for the RTN technote series for operations.
 
 ## 2019-11-03
 

--- a/project_templates/technote_rst/CHANGELOG.md
+++ b/project_templates/technote_rst/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 2020-05-25
+
+- Add support for the OPSTN technote series.
+
 ## 2019-11-03
 
 - Update to the current versions of Documenteer, >=0.5.4, <0.6.

--- a/project_templates/technote_rst/README.md
+++ b/project_templates/technote_rst/README.md
@@ -54,7 +54,7 @@ Choose a GitHub organization that matches the [series](#cookiecutter_series):
 
 - `lsst-dm` for the DM DMTN series.
 - `LSST-IT` for the ITTN series.
-- `lsst-ops` for the OPSTN series.
+- `rubin-observatory` for the OPSTN series.
 - `lsst-sims` for the Simulations Group's SMTN series.
 - `lsst-sitcom` for the SITCOMTN series.
 - `lsst-sqre` for the SQuaRE SQR series.

--- a/project_templates/technote_rst/README.md
+++ b/project_templates/technote_rst/README.md
@@ -25,7 +25,7 @@ Choose the series that fits the document's purpose or aligns with the organizati
 
 - `DMTN` for Data Management technical notes. See [DMTN-000](https://dmtn-000.lsst.io).
 - `ITTN` for LSST IT technical notes.
-- `RTN` for Rubin technical notes. These is to be for all operations technotes regardless of department.
+- `RTN` for Rubin Observatory operations technical notes (all departments).
 - `PSTN` for Project Science Team technical notes.
 - `SMTN` for Simulations Group technical notes. See [SMTN-000](https://smtn-000.lsst.io).
 - `SITCOMTN` for Systems Integration, Testing, and Commissioning notes.

--- a/project_templates/technote_rst/README.md
+++ b/project_templates/technote_rst/README.md
@@ -25,7 +25,7 @@ Choose the series that fits the document's purpose or aligns with the organizati
 
 - `DMTN` for Data Management technical notes. See [DMTN-000](https://dmtn-000.lsst.io).
 - `ITTN` for LSST IT technical notes.
-- `OPSTN` for LSST Operations technical notes.
+- `RTN` for Rubin technical notes. These is to be for all operations technotes regardless of department.
 - `PSTN` for Project Science Team technical notes.
 - `SMTN` for Simulations Group technical notes. See [SMTN-000](https://smtn-000.lsst.io).
 - `SITCOMTN` for Systems Integration, Testing, and Commissioning notes.
@@ -54,7 +54,7 @@ Choose a GitHub organization that matches the [series](#cookiecutter_series):
 
 - `lsst-dm` for the DM DMTN series.
 - `LSST-IT` for the ITTN series.
-- `rubin-observatory` for the OPSTN series.
+- `rubin-observatory` for the RTN series.
 - `lsst-sims` for the Simulations Group's SMTN series.
 - `lsst-sitcom` for the SITCOMTN series.
 - `lsst-sqre` for the SQuaRE SQR series.

--- a/project_templates/technote_rst/cookiecutter.json
+++ b/project_templates/technote_rst/cookiecutter.json
@@ -17,7 +17,7 @@
   "github_org": [
     "lsst-dm",
     "LSST-IT",
-    "lsst-ops",
+    "rubin-observatory",
     "lsst-pst",
     "lsst-sims",
     "lsst-sitcom",

--- a/project_templates/technote_rst/cookiecutter.json
+++ b/project_templates/technote_rst/cookiecutter.json
@@ -3,7 +3,7 @@
   "series": [
     "DMTN",
     "ITTN",
-    "OPSTN",
+    "RTN",
     "PSTN",
     "SMTN",
     "SITCOMTN",

--- a/project_templates/technote_rst/templatekit.yaml
+++ b/project_templates/technote_rst/templatekit.yaml
@@ -25,10 +25,10 @@ dialog_fields:
         presets:
           series: "ITTN"
           github_org: "LSST-IT"
-      - label: "OPSTN"
-        value: "opstn"
+      - label: "RTN"
+        value: "rtn"
         presets:
-          series: "OPSTN"
+          series: "RTN"
           github_org: "rubin-observatory"
       - label: "SITCOMTN"
         value: "sitcomtn"

--- a/project_templates/technote_rst/templatekit.yaml
+++ b/project_templates/technote_rst/templatekit.yaml
@@ -25,6 +25,11 @@ dialog_fields:
         presets:
           series: "ITTN"
           github_org: "LSST-IT"
+      - label: "OPSTN"
+        value: "opstn"
+        presets:
+          series: "OPSTN"
+          github_org: "rubin-observatory"
       - label: "SITCOMTN"
         value: "sitcomtn"
         presets:


### PR DESCRIPTION
These technotes are hosted in the https://github.com/rubin-observatory GitHub organization.

The other half of this work is to add @sqrbot to the rubin-observatory organization to enable Slack-based project creation. @sqrbot requires `admin` level access.

This work resolves a request from @womullan.