### PR TITLE
Rename LSST-IT org to lsst-it

### DIFF
--- a/project_templates/technote_latex/README.md
+++ b/project_templates/technote_latex/README.md
@@ -39,7 +39,7 @@ The GitHub organization where this technote resides.
 Choose a GitHub organization that matches the [series](#cookiecutter_series):
 
 - `lsst-dm` for the DMTN series.
-- `LSST-IT` for the ITTN series.
+- `lsst-it` for the ITTN series.
 - `rubin-observatory` for the RTN series.
 - `lsst-pst` for the PSTN series.
 - `lsst-sims` for the Simulations Group's SMTN series.

--- a/project_templates/technote_latex/cookiecutter.json
+++ b/project_templates/technote_latex/cookiecutter.json
@@ -21,7 +21,7 @@
   "serial_number": "000",
   "github_org": [
     "lsst-dm",
-    "LSST-IT",
+    "lsst-it",
     "rubin-observatory",
     "lsst-pst",
     "lsst-sims",

--- a/project_templates/technote_latex/templatekit.yaml
+++ b/project_templates/technote_latex/templatekit.yaml
@@ -25,7 +25,7 @@ dialog_fields:
         value: "ittn"
         presets:
           series: "ITTN"
-          github_org: "LSST-IT"
+          github_org: "lsst-it"
           org: "PMO"
       - label: "RTN"
         value: "rtn"

--- a/project_templates/technote_rst/README.md
+++ b/project_templates/technote_rst/README.md
@@ -53,7 +53,7 @@ The GitHub organization where this technote resides.
 Choose a GitHub organization that matches the [series](#cookiecutter_series):
 
 - `lsst-dm` for the DM DMTN series.
-- `LSST-IT` for the ITTN series.
+- `lsst-it` for the ITTN series.
 - `rubin-observatory` for the RTN series.
 - `lsst-sims` for the Simulations Group's SMTN series.
 - `lsst-sitcom` for the SITCOMTN series.

--- a/project_templates/technote_rst/cookiecutter.json
+++ b/project_templates/technote_rst/cookiecutter.json
@@ -16,7 +16,7 @@
   "repo_name": "{{ cookiecutter.series.lower() }}-{{ cookiecutter.serial_number }}",
   "github_org": [
     "lsst-dm",
-    "LSST-IT",
+    "lsst-it",
     "rubin-observatory",
     "lsst-pst",
     "lsst-sims",

--- a/project_templates/technote_rst/templatekit.yaml
+++ b/project_templates/technote_rst/templatekit.yaml
@@ -24,7 +24,7 @@ dialog_fields:
         value: "ittn"
         presets:
           series: "ITTN"
-          github_org: "LSST-IT"
+          github_org: "lsst-it"
       - label: "RTN"
         value: "rtn"
         presets:


### PR DESCRIPTION
The canonical name for this organization is now in lowercase.