### PR TITLE
Update roundtable_aiohttp_bot template

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,13 +9,13 @@ jobs:
     strategy:
       matrix:
         python:
-          - 3.7
           - 3.8
+          - 3.9
 
     steps:
-      - uses: actions/checkout@v2.3.3
+      - uses: actions/checkout@v2
 
-      - uses: actions/setup-python@v2.1.3
+      - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
 

--- a/project_templates/roundtable_aiohttp_bot/example/.github/workflows/ci.yaml
+++ b/project_templates/roundtable_aiohttp_bot/example/.github/workflows/ci.yaml
@@ -6,13 +6,19 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        python:
+          - 3.8
+          - 3.9
+
     steps:
       - uses: actions/checkout@v2
 
       - name: Set up Python
-        uses: actions/setup-python@v2.0.1
+        uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: ${{ matrix.python }}
 
       - name: Install tox
         run: pip install tox

--- a/project_templates/roundtable_aiohttp_bot/example/.pre-commit-config.yaml
+++ b/project_templates/roundtable_aiohttp_bot/example/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v3.3.0
     hooks:
       - id: check-yaml
       - id: check-toml
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.5.2
+    rev: 5.6.4
     hooks:
       - id: isort
         additional_dependencies:
@@ -18,6 +18,6 @@ repos:
       - id: black
 
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.3
+    rev: 3.8.4
     hooks:
       - id: flake8

--- a/project_templates/roundtable_aiohttp_bot/example/Dockerfile
+++ b/project_templates/roundtable_aiohttp_bot/example/Dockerfile
@@ -14,13 +14,17 @@
 #   - Runs a non-root user.
 #   - Sets up the entrypoint and port.
 
-FROM python:3.7-slim-buster AS base-image
+FROM python:3.9-slim-buster AS base-image
 
 # Update system packages
 COPY scripts/install-base-packages.sh .
-RUN ./install-base-packages.sh
+RUN ./install-base-packages.sh && rm ./install-base-packages.sh
 
 FROM base-image AS dependencies-image
+
+# Install system packages only needed for building dependencies.
+COPY scripts/install-dependency-packages.sh .
+RUN ./install-dependency-packages.sh
 
 # Create a Python virtual environment
 ENV VIRTUAL_ENV=/opt/venv

--- a/project_templates/roundtable_aiohttp_bot/example/pyproject.toml
+++ b/project_templates/roundtable_aiohttp_bot/example/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = 'setuptools.build_meta'
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py37,coverage-report,typing,lint
+envlist = py,coverage-report,typing,lint
 isolated_build = True
 
 [testenv]
@@ -27,7 +27,7 @@ description = Compile coverage from each test run.
 skip_install = true
 deps = coverage[toml]>=5.0.2
 depends =
-    py37
+    py
 commands =
     coverage combine
     coverage report
