### PR TITLE
DM-25233: Drop the CI badge for Travis CI in rst technotes

### DIFF
--- a/project_templates/technote_rst/testn-000/README.rst
+++ b/project_templates/technote_rst/testn-000/README.rst
@@ -1,7 +1,5 @@
 .. image:: https://img.shields.io/badge/testn--000-lsst.io-brightgreen.svg
    :target: https://testn-000.lsst.io
-.. image:: https://travis-ci.com/lsst-dm/testn-000.svg
-   :target: https://travis-ci.com/lsst-dm/testn-000
 .. image:: https://github.com/lsst-dm/testn-000/workflows/CI/badge.svg
    :target: https://github.com/lsst-dm/testn-000/actions/
 ..

--- a/project_templates/technote_rst/{{cookiecutter.repo_name}}/README.rst
+++ b/project_templates/technote_rst/{{cookiecutter.repo_name}}/README.rst
@@ -1,7 +1,5 @@
 .. image:: https://img.shields.io/badge/{{ cookiecutter.repo_name|replace("-", "--") }}-lsst.io-brightgreen.svg
    :target: {{ cookiecutter.url }}
-.. image:: https://travis-ci.com/{{ cookiecutter.github_namespace }}.svg
-   :target: https://travis-ci.com/{{ cookiecutter.github_namespace }}
 .. image:: https://github.com/{{ cookiecutter.github_namespace }}/workflows/CI/badge.svg
    :target: https://github.com/{{ cookiecutter.github_namespace }}/actions/
 ..


### PR DESCRIPTION
This was accidentally left behind when the badge for GitHub Actions was added.