### PR TITLE
[DM-29123] Update CI and Docker builds

### DIFF
--- a/project_templates/roundtable_aiohttp_bot/example/.dockerignore
+++ b/project_templates/roundtable_aiohttp_bot/example/.dockerignore
@@ -1,0 +1,140 @@
+# Some additional things to ignore beyond what .gitignore already handles.
+# We cannot exclude the .git directory because setuptools_scm requires it.
+tests/
+
+# Everything below this point is a copy of .gitignore.
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/

--- a/project_templates/roundtable_aiohttp_bot/example/.github/workflows/build.yaml
+++ b/project_templates/roundtable_aiohttp_bot/example/.github/workflows/build.yaml
@@ -1,0 +1,48 @@
+name: Docker
+
+"on":
+  push:
+    branches:
+      - "tickets/**"
+    tags:
+      - "*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Define the Docker tag
+        id: vars
+        run: echo ::set-output name=tag::$(echo ${GITHUB_REF} | sed -E 's,refs/(heads|tags)/,,' | sed -E 's,/,-,g')
+
+      - name: Print the tag
+        id: print
+        run: echo ${{steps.vars.outputs.tag}}
+
+      - name: Log into Docker Hub
+        run: echo ${{ secrets.DOCKER_TOKEN }} | docker login --username ${{ secrets.DOCKER_USERNAME }} --password-stdin
+
+      - name: Pull previous images
+        run: |
+          docker pull lsstsqre/example:deps-${{steps.vars.outputs.tag}} || true
+          docker pull lsstsqre/example:${{steps.vars.outputs.tag}} || true
+
+      - name: Build the dependencies Docker image
+        run: |
+          docker build --target dependencies-image \
+            --cache-from=lsstsqre/example:deps-${{steps.vars.outputs.tag}} \
+            --tag lsstsqre/example:deps-${{steps.vars.outputs.tag}} .
+
+      - name: Build the runtime Docker image
+        run: |
+          docker build --target runtime-image \
+            --cache-from=lsstsqre/example:${{steps.vars.outputs.tag}} \
+            --tag lsstsqre/example:${{steps.vars.outputs.tag}} .
+
+      - name: Push Docker images
+        run: |
+          docker push lsstsqre/example:deps-${{steps.vars.outputs.tag}}
+          docker push lsstsqre/example:${{steps.vars.outputs.tag}}

--- a/project_templates/roundtable_aiohttp_bot/example/.github/workflows/ci.yaml
+++ b/project_templates/roundtable_aiohttp_bot/example/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+"on": [push]
 
 jobs:
   test:
@@ -20,6 +20,9 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
 
+      - name: Run pre-commit
+        uses: pre-commit/action@v2.0.0
+
       - name: Install tox
         run: pip install tox
 
@@ -28,49 +31,63 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .tox
-          # requirements/*.txt, pyproject.toml, and .pre-commit-config.yaml
-          # have versioning info that would impact the tox environment.
-          key: tox-${{ hashFiles('requirements/*.txt') }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('.pre-commit-config.yaml') }}
+          # requirements/*.txt and pyproject.toml have versioning info
+          # that would impact the tox environment.
+          key: tox-${{ matrix.python }}-${{ hashFiles('requirements/*.txt') }}-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            tox-${{ matrix.python }}-${{ hashFiles('requirements/*.txt') }}-
 
       - name: Run tox
-        run: tox -e lint,py,coverage-report,typing  # run tox using Python in path
+        run: tox -e py,coverage-report,typing
 
   build:
     runs-on: ubuntu-latest
     needs: [test]
+
+    # Only do Docker builds of ticket branches and tagged releases.
+    if: startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/tickets/')
 
     steps:
       - uses: actions/checkout@v2
 
       - name: Define the Docker tag
         id: vars
