### PR TITLE
[DM-28993] Add security configuration to aiohttp manifest

### DIFF
--- a/project_templates/latex_lsstdoc/EXAMPLE-0/bibentry.txt
+++ b/project_templates/latex_lsstdoc/EXAMPLE-0/bibentry.txt
@@ -4,6 +4,6 @@
    author = { First Author },
     title = {Document Title},
      year = 2021,
-    month = Feb,
+    month = Mar,
    handle = {EXAMPLE-0},
       url = {https://example-0-0.lsst.io } }

--- a/project_templates/latex_lsstdoc/EXAMPLE/bibentry.txt
+++ b/project_templates/latex_lsstdoc/EXAMPLE/bibentry.txt
@@ -4,6 +4,6 @@
    author = { First Author },
     title = {Document Title},
      year = 2021,
-    month = Feb,
+    month = Mar,
    handle = {EXAMPLE},
       url = {https://example-.lsst.io } }

--- a/project_templates/roundtable_aiohttp_bot/example/manifests/base/deployment.yaml
+++ b/project_templates/roundtable_aiohttp_bot/example/manifests/base/deployment.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         name: example
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: app
           imagePullPolicy: "Always"
@@ -25,3 +26,13 @@ spec:
           envFrom:
             - configMapRef:
                 name: example
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - all
+            readOnlyRootFilesystem: true
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000

--- a/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/manifests/base/deployment.yaml
+++ b/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/manifests/base/deployment.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         name: {{ cookiecutter.package_name }}
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: app
           imagePullPolicy: "Always"
@@ -25,3 +26,13 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ cookiecutter.package_name }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - all
+            readOnlyRootFilesystem: true
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000

--- a/project_templates/technote_latex/testn-000/bibentry.txt
+++ b/project_templates/technote_latex/testn-000/bibentry.txt
@@ -4,6 +4,6 @@
    author = { First Last },
     title = {Document Title},
      year = 2021,
-    month = Feb,
+    month = Mar,
    handle = {TESTN-000},
       url = {https://testn-000.lsst.io } }

--- a/project_templates/technote_rst/testn-000/bibentry.txt
+++ b/project_templates/technote_rst/testn-000/bibentry.txt
@@ -4,6 +4,6 @@
    author = { First Last },
     title = {Document Title},
      year = 2021,
-    month = Feb,
+    month = Mar,
    handle = {TESTN-000},
       url = {https://testn-000.lsst.io } }

--- a/project_templates/test_report/TESTTR-0/bibentry.txt
+++ b/project_templates/test_report/TESTTR-0/bibentry.txt
@@ -4,6 +4,6 @@
    author = { First Author },
     title = {Document Title},
      year = 2021,
-    month = Feb,
+    month = Mar,
    handle = {TESTTR-0},
       url = {https://testtr-0.lsst.io } }


### PR DESCRIPTION
Add security hardening to the template Kubernetes maniphest for
the Roundtable aiohttp bot.

This also picked up some month name changes to some templates.