### PR TITLE
[DM-25844] Add Docker monitoring to Dependabot config

### DIFF
--- a/project_templates/roundtable_aiohttp_bot/example/.github/dependabot.yml
+++ b/project_templates/roundtable_aiohttp_bot/example/.github/dependabot.yml
@@ -4,3 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/.github/dependabot.yml
+++ b/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/.github/dependabot.yml
@@ -4,3 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
For the roundtable_aiohttp_bot tmeplate, add Docker monitoring to
the default Dependabot configuration.  This won't catch a lot, but
it will warn if the base Docker image is out of date.