### PR TITLE
DM-26975: Add support for SCTR test reports

### DIFF
--- a/project_templates/test_report/README.md
+++ b/project_templates/test_report/README.md
@@ -13,7 +13,8 @@ Before using this template, the report's handle must be reserved in DocuShare.
 
 The document's series:
 
-- `DMTR` is the handle for test reports.
+- `DMTR` is the handle for DM test reports.
+- `SCTR` is the handle for SITCOM test reports.
 - `TESTTR` is a handle for testing the template.
 
 ### cookiecutter.serial_number

--- a/project_templates/test_report/cookiecutter.json
+++ b/project_templates/test_report/cookiecutter.json
@@ -1,11 +1,13 @@
 {
   "series": [
     "DMTR",
+    "SCTR",
     "TESTTR"
   ],
   "serial_number": "0",
   "github_org": [
     "lsst-dm",
+    "lsst-sitcom",
     "lsst-sqre-testing"
   ],
   "title": "Document Title",

--- a/project_templates/test_report/templatekit.yaml
+++ b/project_templates/test_report/templatekit.yaml
@@ -24,6 +24,11 @@ dialog_fields:
         presets:
           series: "DMTR"
           github_org: "lsst-dm"
+      - label: "SCTR"
+        value: "SCTR"
+        presets:
+          series: "SCTR"
+          github_org: "lsst-sitcom"
       - label: "Test"
         value: "test"
         presets:


### PR DESCRIPTION
This adds support for SCTR test reports with `sqrbot-jr project create`, which uses the same infrastructure as DMTR reports.