### PR TITLE
Install build-essential in the dependencies-image

### DIFF
--- a/project_templates/roundtable_aiohttp_bot/example/Dockerfile
+++ b/project_templates/roundtable_aiohttp_bot/example/Dockerfile
@@ -22,6 +22,9 @@ RUN ./install-base-packages.sh
 
 FROM base-image AS dependencies-image
 
+# Install build-essential in case any Python packages require a compiler.
+RUN apt-get install build-essential
+
 # Create a Python virtual environment
 ENV VIRTUAL_ENV=/opt/venv
 RUN python -m venv $VIRTUAL_ENV

--- a/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/Dockerfile
+++ b/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/Dockerfile
@@ -22,6 +22,9 @@ RUN ./install-base-packages.sh
 
 FROM base-image AS dependencies-image
 
+# Install build-essential in case any Python packages require a compiler.
+RUN apt-get install build-essential
+
 # Create a Python virtual environment
 ENV VIRTUAL_ENV=/opt/venv
 RUN python -m venv $VIRTUAL_ENV


### PR DESCRIPTION
Sometimes, Python packages require a compiler (usually because a
binary wheel isn't yet available).  Install build-essential in the
dependencies image so that pip install will succeed, but the extra
packages are not included in the runtime image.