### PR TITLE
Enable creation of lsstdoc docs in lsst org

### DIFF
--- a/project_templates/latex_lsstdoc/cookiecutter.json
+++ b/project_templates/latex_lsstdoc/cookiecutter.json
@@ -4,6 +4,7 @@
   "serial_number": "",
   "github_org": [
     "rubin-observatory",
+    "lsst",
     "lsst-dm",
     "lsst-it",
     "lsst-pst",

--- a/project_templates/latex_lsstdoc/templatekit.yaml
+++ b/project_templates/latex_lsstdoc/templatekit.yaml
@@ -20,6 +20,11 @@ dialog_fields:
         presets:
           github_org: "rubin-observatory"
           lsstdoc_org: "ops"
+      - label: "lsst"
+        value: "lsst"
+        presets:
+          github_org: "lsst"
+          lsstdoc_org: "dm"
       - label: "lsst-dm"
         value: "lsst-dm"
         presets:


### PR DESCRIPTION
This is necessary for documents such as LDM.