@@ -74,7 +74,7 @@ exclude_lines = [
 
 [tool.black]
 line-length = 79
-target-version = ['py37']
+target-version = ['py38']
 exclude = '''
 /(
     \.eggs

--- a/project_templates/roundtable_aiohttp_bot/example/scripts/install-dependency-packages.sh
+++ b/project_templates/roundtable_aiohttp_bot/example/scripts/install-dependency-packages.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 
-# This script updates packages in the base Docker image that's used by both the
-# build and runtime images, and gives us a place to install additional
-# system-level packages with apt-get.
+# This script installs additional packages used by the dependency image but
+# not needed by the runtime image, such as additional packages required to
+# build Python dependencies.
 #
-# Based on the blog post:
-# https://pythonspeed.com/articles/system-packages-docker/
+# Since the base image wipes all the apt caches to clean up the image that
+# will be reused by the runtime image, we unfortunately have to do another
+# apt-get update here, which wastes some time and network.
 
 # Bash "strict mode", to help catch problems and bugs in the shell
 # script. Every bash script you write should include this. See
@@ -23,15 +24,9 @@ export DEBIAN_FRONTEND=noninteractive
 # Update the package listing, so we know what packages exist:
 apt-get update
 
-# Install security updates:
-apt-get -y upgrade
-
 # Install build-essential because sometimes Python dependencies need to build
 # C modules, particularly when upgrading to newer Python versions.
 apt-get -y install --no-install-recommends build-essential
-
-# Example of installing a new package, without unnecessary packages:
-apt-get -y install --no-install-recommends git
 
 # Delete cached files we don't need anymore:
 apt-get clean

--- a/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/.github/workflows/ci.yaml
+++ b/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/.github/workflows/ci.yaml
@@ -6,13 +6,19 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        python:
+          - 3.8
+          - 3.9
+
     steps:
       - uses: actions/checkout@v2
 
       - name: Set up Python
-        uses: actions/setup-python@v2.0.1
+        uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: {{ "${{ matrix.python }}" }}
 
       - name: Install tox
         run: pip install tox

--- a/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/.pre-commit-config.yaml
+++ b/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v3.3.0
     hooks:
       - id: check-yaml
       - id: check-toml
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.5.2
+    rev: 5.6.4
     hooks:
       - id: isort
         additional_dependencies:
@@ -18,6 +18,6 @@ repos:
       - id: black
 
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.3
+    rev: 3.8.4
     hooks:
       - id: flake8

--- a/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/Dockerfile
+++ b/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/Dockerfile
@@ -14,13 +14,17 @@
 #   - Runs a non-root user.
 #   - Sets up the entrypoint and port.
 
-FROM python:3.7-slim-buster AS base-image
+FROM python:3.9-slim-buster AS base-image
 
 # Update system packages
 COPY scripts/install-base-packages.sh .
-RUN ./install-base-packages.sh
+RUN ./install-base-packages.sh && rm ./install-base-packages.sh
 
 FROM base-image AS dependencies-image
+
+# Install system packages only needed for building dependencies.
+COPY scripts/install-dependency-packages.sh .
+RUN ./install-dependency-packages.sh
 
 # Create a Python virtual environment
 ENV VIRTUAL_ENV=/opt/venv

--- a/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/pyproject.toml
+++ b/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = 'setuptools.build_meta'
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py37,coverage-report,typing,lint
+envlist = py,coverage-report,typing,lint
 isolated_build = True
 
 [testenv]
@@ -27,7 +27,7 @@ description = Compile coverage from each test run.
 skip_install = true
 deps = coverage[toml]>=5.0.2
 depends =
-    py37
+    py
 commands =
     coverage combine
     coverage report
@@ -74,7 +74,7 @@ exclude_lines = [
 
 [tool.black]
 line-length = 79
-target-version = ['py37']
+target-version = ['py38']
 exclude = '''
 /(
     \.eggs

--- a/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/scripts/install-base-packages.sh
+++ b/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/scripts/install-base-packages.sh
@@ -26,6 +26,10 @@ apt-get update
 # Install security updates:
 apt-get -y upgrade
 
+# Install build-essential because sometimes Python dependencies need to build
+# C modules, particularly when upgrading to newer Python versions.
+apt-get -y install --no-install-recommends build-essential
+
 # Example of installing a new package, without unnecessary packages:
 apt-get -y install --no-install-recommends git
 

--- a/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/scripts/install-dependency-packages.sh
+++ b/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/scripts/install-dependency-packages.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 
-# This script updates packages in the base Docker image that's used by both the
-# build and runtime images, and gives us a place to install additional
-# system-level packages with apt-get.
+# This script installs additional packages used by the dependency image but
+# not needed by the runtime image, such as additional packages required to
+# build Python dependencies.
 #
-# Based on the blog post:
-# https://pythonspeed.com/articles/system-packages-docker/
+# Since the base image wipes all the apt caches to clean up the image that
+# will be reused by the runtime image, we unfortunately have to do another
+# apt-get update here, which wastes some time and network.
 
 # Bash "strict mode", to help catch problems and bugs in the shell
 # script. Every bash script you write should include this. See
@@ -23,15 +24,9 @@ export DEBIAN_FRONTEND=noninteractive
 # Update the package listing, so we know what packages exist:
 apt-get update
 
-# Install security updates:
-apt-get -y upgrade
-
 # Install build-essential because sometimes Python dependencies need to build
 # C modules, particularly when upgrading to newer Python versions.
 apt-get -y install --no-install-recommends build-essential
-
-# Example of installing a new package, without unnecessary packages:
-apt-get -y install --no-install-recommends git
 
 # Delete cached files we don't need anymore:
 apt-get clean


### PR DESCRIPTION
Add a new script that installs packages required only in the
dependencies image and install build-essential by default, since
this is often required for building Python extensions, particularly
when upgrading to a new Python version.

Use a test matrix of Python 3.8 and 3.9 by default.  Stop pinning
the version in tox and use whatever the default Python version is.
Remove or update a few more references to Python 3.7.

Update pre-commit hook versions to the latest.

Use the `@v2` syntax for the GitHub Actions configuration, since all
the actions move the major version tag with each release.  This
avoids requiring updates for each minor release.