### PR TITLE
DM-29442: Use camelCase consistently for \vcs* macros.

### DIFF
--- a/project_templates/test_report/TESTTR-0/TESTTR-0.tex
+++ b/project_templates/test_report/TESTTR-0/TESTTR-0.tex
@@ -19,7 +19,7 @@
 
 \title{LVV-P73 Document Title Test Plan and Report}
 \setDocRef{\lsstDocType-\lsstDocNum}
-\date{\vcsdate}
+\date{\vcsDate}
 \author{First Author}
 
 \input{history_and_info.tex}

--- a/project_templates/test_report/TESTTR-0/history_and_info.tex
+++ b/project_templates/test_report/TESTTR-0/history_and_info.tex
@@ -5,4 +5,4 @@
 
 \setDocCurator{First Author}
 \setDocUpstreamLocation{\url{https://github.com/lsst-dm/\lsstDocType-\lsstDocNum}}
-\setDocUpstreamVersion{\vcsrevision}
+\setDocUpstreamVersion{\vcsRevision}

--- a/project_templates/test_report/{{cookiecutter.series.upper()}}-{{cookiecutter.serial_number}}/history_and_info.tex
+++ b/project_templates/test_report/{{cookiecutter.series.upper()}}-{{cookiecutter.serial_number}}/history_and_info.tex
@@ -5,4 +5,4 @@
 
 \setDocCurator{ {{- cookiecutter.author -}} }
 \setDocUpstreamLocation{\url{https://github.com/lsst-dm/\lsstDocType-\lsstDocNum}}
-\setDocUpstreamVersion{\vcsrevision}
+\setDocUpstreamVersion{\vcsRevision}

--- a/project_templates/test_report/{{cookiecutter.series.upper()}}-{{cookiecutter.serial_number}}/{{cookiecutter.series.upper()}}-{{cookiecutter.serial_number}}.tex
+++ b/project_templates/test_report/{{cookiecutter.series.upper()}}-{{cookiecutter.serial_number}}/{{cookiecutter.series.upper()}}-{{cookiecutter.serial_number}}.tex
@@ -19,7 +19,7 @@
 
 \title{ {{- cookiecutter.plan }} {{ cookiecutter.title }} Test Plan and Report}
 \setDocRef{\lsstDocType-\lsstDocNum}
-\date{\vcsdate}
+\date{\vcsDate}
 \author{ {{- cookiecutter.author -}} }
 
 \input{history_and_info.tex}


### PR DESCRIPTION
Per agreement with Wil about a coordinated change in `docsteady`, use camelCase consistently
across all document categories for the `\vcsDate` and `\vcsRevision` macros.

Matches changes made in #102 to the generation of the `meta.tex` file.