### PR TITLE
DM-29889: Update conf.py to documenteer.conf.pipelinespkg in stack_package template

### DIFF
--- a/project_templates/stack_package/CHANGELOG.md
+++ b/project_templates/stack_package/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log
 
+## 2021-04-28
+
+- Switch package Sphinx configuration from `documenteer.sphinxconfig.stackconf` to `documenteer.conf.pipelinespkg` (available in Documenteer 0.6).
+
+[DM-29889](https://jira.lsstcorp.org/browse/DM-29889)
+
 ## 2020-01-24
 
 - Update the Flake8 exceptions list in `setup.cfg` to replace `W504` with `W503`.

--- a/project_templates/stack_package/CHANGELOG.md
+++ b/project_templates/stack_package/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 2021-04-28
 
 - Switch package Sphinx configuration from `documenteer.sphinxconfig.stackconf` to `documenteer.conf.pipelinespkg` (available in Documenteer 0.6).
+- Make the flake8 exclusion of doc/setup.cfg more precise (there were reports that flake8 was not respecting the doc/ exclusion otherwise.
+  This change also has the benefit of ensuring that sample modules included in the documentation are checked with flake8.
 
 [DM-29889](https://jira.lsstcorp.org/browse/DM-29889)
 

--- a/project_templates/stack_package/example/doc/conf.py
+++ b/project_templates/stack_package/example/doc/conf.py
@@ -1,13 +1,14 @@
 """Sphinx configuration file for an LSST stack package.
 
 This configuration only affects single-package Sphinx documentation builds.
+For more information, see:
+https://developer.lsst.io/stack/building-single-package-docs.html
 """
 
-from documenteer.sphinxconfig.stackconf import build_package_configs
-import lsst.example
+from documenteer.conf.pipelinespkg import *
 
 
-_g = globals()
-_g.update(build_package_configs(
-    project_name='example',
-    version=lsst.example.version.__version__))
+project = "example"
+html_theme_options["logotext"] = project
+html_title = project
+html_short_title = project

--- a/project_templates/stack_package/example/setup.cfg
+++ b/project_templates/stack_package/example/setup.cfg
@@ -4,7 +4,7 @@ max-doc-length = 79
 ignore = E133, E226, E228, N802, N803, N806, N812, N813, N815, N816, W503
 exclude =
   bin,
-  doc,
+  doc/conf.py,
   **/*/__init__.py,
   **/*/version.py,
   tests/.tests

--- a/project_templates/stack_package/example_dataonly/doc/conf.py
+++ b/project_templates/stack_package/example_dataonly/doc/conf.py
@@ -1,10 +1,14 @@
 """Sphinx configuration file for an LSST stack package.
 
 This configuration only affects single-package Sphinx documentation builds.
+For more information, see:
+https://developer.lsst.io/stack/building-single-package-docs.html
 """
 
-from documenteer.sphinxconfig.stackconf import build_package_configs
+from documenteer.conf.pipelinespkg import *
 
 
-_g = globals()
-_g.update(build_package_configs(project_name='example_dataonly'))
+project = "example_dataonly"
+html_theme_options["logotext"] = project
+html_title = project
+html_short_title = project

--- a/project_templates/stack_package/example_dds/doc/conf.py
+++ b/project_templates/stack_package/example_dds/doc/conf.py
@@ -1,13 +1,14 @@
 """Sphinx configuration file for an LSST stack package.
 
 This configuration only affects single-package Sphinx documentation builds.
+For more information, see:
+https://developer.lsst.io/stack/building-single-package-docs.html
 """
 
-from documenteer.sphinxconfig.stackconf import build_package_configs
-import lsst.example.dds
+from documenteer.conf.pipelinespkg import *
 
 
-_g = globals()
-_g.update(build_package_configs(
-    project_name='example_dds',
-    version=lsst.example.dds.version.__version__))
+project = "example_dds"
+html_theme_options["logotext"] = project
+html_title = project
+html_short_title = project

--- a/project_templates/stack_package/example_dds/setup.cfg
+++ b/project_templates/stack_package/example_dds/setup.cfg
@@ -4,7 +4,7 @@ max-doc-length = 79
 ignore = E133, E226, E228, N802, N803, N806, N812, N813, N815, N816, W503
 exclude =
   bin,
-  doc,
+  doc/conf.py,
   **/*/__init__.py,
   **/*/version.py,
   tests/.tests

--- a/project_templates/stack_package/example_pythononly/doc/conf.py
+++ b/project_templates/stack_package/example_pythononly/doc/conf.py
@@ -1,13 +1,14 @@
 """Sphinx configuration file for an LSST stack package.
 
 This configuration only affects single-package Sphinx documentation builds.
+For more information, see:
+https://developer.lsst.io/stack/building-single-package-docs.html
 """
 
-from documenteer.sphinxconfig.stackconf import build_package_configs
-import lsst.example.pythononly
+from documenteer.conf.pipelinespkg import *
 
 
-_g = globals()
-_g.update(build_package_configs(
-    project_name='example_pythononly',
-    version=lsst.example.pythononly.version.__version__))
+project = "example_pythononly"
+html_theme_options["logotext"] = project
+html_title = project
+html_short_title = project

--- a/project_templates/stack_package/example_pythononly/setup.cfg
+++ b/project_templates/stack_package/example_pythononly/setup.cfg
@@ -4,7 +4,7 @@ max-doc-length = 79
 ignore = E133, E226, E228, N802, N803, N806, N812, N813, N815, N816, W503
 exclude =
   bin,
-  doc,
+  doc/conf.py,
   **/*/__init__.py,
   **/*/version.py,
   tests/.tests

--- a/project_templates/stack_package/example_standalone/doc/conf.py
+++ b/project_templates/stack_package/example_standalone/doc/conf.py
@@ -1,13 +1,14 @@
 """Sphinx configuration file for an LSST stack package.
 
 This configuration only affects single-package Sphinx documentation builds.
+For more information, see:
+https://developer.lsst.io/stack/building-single-package-docs.html
 """
 
-from documenteer.sphinxconfig.stackconf import build_package_configs
-import lsst.example.standalone
+from documenteer.conf.pipelinespkg import *
 
 
-_g = globals()
-_g.update(build_package_configs(
-    project_name='example_standalone',
-    version=lsst.example.standalone.version.__version__))
+project = "example_standalone"
+html_theme_options["logotext"] = project
+html_title = project
+html_short_title = project

--- a/project_templates/stack_package/example_standalone/setup.cfg
+++ b/project_templates/stack_package/example_standalone/setup.cfg
@@ -4,7 +4,7 @@ max-doc-length = 79
 ignore = E133, E226, E228, N802, N803, N806, N812, N813, N815, N816, W503
 exclude =
   bin,
-  doc,
+  doc/conf.py,
   **/*/__init__.py,
   **/*/version.py,
   tests/.tests

--- a/project_templates/stack_package/example_subpackage/doc/conf.py
+++ b/project_templates/stack_package/example_subpackage/doc/conf.py
@@ -1,13 +1,14 @@
 """Sphinx configuration file for an LSST stack package.
 
 This configuration only affects single-package Sphinx documentation builds.
+For more information, see:
+https://developer.lsst.io/stack/building-single-package-docs.html
 """
 
-from documenteer.sphinxconfig.stackconf import build_package_configs
-import lsst.example.subpackage
+from documenteer.conf.pipelinespkg import *
 
 
-_g = globals()
-_g.update(build_package_configs(
-    project_name='example_subpackage',
-    version=lsst.example.subpackage.version.__version__))
+project = "example_subpackage"
+html_theme_options["logotext"] = project
+html_title = project
+html_short_title = project

--- a/project_templates/stack_package/example_subpackage/setup.cfg
+++ b/project_templates/stack_package/example_subpackage/setup.cfg
@@ -4,7 +4,7 @@ max-doc-length = 79
 ignore = E133, E226, E228, N802, N803, N806, N812, N813, N815, N816, W503
 exclude =
   bin,
-  doc,
+  doc/conf.py,
   **/*/__init__.py,
   **/*/version.py,
   tests/.tests

--- a/project_templates/stack_package/{{cookiecutter.package_name}}/doc/conf.py
+++ b/project_templates/stack_package/{{cookiecutter.package_name}}/doc/conf.py
@@ -1,20 +1,14 @@
 """Sphinx configuration file for an LSST stack package.
 
 This configuration only affects single-package Sphinx documentation builds.
+For more information, see:
+https://developer.lsst.io/stack/building-single-package-docs.html
 """
 
-from documenteer.sphinxconfig.stackconf import build_package_configs
-{%- if cookiecutter.uses_python == 'True' %}
-import {{ cookiecutter.python_module }}
+from documenteer.conf.pipelinespkg import *
 
 
-_g = globals()
-_g.update(build_package_configs(
-    project_name='{{ cookiecutter.package_name }}',
-    version={{ cookiecutter.python_module }}.version.__version__))
-{% else %}
-
-
-_g = globals()
-_g.update(build_package_configs(project_name='{{ cookiecutter.package_name }}'))
-{% endif -%}
+project = "{{ cookiecutter.package_name }}"
+html_theme_options["logotext"] = project
+html_title = project
+html_short_title = project

--- a/project_templates/stack_package/{{cookiecutter.package_name}}/setup.cfg
+++ b/project_templates/stack_package/{{cookiecutter.package_name}}/setup.cfg
@@ -4,7 +4,7 @@ max-doc-length = 79
 ignore = E133, E226, E228, N802, N803, N806, N812, N813, N815, N816, W503
 exclude =
   bin,
-  doc,
+  doc/conf.py,
   **/*/__init__.py,
   **/*/version.py,
   tests/.tests


### PR DESCRIPTION
This new configuration API is available in documenteer 0.6 and solves problems around recursion errors in the Sphinx build.