### PR TITLE
Stop installing build-essential in the base image

### DIFF
--- a/project_templates/roundtable_aiohttp_bot/example/scripts/install-base-packages.sh
+++ b/project_templates/roundtable_aiohttp_bot/example/scripts/install-base-packages.sh
@@ -26,10 +26,6 @@ apt-get update
 # Install security updates:
 apt-get -y upgrade
 
-# Install build-essential because sometimes Python dependencies need to build
-# C modules, particularly when upgrading to newer Python versions.
-apt-get -y install --no-install-recommends build-essential
-
 # Example of installing a new package, without unnecessary packages:
 apt-get -y install --no-install-recommends git
 

--- a/project_templates/roundtable_aiohttp_bot/example/scripts/install-dependency-packages.sh
+++ b/project_templates/roundtable_aiohttp_bot/example/scripts/install-dependency-packages.sh
@@ -25,8 +25,9 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get update
 
 # Install build-essential because sometimes Python dependencies need to build
-# C modules, particularly when upgrading to newer Python versions.
-apt-get -y install --no-install-recommends build-essential
+# C modules, particularly when upgrading to newer Python versions.  libffi-dev
+# is sometimes needed to build cffi (a cryptography dependency).
+apt-get -y install --no-install-recommends build-essential libffi-dev
 
 # Delete cached files we don't need anymore:
 apt-get clean

--- a/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/scripts/install-base-packages.sh
+++ b/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/scripts/install-base-packages.sh
@@ -26,10 +26,6 @@ apt-get update
 # Install security updates:
 apt-get -y upgrade
 
-# Install build-essential because sometimes Python dependencies need to build
-# C modules, particularly when upgrading to newer Python versions.
-apt-get -y install --no-install-recommends build-essential
-
 # Example of installing a new package, without unnecessary packages:
 apt-get -y install --no-install-recommends git
 

--- a/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/scripts/install-dependency-packages.sh
+++ b/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/scripts/install-dependency-packages.sh
@@ -25,8 +25,9 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get update
 
 # Install build-essential because sometimes Python dependencies need to build
-# C modules, particularly when upgrading to newer Python versions.
-apt-get -y install --no-install-recommends build-essential
+# C modules, particularly when upgrading to newer Python versions.  libffi-dev
+# is sometimes needed to build cffi (a cryptography dependency).
+apt-get -y install --no-install-recommends build-essential libffi-dev
 
 # Delete cached files we don't need anymore:
 apt-get clean


### PR DESCRIPTION
The whole point of adding a separate install-dependency-packages
script was to not install build-essential in the base layer but
only where Python extensions were built.  Then I accidentally left
this in the base script.  Clean it up.

Also install libffi-dev in the dependency image since it's often needed
by cffi.