### PR TITLE
[DM-25183] Update dependencies in roundtable template

### DIFF
--- a/project_templates/roundtable_aiohttp_bot/example/.github/dependabot.yml
+++ b/project_templates/roundtable_aiohttp_bot/example/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/project_templates/roundtable_aiohttp_bot/example/.github/workflows/ci.yaml
+++ b/project_templates/roundtable_aiohttp_bot/example/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2.0.1
         with:
           python-version: 3.7
 
@@ -19,7 +19,7 @@ jobs:
 
       - name: Cache tox environments
         id: cache-tox
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: .tox
           # requirements/*.txt, pyproject.toml, and .pre-commit-config.yaml

--- a/project_templates/roundtable_aiohttp_bot/example/.pre-commit-config.yaml
+++ b/project_templates/roundtable_aiohttp_bot/example/.pre-commit-config.yaml
@@ -1,29 +1,29 @@
 repos:
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v2.5.0
-  hooks:
-  - id: check-yaml
-  - id: check-toml
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.1.0
+    hooks:
+      - id: check-yaml
+      - id: check-toml
 
-- repo: https://github.com/asottile/seed-isort-config
-  rev: v1.9.4
-  hooks:
-  - id: seed-isort-config
-    args: [--exclude=docs/.*\.py, --application-directories, src]
+  - repo: https://github.com/asottile/seed-isort-config
+    rev: v2.2.0
+    hooks:
+      - id: seed-isort-config
+        args: [--exclude=docs/.*\.py, --application-directories, src]
 
-- repo: https://github.com/timothycrosley/isort
-  rev: 4.3.21-2
-  hooks:
-  - id: isort
-    additional_dependencies:
-      - toml
+  - repo: https://github.com/timothycrosley/isort
+    rev: 4.3.21-2
+    hooks:
+      - id: isort
+        additional_dependencies:
+          - toml
 
-- repo: https://github.com/ambv/black
-  rev: 19.10b0
-  hooks:
-  - id: black
+  - repo: https://github.com/ambv/black
+    rev: 19.10b0
+    hooks:
+      - id: black
 
-- repo: https://gitlab.com/pycqa/flake8
-  rev: 3.7.9
-  hooks:
-  - id: flake8
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.3
+    hooks:
+      - id: flake8

--- a/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/.github/dependabot.yml
+++ b/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/.github/workflows/ci.yaml
+++ b/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2.0.1
         with:
           python-version: 3.7
 
@@ -19,7 +19,7 @@ jobs:
 
       - name: Cache tox environments
         id: cache-tox
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: .tox
           # requirements/*.txt, pyproject.toml, and .pre-commit-config.yaml

--- a/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/.pre-commit-config.yaml
+++ b/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/.pre-commit-config.yaml
@@ -1,29 +1,29 @@
 repos:
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v2.5.0
-  hooks:
-  - id: check-yaml
-  - id: check-toml
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.1.0
+    hooks:
+      - id: check-yaml
+      - id: check-toml
 
-- repo: https://github.com/asottile/seed-isort-config
-  rev: v1.9.4
-  hooks:
-  - id: seed-isort-config
-    args: [--exclude=docs/.*\.py, --application-directories, src]
+  - repo: https://github.com/asottile/seed-isort-config
+    rev: v2.2.0
+    hooks:
+      - id: seed-isort-config
+        args: [--exclude=docs/.*\.py, --application-directories, src]
 
-- repo: https://github.com/timothycrosley/isort
-  rev: 4.3.21-2
-  hooks:
-  - id: isort
-    additional_dependencies:
-      - toml
+  - repo: https://github.com/timothycrosley/isort
+    rev: 4.3.21-2
+    hooks:
+      - id: isort
+        additional_dependencies:
+          - toml
 
-- repo: https://github.com/ambv/black
-  rev: 19.10b0
-  hooks:
-  - id: black
+  - repo: https://github.com/ambv/black
+    rev: 19.10b0
+    hooks:
+      - id: black
 
-- repo: https://gitlab.com/pycqa/flake8
-  rev: 3.7.9
-  hooks:
-  - id: flake8
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.3
+    hooks:
+      - id: flake8


### PR DESCRIPTION
- Update pre-commit hook dependencies to the latest version.
- Update GitHub workflows to the latest version.
- Add GitHub dependabot configuration for GitHub actions updates.

The pre-commit update is a one-off.  Eventually the best way to
handle this will be for sqrbot-jr to run neophile after generating
the template to update all of the versions before the first commit,
but that's not ready yet.