-        run: echo ::set-output name=tag::$(echo ${GITHUB_REF} | sed -E 's,refs/(heads|tags)/,,' | sed -E 's,/,-,g')
+        run: echo ::set-output name=tag::$(scripts/docker-tag.sh "$GITHUB_REF")
 
       - name: Print the tag
         id: print
-        run: echo ${{steps.vars.outputs.tag}}
+        run: echo ${{ steps.vars.outputs.tag }}
 
-      - name: Log into Docker Hub
-        run: echo ${{ secrets.DOCKER_TOKEN }} | docker login --username ${{ secrets.DOCKER_USERNAME }} --password-stdin
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
 
-      - name: Pull previous images
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys:
+            ${{ runner.os }}-buildx-
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: lsstsqre/example:${{ steps.vars.outputs.tag }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+      # Temp fix
+      # https://github.com/docker/build-push-action/issues/252
+      # https://github.com/moby/buildkit/issues/1896
+      - name: Move cache
         run: |
-          docker pull lsstsqre/example:deps-${{steps.vars.outputs.tag}} || true
-          docker pull lsstsqre/example:${{steps.vars.outputs.tag}} || true
-
-      - name: Build the dependencies Docker image
-        run: |
-          docker build --target dependencies-image \
-            --cache-from=lsstsqre/example:deps-${{steps.vars.outputs.tag}} \
-            --tag lsstsqre/example:deps-${{steps.vars.outputs.tag}} .
-
-      - name: Build the runtime Docker image
-        run: |
-          docker build --target runtime-image \
-            --cache-from=lsstsqre/example:${{steps.vars.outputs.tag}} \
-            --tag lsstsqre/example:${{steps.vars.outputs.tag}} .
-
-      - name: Push Docker images
-        run: |
-          docker push lsstsqre/example:deps-${{steps.vars.outputs.tag}}
-          docker push lsstsqre/example:${{steps.vars.outputs.tag}}
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/project_templates/roundtable_aiohttp_bot/example/scripts/docker-tag.sh
+++ b/project_templates/roundtable_aiohttp_bot/example/scripts/docker-tag.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Determine the tag for Docker images.  Takes the Git ref as its only
+# argument.
+
+set -eo pipefail
+
+if [ -z "$1" ]; then
+    echo 'Usage: scripts/docker-tag.sh $GITHUB_REF' >&2
+    exit 1
+fi
+
+echo "$1" | sed -E 's,refs/(heads|tags)/,,' | sed -E 's,/,-,g'

--- a/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/.dockerignore
+++ b/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/.dockerignore
@@ -1,0 +1,140 @@
+# Some additional things to ignore beyond what .gitignore already handles.
+# We cannot exclude the .git directory because setuptools_scm requires it.
+tests/
+
+# Everything below this point is a copy of .gitignore.
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/

--- a/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/.github/workflows/ci.yaml
+++ b/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+"on": [push]
 
 jobs:
   test:
@@ -20,6 +20,9 @@ jobs:
         with:
           python-version: {{ "${{ matrix.python }}" }}
 
+      - name: Run pre-commit
+        uses: pre-commit/action@v2.0.0
+
       - name: Install tox
         run: pip install tox
 
@@ -28,49 +31,63 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .tox
-          # requirements/*.txt, pyproject.toml, and .pre-commit-config.yaml
-          # have versioning info that would impact the tox environment.
-          key: {{ "tox-${{ hashFiles('requirements/*.txt') }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('.pre-commit-config.yaml') }}" }}
+          # requirements/*.txt and pyproject.toml have versioning info
+          # that would impact the tox environment.
+          key: {{ "tox-${{ matrix.python }}-${{ hashFiles('requirements/*.txt') }}-${{ hashFiles('pyproject.toml') }}" }}
+          restore-keys: |
+            {{ "tox-${{ matrix.python }}-${{ hashFiles('requirements/*.txt') }}-" }}
 
       - name: Run tox
-        run: tox -e lint,py,coverage-report,typing  # run tox using Python in path
+        run: tox -e py,coverage-report,typing
 
   build:
     runs-on: ubuntu-latest
     needs: [test]
+
+    # Only do Docker builds of ticket branches and tagged releases.
+    if: startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/tickets/')
 
     steps:
       - uses: actions/checkout@v2
 
       - name: Define the Docker tag
         id: vars
-        run: echo ::set-output name=tag::$(echo ${GITHUB_REF} | sed -E 's,refs/(heads|tags)/,,' | sed -E 's,/,-,g')
+        run: echo ::set-output name=tag::$(scripts/docker-tag.sh "$GITHUB_REF")
 
       - name: Print the tag
         id: print
-        run: {{ "echo ${{steps.vars.outputs.tag}}" }}
+        run: echo {{ "${{ steps.vars.outputs.tag }}" }}
 
-      - name: Log into Docker Hub
-        run: {{ "echo ${{ secrets.DOCKER_TOKEN }} | docker login --username ${{ secrets.DOCKER_USERNAME }} --password-stdin" }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
 
-      - name: Pull previous images
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: {{ "${{ runner.os }}" }}-buildx-{{ "${{ github.sha }}" }}
+          restore-keys:
+            {{ "${{ runner.os }}" }}-buildx-
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: {{ "${{ secrets.DOCKER_USERNAME }}" }}
+          password: {{ "${{ secrets.DOCKER_TOKEN }}" }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: lsstsqre/{{ cookiecutter.package_name }}:{{ "${{ steps.vars.outputs.tag }}" }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+      # Temp fix
+      # https://github.com/docker/build-push-action/issues/252
+      # https://github.com/moby/buildkit/issues/1896
+      - name: Move cache
         run: |
-          docker pull lsstsqre/{{ cookiecutter.package_name }}:deps-{{ "${{steps.vars.outputs.tag}}" }} || true
-          docker pull lsstsqre/{{ cookiecutter.package_name }}:{{ "${{steps.vars.outputs.tag}}" }} || true
-
-      - name: Build the dependencies Docker image
-        run: |
-          docker build --target dependencies-image \
-            --cache-from=lsstsqre/{{ cookiecutter.package_name }}:deps-{{ "${{steps.vars.outputs.tag}}" }} \
-            --tag lsstsqre/{{ cookiecutter.package_name }}:deps-{{ "${{steps.vars.outputs.tag}}" }} .
-
-      - name: Build the runtime Docker image
-        run: |
-          docker build --target runtime-image \
-            --cache-from=lsstsqre/{{ cookiecutter.package_name }}:{{ "${{steps.vars.outputs.tag}}" }} \
-            --tag lsstsqre/{{ cookiecutter.package_name }}:{{ "${{steps.vars.outputs.tag}}" }} .
-
-      - name: Push Docker images
-        run: |
-          docker push lsstsqre/{{ cookiecutter.package_name }}:deps-{{ "${{steps.vars.outputs.tag}}" }}
-          docker push lsstsqre/{{ cookiecutter.package_name }}:{{ "${{steps.vars.outputs.tag}}" }}
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/scripts/docker-tag.sh
+++ b/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/scripts/docker-tag.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Determine the tag for Docker images.  Takes the Git ref as its only
+# argument.
+
+set -eo pipefail
+
+if [ -z "$1" ]; then
+    echo 'Usage: scripts/docker-tag.sh $GITHUB_REF' >&2
+    exit 1
+fi
+
+echo "$1" | sed -E 's,refs/(heads|tags)/,,' | sed -E 's,/,-,g'


### PR DESCRIPTION
Use the official pre-commit action instead of running pre-commit
with tox, since it automatically handles caching.  Add the Python
version to the tox cache key and remove .pre-commit-config.yaml.

Change the Docker build to only trigger on ticket branches and
tags to cut down on the number of spurious images we push.  Use the
official Docker actions and cache layers in GitHub rather than on
Docker Hub.

Use an external script to determine the tag of the Docker image.