### PR TITLE
Tiny patch to extend stack package copyright holder list to include Fermilab and BNL, following #105

### DIFF
--- a/file_templates/copyright/cookiecutter.json
+++ b/file_templates/copyright/cookiecutter.json
@@ -2,7 +2,9 @@
   "copyright_year": "{% now 'utc', '%Y' %}",
   "copyright_holder": [
     "Association of Universities for Research in Astronomy, Inc. (AURA)",
+    "Brookhaven Science Associates, LLC",
     "California Institute of Technology",
+    "Fermi Research Alliance, LLC",
     "The Board of Trustees of the Leland Stanford Junior University, through SLAC National Accelerator Laboratory",
     "The Trustees of Princeton University",
     "University of Illinois Board of Trustees",

--- a/project_templates/stack_package/cookiecutter.json
+++ b/project_templates/stack_package/cookiecutter.json
@@ -7,7 +7,9 @@
   "copyright_year": "{% now 'utc', '%Y' %}",
   "copyright_holder": [
     "Association of Universities for Research in Astronomy, Inc. (AURA)",
+    "Brookhaven Science Associates, LLC",
     "California Institute of Technology",
+    "Fermi Research Alliance, LLC",
     "The Board of Trustees of the Leland Stanford Junior University, through SLAC National Accelerator Laboratory",
     "The Trustees of Princeton University",
     "University of Illinois Board of Trustees",


### PR DESCRIPTION
@womullan I think we should have done this in #105 already, it should be trivial to review. There's some work to do at the labs to enable lab staff to assert copyright in open source projects but that can be pursued in parallel to making it easy for staff to make a COPYRIGHT file, I think.