### PR TITLE
DM-25233: Fix technote_rst usage of secrets in GitHub Actions

### DIFF
--- a/project_templates/technote_rst/testn-000/.github/workflows/ci.yaml
+++ b/project_templates/technote_rst/testn-000/.github/workflows/ci.yaml
@@ -28,6 +28,7 @@ jobs:
           make html
 
       - name: Upload
+        if: ${{ github.event_name == 'push' }}
         env:
           LTD_PASSWORD: ${{ secrets.LTD_PASSWORD }}
           LTD_USERNAME: ${{ secrets.LTD_USERNAME }}

--- a/project_templates/technote_rst/testn-000/.github/workflows/ci.yaml
+++ b/project_templates/technote_rst/testn-000/.github/workflows/ci.yaml
@@ -28,5 +28,8 @@ jobs:
           make html
 
       - name: Upload
+        env:
+          LTD_PASSWORD: ${{ secrets.LTD_PASSWORD }}
+          LTD_USERNAME: ${{ secrets.LTD_USERNAME }}
         run: |
           ltd upload --gh --dir _build/html --product testn-000

--- a/project_templates/technote_rst/{{cookiecutter.repo_name}}/.github/workflows/ci.yaml
+++ b/project_templates/technote_rst/{{cookiecutter.repo_name}}/.github/workflows/ci.yaml
@@ -28,6 +28,7 @@ jobs:
           make html
 
       - name: Upload
+        if: {% raw %}${{ github.event_name == 'push' }}{% endraw %}
         env:
           LTD_PASSWORD: {% raw %}${{ secrets.LTD_PASSWORD }}{% endraw %}
           LTD_USERNAME: {% raw %}${{ secrets.LTD_USERNAME }}{% endraw %}

--- a/project_templates/technote_rst/{{cookiecutter.repo_name}}/.github/workflows/ci.yaml
+++ b/project_templates/technote_rst/{{cookiecutter.repo_name}}/.github/workflows/ci.yaml
@@ -28,5 +28,8 @@ jobs:
           make html
 
       - name: Upload
+        env:
+          LTD_PASSWORD: {% raw %}${{ secrets.LTD_PASSWORD }}{% endraw %}
+          LTD_USERNAME: {% raw %}${{ secrets.LTD_USERNAME }}{% endraw %}
         run: |
           ltd upload --gh --dir _build/html --product {{ cookiecutter.series.lower() }}-{{ cookiecutter.serial_number }}


### PR DESCRIPTION
- Add an env field to the `technote_rst` workflow's upload step to give it access to the LTD credentials stored as GitHub Secrets (already done for LaTeX technotes).
- Only upload specifically on a push event, not a PR event (which won't have access to credentials, and thus will fail.