### PR TITLE
Fix usage information for subcommands

### DIFF
--- a/project_templates/roundtable_aiohttp_bot/example/src/example/cli.py
+++ b/project_templates/roundtable_aiohttp_bot/example/src/example/cli.py
@@ -35,6 +35,7 @@ def help(ctx: click.Context, topic: Union[None, str], **kw: Any) -> None:
     # https://www.burgundywall.com/post/having-click-help-subcommand
     if topic:
         if topic in main.commands:
+            ctx.info_name = topic
             click.echo(main.commands[topic].get_help(ctx))
         else:
             raise click.UsageError(f"Unknown help topic {topic}", ctx)

--- a/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/src/{{cookiecutter.package_name}}/cli.py
+++ b/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/src/{{cookiecutter.package_name}}/cli.py
@@ -35,6 +35,7 @@ def help(ctx: click.Context, topic: Union[None, str], **kw: Any) -> None:
     # https://www.burgundywall.com/post/having-click-help-subcommand
     if topic:
         if topic in main.commands:
+            ctx.info_name = topic
             click.echo(main.commands[topic].get_help(ctx))
         else:
             raise click.UsageError(f"Unknown help topic {topic}", ctx)


### PR DESCRIPTION
Set info_name in the context before displaying help for subcommands.
Otherwise, the usage summary displayed as part of the help will show
"help" as the subcommand because it is the current context.