### PR TITLE
Add .gitattributes to rst technote template to suppress vendored bib files from GitHub stats/reviews

### DIFF
--- a/project_templates/technote_rst/CHANGELOG.md
+++ b/project_templates/technote_rst/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 2021-05-13
+
+- The `.gitattributes` file now helps suppress the vendored bibtex files from [GitHub pull requests and linguist stats](https://docs.github.com/en/github/administering-a-repository/customizing-how-changed-files-appear-on-github).
+
 ## 2020-12-10
 
 - The RTN technote series is now hosted in the "lsst" GitHub organization.

--- a/project_templates/technote_rst/testn-000/.gitattributes
+++ b/project_templates/technote_rst/testn-000/.gitattributes
@@ -1,0 +1,1 @@
+lsstbib/*  linguist-generated=true

--- a/project_templates/technote_rst/testn-000/lsstbib/books.bib
+++ b/project_templates/technote_rst/testn-000/lsstbib/books.bib
@@ -285,3 +285,77 @@
   publisher = {Manning Publications Co.},
   address = {Greenwich, CT, USA},
 }
+
+@BOOK{NAP9839,
+  author    = "{National Research Council}",
+  title     = "Astronomy and Astrophysics in the New Millennium",
+  isbn      = "978-0-309-07031-7",
+  doi       = "10.17226/9839",
+  abstract  = "In this new book, a distinguished panel makes recommendations for the nation's programs in astronomy and astrophysics, including a number of new initiatives for observing the universe.  With the goal of optimum value, the recommendations address the role of federal research agencies, allocation of funding, training for scientists, competition and collaboration among space facilities, and much more.\n\n\nThe book identifies the most pressing science questions and explains how specific efforts, from the Next Generation Space Telescope to theoretical studies, will help reveal the answers.  Discussions of how emerging information technologies can help scientists make sense of the wealth of data available are also included.\n\n\nAstronomy has significant impact on science in general as well as on public imagination. The committee discusses how to integrate astronomical discoveries into our education system and our national life.\n\n\nIn preparing the New Millennium report, the AASC made use of a series of panel reports that address various aspects of ground- and space-based astronomy and astrophysics.  These reports provide in-depth technical detail.\nAstronomy and Astrophysics in the New Millenium: An Overview summarizes the science goals and recommended initiatives in a short, richly illustrated, non-technical booklet.\n",
+  url       = "https://www.nap.edu/catalog/9839/astronomy-and-astrophysics-in-the-new-millennium",
+  year      = 2001,
+  publisher = "The National Academies Press",
+  address   = "Washington, DC"
+}
+
+@BOOK{NAP10079,
+  author    = "{National Research Council}",
+  title     = "Connecting Quarks with the Cosmos: Eleven Science Questions for the New Century",
+  isbn      = "978-0-309-07406-3",
+  doi       = "10.17226/10079",
+  abstract  = "Advances made by physicists in understanding matter, space, and time and by astronomers in understanding the universe as a whole have closely intertwined the question being asked about the universe at its two extremes\u2014the very large and the very small. This report identifies 11 key questions that have a good chance to be answered in the next decade.  It urges that a new research strategy be created that brings to bear the techniques of both astronomy and sub-atomic physics in a cross-disciplinary way to address these questions. The report presents seven recommendations to facilitate the necessary research and development coordination. These recommendations identify key priorities for future scientific projects critical for realizing these scientific opportunities.\n",
+  url       = "https://www.nap.edu/catalog/10079/connecting-quarks-with-the-cosmos-eleven-science-questions-for-the",
+  year      = 2003,
+  publisher = "The National Academies Press",
+  address   = "Washington, DC"
+}
+
+@BOOK{NAP12982,
+  author    = "{National Research Council}",
+  title     = "Panel Reports—New Worlds, New Horizons in Astronomy and Astrophysics",
+  isbn      = "978-0-309-15962-3",
+  doi       = "10.17226/12982",
+  abstract  = "Every 10 years the National Research Council releases a survey of astronomy and astrophysics outlining priorities for the coming decade. The most recent survey, titled New Worlds, New Horizons in Astronomy and Astrophysics, provides overall priorities and recommendations for the field as a whole based on a broad and comprehensive examination of scientific opportunities, infrastructure, and organization in a national and international context. \n\nPanel Reports--New Worlds, New Horizons in Astronomy and Astrophysics is a collection of reports, each of which addresses a key sub-area of the field, prepared by specialists in that subarea, and each of which played an important role in setting overall priorities for the field. The collection, published in a single volume, includes the reports of the following panels:\n\n    Cosmology and Fundamental Physics\n    Galaxies Across Cosmic Time\n    The Galactic Neighborhood\n    Stars and Stellar Evolution\n    Planetary Systems and Star Formation\n    Electromagnetic Observations from Space\n    Optical and Infrared Astronomy from the Ground\n    Particle Astrophysics and Gravitation\n    Radio, Millimeter, and Submillimeter Astronomy from the Ground\n\n\nThe Committee for a Decadal Survey of Astronomy and Astrophysics synthesized these reports in the preparation of its prioritized recommendations for the field as a whole. These reports provide additional depth and detail in each of their respective areas. Taken together, they form an essential companion volume to New Worlds, New Horizons: A Decadal Survey of Astronomy and Astrophysics. The book of panel reports will be useful to managers of programs of research in the field of astronomy and astrophysics, the Congressional committees with jurisdiction over the agencies supporting this research, the scientific community, and the public.",
+  url       = "https://www.nap.edu/catalog/12982/panel-reports-new-worlds-new-horizons-in-astronomy-and-astrophysics",
+  year      = 2011,
+  publisher = "The National Academies Press",
+  address   = "Washington, DC"
+}
+
+@BOOK{NAP10432,
+  author    = "{National Research Council}",
+  title     = "New Frontiers in the Solar System: An Integrated Exploration Strategy",
+  doi       = "10.17226/10432",
+  abstract  = "Solar system exploration is that grand human endeavor which reaches out through interplanetary space to discover the nature and origins of the system of planets in which we live and to learn whether life exists beyond Earth.  It is an international enterprise involving scientists, engineers, managers, politicians, and others, sometimes working together and sometimes in competition, to open new frontiers of knowledge.  It has a proud past, a productive present, and an auspicious future. This survey was requested by the National Aeronautics and Space Administration (NASA) to determine the contemporary nature of solar system exploration and why it remains a compelling activity today.  A broad survey of the state of knowledge was requested.  In addition NASA asked for the identifcation of the top-level scientific questions to guide its ongoing program and a prioritized list of the most promising avenues for flight investigations and supporting ground-based activities.  \n",
+  url       = "https://www.nap.edu/catalog/10432/new-frontiers-in-the-solar-system-an-integrated-exploration-strategy",
+  year      = 2003,
+  publisher = "The National Academies Press",
+  address   = "Washington, DC"
+}
+
+@Book{Few:2013,
+  author    = "Stephen~Few",
+  title     = "{Information Dashboard Design}",
+  publisher = {Analytics Press},
+  year      = 2013,
+  edition   = 2
+}
+
+@book{Beyer:2016:SRE:3006357,
+ author = {Beyer, Betsy and Jones, Chris and Petoff, Jennifer and Murphy, Niall Richard},
+ title = {Site Reliability Engineering: How Google Runs Production Systems},
+ year = {2016},
+ isbn = {149192912X, 9781491929124},
+ edition = {1st},
+ publisher = {O'Reilly Media, Inc.},
+}
+
+@Book{1982mmme.book.....B,
+   author = {{Brooks}, F.~P.},
+    title = "{The Mythical Man-Month: Essays on Software Engineering}",
+booktitle = {Reading: Addison-Wesley, 1982},
+     year = 1982,
+   adsurl = {https://ui.adsabs.harvard.edu/abs/1982mmme.book.....B},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+

--- a/project_templates/technote_rst/testn-000/lsstbib/lsst-dm.bib
+++ b/project_templates/technote_rst/testn-000/lsstbib/lsst-dm.bib
@@ -2536,8 +2536,60 @@ booktitle = {Ground-based and Airborne Telescopes VI},
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+@INBOOK{2019ASPC..523..521B,
+       author = {{Bosch}, James and {AlSayyad}, Yusra and {Armstrong}, Robert and
+         {Bellm}, Eric and {Chiang}, Hsin-Fang and {Eggl}, Siegfried and
+         {Findeisen}, Krzysztof and {Fisher-Levine}, Merlin and
+         {Guy}, Leanne P. and {Guyonnet}, Augustin and
+         {Ivezi{\'c}}, {\v{Z}}eljko and {Jenness}, Tim and
+         {Kov{\'a}cs}, G{\'a}bor and {Krughoff}, K. Simon and
+         {Lupton}, Robert H. and {Lust}, Nate B. and {MacArthur}, Lauren A. and
+         {Meyers}, Joshua and {Moolekamp}, Fred and {Morrison}, Christopher B. and
+         {Morton}, Timothy D. and {O'Mullane}, William and {Parejko}, John K. and
+         {Plazas}, Andr{\'e}s A. and {Price}, Paul A. and {Rawls}, Meredith L. and
+         {Reed}, Sophie L. and {Schellart}, Pim and {Slater}, Colin T. and
+         {Sullivan}, Ian and {Swinbank}, John D. and {Taranu}, Dan and
+         {Waters}, Christopher Z. and {Wood-Vasey}, W.~M.},
+        title = "{An Overview of the LSST Image Processing Pipelines}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+    booktitle = {Astronomical Data Analysis Software and Systems XXVII},
+         year = "2019",
+       editor = {{Teuben}, Peter J. and {Pound}, Marc W. and {Thomas}, Brian A. and
+         {Warner}, Elizabeth M.},
+       volume = {523},
+       series = {Astronomical Society of the Pacific Conference Series},
+        pages = {521},
+     abstract = "{The Large Synoptic Survey Telescope (LSST) is an ambitious astronomical
+        survey with a similarly ambitious Data Management component.
+        Data Management for LSST includes processing on both nightly and
+        yearly cadences to generate transient alerts, deep catalogs of
+        the static sky, and forced photometry light-curves for billions
+        of objects at hundreds of epochs, spanning at least a decade.
+        The algorithms running in these pipelines are individually
+        sophisticated and interact in subtle ways. This paper provides
+        an overview of those pipelines, focusing more on those
+        interactions than the details of any individual algorithm. <P />}",
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2019ASPC..523..521B},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
 @Misc{DevGuide,
   author =       {{LSST Data Management}},
 	title =        "{LSST DM Developer Guide}",
 	url =          {https://developer.lsst.io/}
+}
+
+@inproceedings{10.1117/12.2561604,
+author = {Gabriele Comoretto and Leanne P. Guy and William O'Mullane and Keith Bechtol and Jeffrey L. Carlin and Jonathan Sick and Brian Van Klaveren and Austin Roberts},
+title = {{Documentation automation for the verification and validation of Rubin Observatory software}},
+volume = {11450},
+booktitle = {Modeling, Systems Engineering, and Project Management for Astronomy IX},
+editor = {George Z. Angeli and Philippe Dierickx},
+organization = {International Society for Optics and Photonics},
+publisher = {SPIE},
+pages = {68 -- 78},
+keywords = {verification and validation, documentation automation, test documentation, test management, LSST, LSST Data Management},
+year = {2020},
+doi = {10.1117/12.2561604},
+URL = {https://doi.org/10.1117/12.2561604}
 }

--- a/project_templates/technote_rst/testn-000/lsstbib/lsst.bib
+++ b/project_templates/technote_rst/testn-000/lsstbib/lsst.bib
@@ -1,3 +1,18 @@
+@DocuShare{RDO-013,
+  author = {Robert Blum and the Rubin Operations Team},
+  title = "{Vera C. Rubin Observatory
+Data Policy}",
+  year = {2020},
+  month =        sep,
+  handle = {RDO-013}
+}
+@DocuShare{Agreement-51,
+  author = {LSST},
+  title = "{Memorandum of Agreement regarding collaboration in the scientific exploitation of data acquired with LSST by specified Principal Investigators and scientists at IN2P3}",
+  year = {2015},
+  month =        mar,
+  handle = {Agreement-51}
+}
 
 @DocuShare{Document-1386,
   author =       {Jacek Becla},
@@ -6,6 +21,8 @@
   month =        mar,
   handle =       {Document-1386},
 }
+
+
 
 @DocuShare{Document-5356,
   author =       {Tim Axelrod and Robyn Allsman and Jeff Kantor and Jon Myers and
@@ -64,7 +81,7 @@
 
 @DocuShare{Document-9224,
   author =       {George Angeli and Robert McKercher},
-  title =        {Change Controlled Document Cover Page and Style Guide},
+  title =        "{Change Controlled Document Cover Page and Style Guide}",
   year =         2013,
   month =        oct,
   handle =       {Document-9224},
@@ -74,23 +91,69 @@
   author =       {Ray Plante and Robyn Allsman and Tim Axelrood and Jacek Becla
                   and Cristina Beldica and Greg Daues and Jeff Kantor and Jonathan Myers
                   and Russell Owen and Steve Pietrowicz},
-  title =        {Results from Data Challenge 1},
+  title =        "{Results from Data Challenge 1}",
   year =         2010,
   month =        jul,
   handle =       {Document-9541},
 }
 
+
+@DocuShare{Document-10548,
+  author = {William S. Smith and Steven M.  Kahn and Donald W Sweeney and J. Anthony Tyson and Sidney C Wolff  },
+   title = "{Fastlane Proposal for Construction of the Large Synoptic Survey Telescope}",
+    year = 2011,
+   month = feb,
+  handle = {Document-10548},
+}
+
+@DocuShare{Document-10549,
+  author =       {Sidney C. Wolff and Steven M. Kahn and Victor L. Krabbendam
+                  and Donald W. Sweeney and J. Anthony Tyson},
+  title =        "{Proposal to the National Science Foundation}",
+  year =         2011,
+  month =        feb,
+  handle =       {Document-10549},
+}
+
 @DocuShare{Document-10762,
   author =       {Richard Shaw and Michael Strauss},
-  title =        {LSST Data Challenge Handbook Version 1.1},
+  title =        "{LSST Data Challenge Handbook Version 1.1}",
   year =         2011,
   month =        aug,
   handle =       {Document-10762},
 }
 
+@DocuShare{Document-10963,
+  author =       {Zhaoming Ma and others},
+  title =        {{Science White Paper for LSST Deep-Drilling Field Observations: Using LSST Deep Drilling Fields to Improve Weak Lensing Measurements}},
+  year =         2011,
+  handle = {Document-10963},
+}
+
+@DocuShare{Document-11013,
+  author =       {Becker, A. and others},
+  title =        {{Science White Paper for LSST Deep-Drilling Field Observations Opportunities for Solar System Science}},
+  year =         2011,
+  handle = {Document-11013},
+}
+
+@DocuShare{Document-11019,
+  author =       {Arlin Crotts},
+  title =        {{Standard Candle Relations and Photo-diversity of Type Ia Supernovae}},
+  year =         2011,
+  handle = {Document-11019},
+}
+
+@DocuShare{Document-11622,
+  author =       {William Smith and Victor Perez Vera},
+  title =        {Supplementary and Clarifying Agreement between the Universidad de Chile and AURA covering the use of the LSST on Cerro Pachon},
+  year =         2011,
+  handle =       {Document-11622},
+}
+
 @DocuShare{Document-11624,
   author =       {{LSST Science Council}},
-  title =        {Optimization of LSST Deployment Parameters},
+  title =        "{Optimization of LSST Deployment Parameters}",
   year =         2011,
   month =        jul,
   handle =       {Document-11624},
@@ -106,7 +169,7 @@
 
 @DocuShare{Document-11701,
   author =       {Jacek Becla and Kian-Tat Lim and Daniel Wang},
-  title =        {Evaluation of Solid State Disks},
+  title =        "{Evaluation of Solid State Disks}",
   year =         2011,
   month =        jul,
   handle =       {Document-11701},
@@ -114,10 +177,18 @@
 
 @DocuShare{Document-11920,
   author =       {George Angeli and Robert McKercher},
-  title =        {Document Cover Page and Style Guide},
+  title =        "{Document Cover Page and Style Guide}",
   year =         2013,
   month =        oct,
   handle =       {Document-11920},
+}
+
+@DocuShare{Document-13380,
+  author =       {Sidney Wolff and Steven Kahn},
+  title =        "{Data Rights and Data Management Policy}",
+  year =         2013,
+  month =        aug,
+  handle =       {Document-13380},
 }
 
 @DocuShare{Document-13760,
@@ -138,7 +209,7 @@
 
 @DocuShare{Document-15077,
   author =        {Sidney Wolff},
-  title =         {LSST Project Overview},
+  title =         "{LSST Project Overview}",
   year =          2013,
   month=          sep,
   handle =        {Document-15077},
@@ -155,7 +226,7 @@
 @DocuShare{Document-15125,
   author =       {Peter Yoachim and Lynne Jones and {\v
                   Z}. {Ivezi{\'c}} and Tim Axelrod},
-  title =        {Photometric Self Calibration Design and Prototype},
+  title =        "{Photometric Self Calibration Design and Prototype}",
   year =         2013,
   month =        oct,
   handle =       {Document-15125},
@@ -163,7 +234,7 @@
 
 @DocuShare{Document-15286,
   author =       {Richard A. Shaw},
-  title =        {LSST Data Challenge Handbook: Summer 2012 Data Release},
+  title =        "{LSST Data Challenge Handbook: Summer 2012 Data Release}",
   year =         2012,
   month =        aug,
   handle =       {Document-15286},
@@ -171,7 +242,7 @@
 
 @DocuShare{Document-15298,
   author =       {J. Bosch and P. Gee and R. Owen and M. Juri\'c},
-  title =        {LSST DM S13 Report: Shapre Measurement Plans and Prototypes},
+  title =        "{LSST DM S13 Report: Shapre Measurement Plans and Prototypes}",
   year =         2013,
   month =        oct,
   handle =       {Document-15298},
@@ -179,7 +250,7 @@
 
 @DocuShare{Document-15299,
   author =       {Richard A. Shaw},
-  title =        {LSST Data Challenge Handbook: Winter 2013 Early Data Release},
+  title =        "{LSST Data Challenge Handbook: Winter 2013 Early Data Release}",
   year =         2013,
   month =        jan,
   handle =       {Document-15299},
@@ -187,7 +258,7 @@
 
 @DocuShare{Document-16168,
   author =       {{LSST Systems Engineering}},
-  title =        {{LSST Key System Parameters Summary}},
+  title =        "{{LSST Key System Parameters Summary}}",
   year =         2014,
   month =        jan,
   handle =       {Document-16168},
@@ -195,7 +266,7 @@
 
 @DocuShare{Document-26217,
   author =       {Jeff Kantor},
-  title =        {Data Challenge 3b Performance Test 1.1},
+  title =        "{Data Challenge 3b Performance Test 1.1}",
   year =         2010,
   month =        aug,
   handle =       {Document-26217},
@@ -203,23 +274,95 @@
 
 @DocuShare{Document-26273,
   author =       {Brian Selvy},
-  title =        {Risk \& Opportunity Management Report May 2017},
+  title =        "{Risk \& Opportunity Management Report May 2017}",
   year =         2017,
   month =        jul,
   handle =       {Document-26273},
 }
 
+@DocuShare{Document-26952,
+  author =       {{Science Working Group of the LSST} and Michael A. Strauss},
+  title =        "{Towards a Design Reference Mission for the Large Synoptic Survey Telescope}",
+  year =         2004,
+  month =        jun,
+  handle =       {Document-26952},
+}
+
 @DocuShare{Document-26276,
   author =       {Jacek Becla and K-T Lim and Daniel Wang},
-  title =        {Scalable Partitioning},
+  title =        "{Scalable Partitioning}",
   year =         2013,
   month =        feb,
   handle =       {Document-26276},
 }
 
+@DocuShare{Document-27758,
+  author =       {{\v Z}. {Ivezi{\'c}} and {LSST Project Science Team}},
+  title =        "{On the choice of LSST flux units}",
+  year =         2018,
+  month =        feb,
+  handle =       {Document-27758},
+}
+
+@DocuShare{Document-28449,
+  author =       {F. Delgado},
+  title =        "{Project Response to Telescope \& Site Software Review Report 2018-02}",
+  year =         2018,
+  month =        may,
+  handle =       {Document-28449},
+}
+
+@DocuShare{Document-28547,
+  author =       {J. Kantor},
+  title =        "{LSST Network Bandwidth Tests between Chile and the United States }",
+  year =         2018,
+  month =        jun,
+  handle =       {Document-28547},
+}
+
+@DocuShare{Document-28973,
+  author =       {R. Gill},
+  title =        "{LSST MEETINGS CODE OF CONDUCT}",
+  year =         2018,
+  month =        jul,
+  handle =       {Document-28973},
+}
+
+@DocuShare{Document-24920,
+  author =       {R. Gill},
+  title =        "{LSST COMMUNICATIONS CODE OF CONDUCT}",
+  year =         2018,
+  month =        jul,
+  handle =       {Document-24920}
+}
+
+@DocuShare{Document-31100,
+  author =       {J. Ross Thomson},
+  title =        "{LSST Benchmarkin of Qserv and BigQuery}",
+  year =         2019,
+  month =        jan,
+  handle =       {Document-31100}
+}
+
+@DocuShare{Document-32503,
+  author =       {Kian-Tat Lim and Review Committee},
+  title =        "{Identity Management Review Report}",
+  year =         2019,
+  month =        apr,
+  handle =       {Document-32503}
+}
+
+@DocuShare{Document-35896,
+  author =       {Federica Bianco and  SCs coordinator and  TVS SC},
+  title =        "{MEMO on the impact of delays in pixel-level data access}",
+  year =         2020,
+  month =        may,
+  handle =       {Document-35896}
+}
+
 @DocuShare{LCA-227,
   author =       {Martin Nordby and Nadine Kurita and Frank O'Neill and Darren Marsh},
-  title =        {LSST Camera Quality Implementation Plan},
+  title =        "{LSST Camera Quality Implementation Plan}",
   year =         2014,
   month =        sep,
   handle =       {LCA-227},
@@ -227,23 +370,24 @@
 
 @DocuShare{LDM-17,
   author =       {Tim Axelrod and others},
-  title =        {LSST Data Challenge 3a Final Report},
+  title =        "{LSST Data Challenge 3a Final Report}",
   year =         2009,
   month =        aug,
   handle =       {LDM-17},
 }
 
 @DocuShare{LDM-129,
-  author =       {Mike Freemon and Jeff Kantor},
-  title =        {Data Management Infrastructure Design},
-  year =         2013,
-  month =        oct,
+  author =       {Don Petravick and Margaret Johnson and Michelle Butler},
+  title =        "{LSST Data Facility Logical Information Technology and
+                   Communications Design}",
+  year =         2018,
+  month =        jul,
   handle =       {LDM-129},
 }
 
 @DocuShare{LDM-130,
   author =       {Unknown},
-  title =        {LSST Science User Interface and Tools Requirements},
+  title =        "{LSST Science User Interface and Tools Requirements}",
   institution =  {IPAC},
   year =         2017,
   month =        sep,
@@ -261,7 +405,7 @@
 
 @DocuShare{LDM-133,
   author =       {Mario Juri\'c and Kian-Tat Lim and Jeff Kantor},
-  title =        {Data Management UML Domain Model},
+  title =        "{Data Management UML Domain Model}",
   year =         2013,
   month =        oct,
   handle =       {LDM-133},
@@ -269,7 +413,7 @@
 
 @DocuShare{LDM-134,
   author =       {Mario Juri\'c and Robyn Allsman and Jeff Kantor},
-  title =        {Data Management Applications UML Use Case Model},
+  title =        "{Data Management Applications UML Use Case Model}",
   year =         2013,
   month =        oct,
   handle =       {LDM-134},
@@ -277,16 +421,17 @@
 
 @DocuShare{LDM-135,
   author =       {Jacek Becla and Daniel Wang and Serge Monkewitz and
-                  K-T Lim and Douglas Smith and Bill Chickering},
-  title =        {Database Design},
-  year =         2013,
-  month =        oct,
+                  K-T Lim and Douglas Smith and Bill Chickering and
+                  Michael Kelsey and Fritz Mueller},
+  title =        "{Data Management Database Design}",
+  year =         2017,
+  month =        jul,
   handle =       {LDM-135},
 }
 
 @DocuShare{LDM-138,
   author =       {Jeff Kantor and Tim Axelrod and Kian-Tat Lim},
-  title =        {Data Management Compute Sizing Model},
+  title =        "{Data Management Compute Sizing Model}",
   year =         2013,
   month =        oct,
   handle =       {LDM-138},
@@ -304,7 +449,7 @@
 @DocuShare{LDM-140,
   author =       {Kian-Tat Lim and Chris Smith and Tim Axelrod and
                   Gregory Dubois-Felsmann and Mike Freemon},
-  title =        {Data Management Compute Sizing Explanation},
+  title =        "{Data Management Compute Sizing Explanation}",
   year =         2013,
   month =        oct,
   handle =       {LDM-140},
@@ -312,7 +457,7 @@
 
 @DocuShare{LDM-141,
   author =       {Jacek Becla and K.-T. Lim},
-  title =        {Data Management Storage Sizing and I/O Model},
+  title =        "{Data Management Storage Sizing and I/O Model}",
   year =         2013,
   month =        oct,
   handle =       {LDM-141},
@@ -320,7 +465,7 @@
 
 @DocuShare{LDM-142,
   author =       {Jeff Kantor},
-  title =        {Network Sizing Model},
+  title =        "{Network Sizing Model}",
   year =         2017,
   month =        jan,
   handle =       {LDM-142},
@@ -328,7 +473,7 @@
 
 @DocuShare{LDM-143,
   author =       {Mike Freemon and Steve Pietrowicz},
-  title =        {Site Specific Infrastructure Estimation Explanation},
+  title =        "{Site Specific Infrastructure Estimation Explanation}",
   year =         2013,
   month =        oct,
   handle =       {LDM-143},
@@ -336,7 +481,7 @@
 
 @DocuShare{LDM-144,
   author =       {Mike Freemon and Steve Pietrowicz and Jason Alt},
-  title =        {Site Specific Infrastructure Estimation Model},
+  title =        "{Site Specific Infrastructure Estimation Model}",
   year =         2016,
   month =        jan,
   handle =       {LDM-144},
@@ -355,15 +500,15 @@
   author =       {K.-T. Lim and J. Bosch and G. Dubois-Felsmann and T. Jenness
                   and J. Kantor and W. O'Mullane and D. Petravick and
                   {The DM Leadership Team}},
-  title =        {Data Management System Design},
-  year =         2017,
+  title =        "{Data Management System Design}",
+  year =         2018,
   month =        jul,
   handle =       {LDM-148},
 }
 
 @DocuShare{LDM-151,
   author =       {John D. Swinbank and others},
-  title =        {Data Management Science Pipelines Design},
+  title =        "{Data Management Science Pipelines Design}",
   year =         2017,
   month =        may,
   handle =       {LDM-151},
@@ -372,7 +517,7 @@
 @DocuShare{LDM-152,
   author =       {Kian-Tat Lim and Gregory Dubois-Felsmann and M. Johnson
                   and M. Juri\'c and D. Petravick},
-  title =        {Data Management Middleware Design},
+  title =        "{Data Management Middleware Design}",
   year =         2017,
   month =        jul,
   handle =       {LDM-152},
@@ -380,14 +525,14 @@
 
 @DocuShare{LDM-153,
   author =      {J. Becla},
-  title =       {LSST Database Baseline Schema},
+  title =       "{LSST Database Baseline Schema}",
   year =        2013,
   handle =      {LDM-153},
 }
 
 @DocuShare{LDM-156,
   author =       {Jonathan Myers and Lynne Jones and Tim Axelrod},
-  title =        {Moving Object Pipeline System Design},
+  title =        "{Moving Object Pipeline System Design}",
   year =         2013,
   month =        oct,
   handle =       {LDM-156},
@@ -421,23 +566,23 @@
                   Ron Lambert and Kian-Tat Lim and Bruce Mather and Serge Monkewitz and
                   Knut Olsen and Steve Pietrowicz and Ray Plante and Dick Shaw and
                   Douglas Smith and Schuyler Van Dyk and Daniel Wang},
-  title =        {Report on Late Winter2013 Production: Image Differencing},
+  title =        "{Report on Late Winter2013 Production: Image Differencing}",
   year =         2013,
   month =        apr,
   handle =       {LDM-227},
 }
 
 @DocuShare{LDM-230,
-  author =       {D. Petravick and M. Gelman},
-  title =        {Concept of Operations for the LSST Data Facility Services},
-  year =         2017,
+  author =       {D. Petravick and M. Butler and M. Gelman},
+  title =        "{Concept of Operations for the LSST Data Facility Services}",
+  year =         2018,
   month =        jul,
   handle =       {LDM-230},
 }
 
 @DocuShare{LDM-240,
   author =       {Jeff Kantor and Mario Juri\'c and Kian-Tat Lim},
-  title =        {Data Management Releases},
+  title =        "{Data Management Releases}",
   year =         2016,
   month =        feb,
   handle =       {LDM-240},
@@ -446,15 +591,23 @@
 @DocuShare{LDM-294,
   author =       {William O'Mullane and John Swinbank and Mario Juri\'c
                   and {DMLT}},
-  title =        {Data Management Organization and Management},
-  year =         2017,
-  month =        jul,
+  title =        "{Data Management Organization and Management}",
+  year =         2018,
+  month =        jun,
   handle =       {LDM-294},
+}
+
+@DocuShare{LDM-324,
+  author =       {Jeff Kantor},
+  title =        "{Data Management Information Security Plan}",
+  year =         2016,
+  month =        mar,
+  handle =       {LDM-324},
 }
 
 @DocuShare{LDM-463,
   author =       {Jacek Becla and Nate Pease},
-  title =        {Data Access Design},
+  title =        "{Data Access Design}",
   year =         2017,
   month =        apr,
   handle =       {LDM-463},
@@ -464,7 +617,7 @@
   author =       {Jacek Becla and Frossie Economou and Fritz Mueller and
                   Margaret Johnson and K. Simon Krughoff and K-T Lim and
                   John Swinbank and Xiuqin Wu},
-  title =        {LSST DM Project Management and Tools},
+  title =        "{LSST DM Project Management and Tools}",
   year =         2017,
   month =        feb,
   handle =       {LDM-472},
@@ -472,7 +625,7 @@
 
 @DocuShare{LDM-482,
   author =       {David Ciardi and Gregory Dubois-Felsmann},
-  title =        {Data Access Policy for the Data Management Prototype DAC},
+  title =        "{Data Access Policy for the Data Management Prototype DAC}",
   year =         2016,
   month =        aug,
   handle =       {LDM-482},
@@ -481,7 +634,7 @@
 @DocuShare{LDM-492,
   author =       {David R. Ciardi and Xiuqin Wu and Gregory
                   Dubois-Felsmann},
-  title =        {A Vision for the Science User Interface and Tools},
+  title =        "{A Vision for the Science User Interface and Tools}",
   institution =  {IPAC},
   year =         2016,
   month =        sep,
@@ -490,7 +643,7 @@
 
 @DocuShare{LDM-493,
   author =       {Jonathan Sick},
-  title =        {Data Management Documentation Architecture},
+  title =        "{Data Management Documentation Architecture}",
   year =         2016,
   month =        nov,
   handle =       {LDM-493},
@@ -498,24 +651,24 @@
 
 @DocuShare{LDM-502,
   author =       {David Nidever and Frossie Economou},
-  title =        {The Measurement and Verification of DM Key Performance Metrics},
+  title =        "{The Measurement and Verification of DM Key Performance Metrics}",
   year =         2016,
   month =        may,
   handle =       {LDM-502},
 }
 
 @DocuShare{LDM-503,
-  author =       {William O'Mullane and Mario Juri\'c and Frossie
+  author =       {William O'Mullane and John Swinbank and Mario Juri\'c and Frossie
                   Economou},
-  title =        {Data Management Test Plan},
-  year =         2017,
+  title =        "{Data Management Test Plan}",
+  year =         2018,
   month =        jun,
   handle =       {LDM-503},
 }
 
 @DocuShare{LDM-512,
   author =       {Tim Jenness and William O'Mullane},
-  title =        {Data Management Risk Assessment Process},
+  title =        "{Data Management Risk Assessment Process}",
   year =         2017,
   month =        apr,
   handle =       {LDM-512},
@@ -523,7 +676,7 @@
 
 @DocuShare{LDM-513,
   author =       {Jim Bosch},
-  title =        {Proposal for Deblender Outputs as Level 2 Data Products},
+  title =        "{Proposal for Deblender Outputs as Level 2 Data Products}",
   year =         2017,
   month =        apr,
   handle =       {LDM-513},
@@ -531,7 +684,7 @@
 
 @DocuShare{LDM-522,
   author =       {Frossie Economou and Michael Wood-Vasey},
-  title =        {DM Science Quality Data Assurance System Conceptual Design},
+  title =        "{DM Science Quality Data Assurance System Conceptual Design}",
   year =         2017,
   month =        may,
   handle =       {LDM-522},
@@ -539,7 +692,7 @@
 
 @DocuShare{LDM-523,
   author =       {C. T. Slater and R. L. Jones and E. Bellm and M. Juri\'c},
-  title =        {Impact of a Heterogeneous Focal Plane on LSST Image Differencing},
+  title =        "{Impact of a Heterogeneous Focal Plane on LSST Image Differencing}",
   year =         2017,
   month =        may,
   handle =       {LDM-523},
@@ -547,15 +700,15 @@
 
 @DocuShare{LDM-532,
   author =       {Unknown},
-  title =        {NCSA Enclave Test Specification},
+  title =        "{NCSA Enclave Test Specification}",
   year =         2017,
   month =        jun,
   handle =       {LDM-532},
 }
 
 @DocuShare{LDM-533,
-  author =       {Unknown},
-  title =        {Level 1 System Software Test Specification},
+  author =       {Eric C. Bellm},
+  title =        "{Level 1 System Software Test Specification}",
   year =         2017,
   month =        jun,
   handle =       {LDM-533},
@@ -563,7 +716,7 @@
 
 @DocuShare{LDM-534,
   author =       {John D. Swinbank},
-  title =        {Level 2 System Software Test Specification},
+  title =        "{Level 2 System Software Test Specification}",
   year =         2017,
   month =        jun,
   handle =       {LDM-534},
@@ -571,7 +724,7 @@
 
 @DocuShare{LDM-535,
   author =       {Unknown},
-  title =        {Data Backbone Test Specification},
+  title =        "{Data Backbone Test Specification}",
   year =         2017,
   month =        jun,
   handle =       {LDM-535},
@@ -579,7 +732,7 @@
 
 @DocuShare{LDM-536,
   author =       {Unknown},
-  title =        {Data Backbone Data Services Test Specification},
+  title =        "{Data Backbone Data Services Test Specification}",
   year =         2017,
   month =        jun,
   handle =       {LDM-536},
@@ -587,39 +740,39 @@
 
 @DocuShare{LDM-537,
   author =       {Unknown},
-  title =        {Data Backbone Infrastructure Test Specification},
+  title =        "{Data Backbone Infrastructure Test Specification}",
   year =         2017,
   month =        jun,
   handle =       {LDM-537},
 }
 
 @DocuShare{LDM-538,
-  author =       {Unknown},
-  title =        {Base Enclave Test Specification},
-  year =         2017,
+  author =       {Michelle Butler and Jim Parsons and Michelle Gower},
+  title =        "{Raw Image Archiving Service Test Specification}",
+  year =         2018,
   month =        jun,
   handle =       {LDM-538},
 }
 
 @DocuShare{LDM-539,
   author =       {Unknown},
-  title =        {Data Access Center Enclave Test Specification},
+  title =        "{Data Access Center Enclave Test Specification}",
   year =         2017,
   month =        jun,
   handle =       {LDM-539},
 }
 
 @DocuShare{LDM-540,
-  author =       {Unknown},
-  title =        {LSST Science Platform Test Specification},
-  year =         2017,
-  month =        jun,
+  author =       {Gregory Dubois-Felsmann},
+  title =        "{LSST Science Platform Test Specification}",
+  year =         2018,
+  month =        may,
   handle =       {LDM-540},
 }
 
 @DocuShare{LDM-541,
   author =       {Unknown},
-  title =        {Commissioning Cluster Enclave Test Specification},
+  title =        "{Commissioning Cluster Enclave Test Specification}",
   year =         2017,
   month =        jun,
   handle =       {LDM-541},
@@ -627,7 +780,7 @@
 
 @DocuShare{LDM-542,
   author =       {Gregory Dubois-Felsmann and Kian-Tat Lim and Xiuqin Wu and Frossie Economou and Fritz Mueller and Brian Van Klaveren and Kenny Lo},
-  title =        {LSST Science Platform Design},
+  title =        "{LSST Science Platform Design}",
   year =         2017,
   month =        jun,
   handle =       {LDM-542},
@@ -635,7 +788,7 @@
 
 @DocuShare{LDM-552,
   author =       {Fritz Mueller},
-  title =        {Qserv Software Test Specification},
+  title =        "{Qserv Software Test Specification}",
   year =         2017,
   month =        jun,
   handle =       {LDM-552},
@@ -643,48 +796,206 @@
 
 @DocuShare{LDM-553,
   author =       {William O'Mullane and John D. Swinbank and Mario Juri\'c and {DMLT}},
-  title =        {Evolution of the Data Management Plan and Organization},
+  title =        "{Evolution of the Data Management Plan and Organization}",
   year =         2017,
   month =        jun,
   handle =       {LDM-553},
 }
 
 @DocuShare{LDM-554,
-  author =       {David Ciardi and Gregory Dubois-Felsmann},
-  title =        {Science Platform Requirements},
-  year =         2017,
+  author =       {Gregory Dubois-Felsmann and David Ciardi and Fritz Mueller
+                  and Frossie Economou},
+  title =        "{Science Platform Requirements}",
+  year =         2018,
   month =        jun,
   handle =       {LDM-554},
 }
 
 @DocuShare{LDM-555,
   author =       {Jacek Becla},
-  title =        {Data Management Database Requirements},
+  title =        "{Data Management Database Requirements}",
   year =         2017,
   month =        jun,
   handle =       {LDM-555},
 }
 
 @DocuShare{LDM-556,
-  author =       {Gregory Dubois-Felsmann},
-  title =        {Data Management Middleware Requirements},
-  year =         2017,
-  month =        jun,
+  author =       {Gregory Dubois-Felsmann and Tim Jenness and Jim Bosch
+                  and Michelle Gower and Simon Krughoff and Russell Owen
+                  and Pim Schellart and Brian {van Klaveren}},
+  title =        "{Data Management Middleware Requirements}",
+  year =         2018,
+  month =        may,
   handle =       {LDM-556},
+}
+
+@DocuShare{LDM-562,
+  author =       {Jim Bosch},
+  title =        "{Data Management System Level 2 System Requirements}",
+  year =         2017,
+  month =        nov,
+  handle =       {LDM-562},
+}
+
+@DocuShare{LDM-563,
+  author =       {William O'Mullane and Tim Jenness},
+  title =        "{Butler Working Group Charge}",
+  year =         2017,
+  month =        aug,
+  handle =       {LDM-563},
+}
+
+@DocuShare{LDM-564,
+  author =       {William O'Mullane and Frossie Economou and Tim Jenness and Andrew Loftus},
+  title =        "{Data Management Software Releases for Verification/Integration}",
+  year =         2018,
+  month =        jun,
+  handle =       {LDM-564},
+}
+
+@DocuShare{LDM-572,
+  author =       {William O'Mullane and Donald Petravick},
+  title =        "{Chilean Data Access Center}",
+  year =         2017,
+  month =        nov,
+  handle =       {LDM-572},
+}
+
+@DocuShare{LDM-582,
+  author =       {Mario Juric and Robert Gruendl},
+  title =        "{Lossy Compression Working Group Charge}",
+  year =         2017,
+  month =        oct,
+  handle =       {LDM-582},
+}
+
+@DocuShare{LDM-592,
+  author =       {Tim Jenness and Jim Bosch and Michelle Gower and
+                  Simon Krughoff and Russell Owen and Pim Schellart and
+                  Brian {van Klaveren} and Dominique Boutigny},
+  title =        "{Data Access Use Cases}",
+  year =         2017,
+  month =        nov,
+  handle =       {LDM-592},
+}
+
+@DocuShare{LDM-612,
+  author =       {Eric Bellm and Robert Blum and Melissa Graham and Leanne Guy and {\v Z}eljko {Ivezi{\'c}} and William O’Mullane and Maria Patterson and John Swinbank and Beth Willman},
+  title =        "{Plans and Policies for LSST Alert Distribution}",
+  year =         2019,
+  month =        jan,
+  handle =       {LDM-612},
+}
+
+
+@DocuShare{LDM-622,
+  author =       {John Swinbank},
+  title =        "{Data Management QA Strategy Working Group Charge}",
+  year =         2018,
+  month =        apr,
+  handle =       {LDM-622},
+}
+
+@DocuShare{LDM-633,
+  author =       {Mikolaj Kowalik and Michelle Gower and Rob Kooper},
+  title =        "{Offline Batch Production Services Use Cases}",
+  year =         2019,
+  month =        mar,
+  handle =       {LDM-633},
+}
+
+@DocuShare{LDM-635,
+  author =       {Michelle Gower and Michelle Butler and Kian-Tat Lim},
+  title =        "{Data Management Data Backbone Services Requirements}",
+  year =         2018,
+  month =        jun,
+  handle =       {LDM-635},
+}
+
+@DocuShare{LDM-636,
+  author =       {Mikolaj Kowalik and Michelle Gower and Rob Kooper},
+  title =        "{Batch Production Service Requirements}",
+  year =         2019,
+  month =        mar,
+  handle =       {LDM-636},
+}
+
+@DocuShare{LDM-639,
+  author =      {L. Guy},
+  title =       "{DM Acceptance Test Specification}",
+  year =        2018,
+  month =       jun,
+  handle =      {LDM-639},
+}
+
+@DocuShare{LDM-643,
+  author =      {M.~Johnson and R.A.~Gruendl},
+  title =       "{Proposed DM OPS Rehearsals}",
+  year =        2019,
+  month =       mar,
+  handle =      {LDM-643},
+}
+
+@DocuShare{LDM-672,
+   author = {G. Comoretto and L. Guy},
+    title = {LSST Software Release Management Policy},
+     year = 2019,
+    month = jul,
+   handle = {LDM-672},
+      url = {http://LDM-672.lsst.io } }
+
+@DocuShare{LDM-682,
+  author =       {Eric Bellm and Robert Blum and Melissa Graham and Leanne Guy and {\v Z}eljko {Ivezi{\'c}} and William O’Mullane and John Swinbank},
+  title =        "{Call for Letters of Intent for Community Alert Brokers}",
+  year =         2019,
+  month =        feb,
+  handle =       {LDM-682},
+}
+
+@DocuShare{LDM-692,
+   author = {Gabriele Comoretto},
+    title = {DM Verification Control Document},
+     year = 2019,
+    month = jun,
+   handle = {LDM-692},
+      url = {http://lm-692.lsst.io } }
+
+@DocuShare{LDM-702,
+  author =       {William O'Mullane},
+  title =        "{Image display working group charge}",
+  year =         2019,
+  month =        jun,
+  handle =       {LDM-702},
+}
+
+@DocuShare{LDM-723,
+  author =       {Eric Bellm and Robert Blum and Melissa Graham and Leanne Guy and {\v Z}eljko {Ivezi{\'c}} and William O’Mullane and John Swinbank},
+  title =        "{Call for Proposals for Community Alert Brokers}",
+  year =         2019,
+  month =        dec,
+  handle =       {LDM-723},
 }
 
 @DocuShare{LPM-17,
   author =       {{\v Z}. {Ivezi{\'c}} and {The LSST Science
                   Collaboration}},
   title =        "{LSST Science Requirements Document}",
-  year =         2011,
-  month =        jul,
+  year =         2018,
+  month =        jan,
   handle =       {LPM-17},
+}
+
+@DocuShare{LPM-18,
+  author =       {Chuck Gessner and Victor Krabbendam },
+  title =        "{Safety Policy}",
+  year =         2014,
+  month =        nov,
+  handle =       {LPM-18},
 }
 
 @DocuShare{LPM-19,
   author =       {George Angeli and Robert McKercher},
-  title =        {Change Control Process},
+  title =        "{Change Control Process}",
   year =         2015,
   month =        dec,
   handle =       {LPM-19},
@@ -692,7 +1003,7 @@
 
 @DocuShare{LPM-20,
   author =       {Victor Krabbendam and Brian Selvy},
-  title =        {Risk \& Opportunity Management Plan},
+  title =        "{Risk \& Opportunity Management Plan}",
   year =         2015,
   month =        aug,
   handle =       {LPM-20},
@@ -700,7 +1011,7 @@
 
 @DocuShare{LPM-43,
   author =       {Robert McKercher},
-  title =        {WBS Structure},
+  title =        "{WBS Structure}",
   year =         2016,
   month =        jul,
   handle =       {LPM-43},
@@ -708,7 +1019,7 @@
 
 @DocuShare{LPM-44,
   author =       {Robert McKercher},
-  title =        {WBS Dictionary},
+  title =        "{WBS Dictionary}",
   year =         2016,
   month =        jul,
   handle =       {LPM-44},
@@ -716,7 +1027,7 @@
 
 @DocuShare{LPM-51,
   author =       {Robert McKercher},
-  title =        {Document Management Plan},
+  title =        "{Document Management Plan}",
   year =         2013,
   month =        aug,
   handle =       {LPM-51},
@@ -724,7 +1035,7 @@
 
 @DocuShare{LPM-55,
   author =       {Donald Sweeney and Robert McKercher},
-  title =        {Project Quality Assurance Plan},
+  title =        "{Project Quality Assurance Plan}",
   year =         2013,
   month =        aug,
   handle =       {LPM-55},
@@ -732,7 +1043,7 @@
 
 @DocuShare{LPM-72,
   author =       {Victor Krabbendam},
-  title =        {Scope Options},
+  title =        "{Scope Options}",
   year =         2015,
   month =        oct,
   handle =       {LPM-72},
@@ -740,7 +1051,7 @@
 
 @DocuShare{LPM-73,
   author =       {Sidney Wolff},
-  title =        {Operations Plan},
+  title =        "{Operations Plan}",
   year =         2013,
   month =        oct,
   handle =       {LPM-73},
@@ -748,7 +1059,7 @@
 
 @DocuShare{LPM-81,
   author =       {Jeff Kantor and Victor Krabbendam},
-  title =        {Cost Estimating Plan},
+  title =        "{Cost Estimating Plan}",
   year =         2015,
   month =        aug,
   handle =       {LPM-81},
@@ -756,7 +1067,7 @@
 
 @DocuShare{LPM-98,
   author =       {Kevin E. Long},
-  title =        {LSST Project Controls System Description},
+  title =        "{LSST Project Controls System Description}",
   year =         2016,
   month =        dec,
   handle =       {LPM-98},
@@ -764,7 +1075,7 @@
 
 @DocuShare{LPM-121,
   author =       {Donald L. Petravick and Alexander Withers},
-  title =        {LSST Master Information Security Policy},
+  title =        "{LSST Master Information Security Policy}",
   year =         2016,
   month =        sep,
   handle =       {LPM-121},
@@ -772,15 +1083,23 @@
 
 @DocuShare{LPM-122,
   author =       {Donald Petravick},
-  title =        {LSST Information Classification Policy},
+  title =        "{LSST Information Classification Policy}",
   year =         2015,
   month =        aug,
   handle =       {LPM-122},
 }
 
+@DocuShare{LPM-123,
+  author =       {Donald Petravick},
+  title =        "{ LSST General Acceptable Use Policy  }",
+  year =         2017,
+  month =        oct,
+  handle =       {LPM-123},
+}
+
 @DocuShare{LPM-162,
   author =       {{Project Science Team}},
-  title =        {Project Publication Policy},
+  title =        "{Project Publication Policy}",
   year =         2015,
   month =        aug,
   handle =       {LPM-162},
@@ -794,9 +1113,33 @@
   handle =       {LPM-191},
 }
 
+@DocuShare{LPM-221,
+  author =       {William O'Mullane and Beth Willman},
+  title =        "{Charge for LSST Data Access Policy Working Group}",
+  year =         2017,
+  month =        nov,
+  handle =       {LPM-221},
+}
+
+@DocuShare{LPM-231,
+  author =       {G. P. Dubois-Felsmann and Z. Ivezic and M. Juric},
+  title =        "{LSST Data Product Categories}",
+  year =         2018,
+  month =        jan,
+  handle =       {LPM-231},
+}
+
+@DocuShare{LPM-251,
+  author =       {William O'Mullane and  Beth Willman and  Melissa Graham},
+  title =        "{Policy for Independent Data Access Centers}",
+  year =         2018,
+  month =        Jun,
+  handle =       {LPM-251},
+}
+
 @DocuShare{LSE-16,
   author =       {Robyn Allsman and Gregory Dubois-Felsmann and Jeff Kantor},
-  title =        {LSST Software Development Plan},
+  title =        "{LSST Software Development Plan}",
   year =         2009,
   month =        may,
   handle =       {LSE-16},
@@ -804,7 +1147,7 @@
 
 @DocuShare{LSE-17,
   author =       {Charles Claver and George Angeli and Brian Selvy},
-  title =        {Systems Engineering Management Plan},
+  title =        "{Systems Engineering Management Plan}",
   year =         2016,
   month =        jan,
   handle =       {LSE-17},
@@ -813,18 +1156,18 @@
 @DocuShare{LSE-29,
   author =       {Charles F. Claver and {The LSST Systems Engineering
                   Integrated Project Team}},
-  title =        {LSST System Requirements},
-  year =         2016,
-  month =        aug,
+  title =        "{LSST System Requirements (LSR)}",
+  year =         2017,
+  month =        sep,
   handle =       {LSE-29},
 }
 
 @DocuShare{LSE-30,
   author =       {Charles F. Claver and {The LSST Systems Engineering
                   Integrated Project Team}},
-  title =        {LSST System Requirements},
-  year =         2016,
-  month =        aug,
+  title =        "{Observatory System Specifications (OSS)}",
+  year =         2018,
+  month =        jan,
   handle =       {LSE-30},
 }
 
@@ -836,12 +1179,28 @@
   handle =       {LSE-39},
 }
 
+@DocuShare{LSE-60,
+  author =       {Jacques Sebag and Victor Krabbendam},
+  title =        "{LSST Telescope and Site (TS) Requirements}",
+  year =         2018,
+  month =        may,
+  handle =       {LSE-60},
+}
+
 @DocuShare{LSE-61,
-  author =       {Gregory Dubois-Felsmann},
-  title =        {LSST Data Management Subsystem Requirements},
-  year =         2016,
-  month =        feb,
+  author =       {Gregory Dubois-Felsmann and Tim Jenness},
+  title =        "{LSST Data Management Subsystem Requirements}",
+  year =         2018,
+  month =        jul,
   handle =       {LSE-61},
+}
+
+@DocuShare{LSE-62,
+  author =       {German Schumacher and Francisco Delgado},
+  title =        "{LSST Observatory Control System Requirements}",
+  year =         2019,
+  month =        oct,
+  handle =       {LSE-62},
 }
 
 @DocuShare{LSE-63,
@@ -856,7 +1215,7 @@
 
 @DocuShare{LSE-68,
   author =       {Gregory Dubois-Felsmann},
-  title =        {Camera Data Acquisition Interface},
+  title =        "{Camera Data Acquisition Interface}",
   year =         2015,
   month =        jun,
   handle =       {LSE-68},
@@ -864,7 +1223,7 @@
 
 @DocuShare{LSE-69,
   author =       {Gregory Dubois-Felsmann},
-  title =        {Interface between the Camera and Data Management},
+  title =        "{Interface between the Camera and Data Management}",
   year =         2014,
   month =        oct,
   handle =       {LSE-69},
@@ -879,7 +1238,7 @@
 }
 
 @DocuShare{LSE-72,
-  author =       {Gregory Dubious-Felsmann and German Schumacher and
+  author =       {Gregory Dubois-Felsmann and German Schumacher and
                   Brian Selvy},
   title =        "{OCS Command Dictionary for Data Management}",
   year =         2014,
@@ -888,7 +1247,7 @@
 }
 
 @DocuShare{LSE-75,
-  author =       {Gregory Dubious-Felsmann},
+  author =       {Gregory Dubois-Felsmann},
   title =        "{Control System Interfaces between the Telescope and Data Management}",
   year =         2011,
   month =        aug,
@@ -896,7 +1255,7 @@
 }
 
 @DocuShare{LSE-76,
-  author =       {Gregory Dubious-Felsmann},
+  author =       {Gregory Dubois-Felsmann},
   title =        "{Infrastructure Interfaces between Summit Facility and Data Management}",
   year =         2011,
   month =        aug,
@@ -904,7 +1263,7 @@
 }
 
 @DocuShare{LSE-77,
-  author =       {Gregory Dubious-Felsmann},
+  author =       {Gregory Dubois-Felsmann},
   title =        "{Infrastructure Interfaces between Base Facility and Data Management}",
   year =         2013,
   month =        oct,
@@ -914,7 +1273,7 @@
 @DocuShare{LSE-78,
 	author =       {Ron Lambert and Jeff Kantor and Mike Huffer and Chip Cox
                   and Paul Wefel and Matt Kollross and Sandra Jaque},
-	title =        { LSST Observatory Network Design},
+	title =        "{ LSST Observatory Network Design}",
 	year =         2017,
 	month =        apr,
 	handle =       {LSE-78},
@@ -922,15 +1281,24 @@
 
 @DocuShare{LSE-79,
   author =       {Chuck Claver and {The LSST Commissioning Planning Team}},
-  title =        {System AI\&T and Commissioning Plan},
+  title =        "{System AI\&T and Commissioning Plan}",
   year =         2017,
   month =        jan,
   handle =       {LSE-79},
 }
 
+@DocuShare{LEP-031,
+  author =       {The LSST EPO Team},
+  title =        "{LSST EPO Design}",
+  year =         2018,
+  month =        jul,
+  handle =       {LEP-031},
+}
+
+
 @DocuShare{LSE-81,
   author =       {Gregory Dubois-Felsmann},
-  title =        {LSST Science and Project Sizing Inputs},
+  title =        "{LSST Science and Project Sizing Inputs}",
   year =         2013,
   month =        oct,
   handle =       {LSE-81},
@@ -938,11 +1306,20 @@
 
 @DocuShare{LSE-82,
   author =       {Gregory Dubois-Felsmann and Kian-Tat Lim},
-  title =        {Science and Project Sizing Inputs Explanation},
+  title =        "{Science and Project Sizing Inputs Explanation}",
   year =         2013,
   month =        oct,
   handle =       {LSE-82},
 }
+
+@DocuShare{LSE-89,
+  author =       {Ben Emmons and Amanda Bauer},
+  title =        "{Education and Public Outreach Requirements}",
+  year =         2018,
+  month =        jan,
+  handle =       {LSE-89}
+}
+
 
 @DocuShare{LSE-130,
   author =       {Gregory Dubois-Felsmann},
@@ -969,6 +1346,14 @@
   handle =       {LSE-140},
 }
 
+@DocuShare{LSE-150,
+  author =       {Tiago Ribeiro and William O’Mullane and Tim Axelrod and Dave Mills},
+  title =        "{Control Software Architecture}",
+  year =         2019,
+  month =        aug,
+  handle =       {LSE-150},
+}
+
 @DocuShare{LSE-159,
   author =       {George Angeli},
   title =        "{Reviews Definitions, Guidelines, and Procedures}",
@@ -979,7 +1364,7 @@
 
 @DocuShare{LSE-163,
   author =       {Mario Juri\'c and others},
-  title =        {LSST Data Products Definition Document},
+  title =        "{LSST Data Products Definition Document}",
   year =         2017,
   month =        apr,
   handle =       {LSE-163},
@@ -987,34 +1372,115 @@
 
 @DocuShare{LSE-180,
   author =       {Lynne Jones},
-  title =        {Level 2 Photometric Calibration for the LSST Survey},
+  title =        "{Level 2 Photometric Calibration for the LSST Survey}",
   year =         2013,
   month =        nov,
   handle =       {LSE-180},
 }
 
 @DocuShare{LSE-209,
-	author =	     {Paul Lotz},
-	title =	 	     {Software Component to OCS Interface},
-	year =		     2016,
-	month =		     oct,
-	handle =	     {LSE-209},
+  author =       {Paul Lotz},
+  title =        {Software Component to OCS Interface},
+  year =         2016,
+  month =        oct,
+  handle =       {LSE-209},
+}
+
+@DocuShare{LSE-239,
+  author =       {Donald Petravick and Josh Hoblitt and Kian-Tat Lim and Ron Lambert and Gregory Dubois-Felsmann and Tom Durbin and Jeff Barr},
+  title =        "{Base Facility Data Center Design Requirements}",
+  year =         2016,
+  month =        aug,
+  handle =       {LSE-239},
 }
 
 @DocuShare{LSE-279,
-	author =	     {Alex Withers},
-	title =	 	     "{Concept of Operations for Unified LSST Authentication and Authorization Services}",
-	year =		     2017,
-	month =		     jan,
-	handle =	     {LSE-279},
+  author =       {Alex Withers},
+  title =        "{Concept of Operations for Unified LSST Authentication and Authorization Services}",
+  year =         2017,
+  month =        jan,
+  handle =       {LSE-279},
+}
+
+@DocuShare{LSE-309,
+  author =       {Jeff Kantor},
+  title =        "{Summit to Base Information Technology and Communication (ITC) Design}",
+  year =         2017,
+  month =        nov,
+  handle =       {LSE-309},
 }
 
 @DocuShare{LSE-319,
   author =       {M. Juri\'c and D. Ciardi and G.P. Dubois-Felsmann},
-  title =        {LSST Science Platform Vision Document},
+  title =        "{LSST Science Platform Vision Document}",
   year =         2017,
   month =        jun,
   handle =       {LSE-319},
+}
+
+@DocuShare{LPM-261,
+  author =       {Beth Willman and Melissa Graham and William O'Mullane and Donald Petravick},
+  title =        "{Access Policy for LSST Data and Data Access Center}",
+  year =         2018,
+  month =        mar,
+  handle =       {LPM-261},
+  note =         {Superseded by LDO-13},
+}
+
+@DocuShare{LSE-349,
+  author =       {K. Simon Krughoff},
+  title =        "{Defining the Transformation Between Camera Engineering Coordinates and Camera Data Visualization Coordinates}",
+  year =         2019,
+  month =        mar,
+  handle =       {LSE-349},
+}
+
+@DocuShare{LSE-379,
+  author =       {Patrick Ingraham},
+  title =        "{Auxiliary Telescope Concept of Operations}",
+  year =         2018,
+  month =        may,
+  handle =       {LSE-379},
+}
+
+@DocuShare{LSE-390,
+  author =       {Kevin Reil and  Chuck Claver and  Vincent Riot and Victor Krabbendam},
+  title =        "{Commissioning Execution Plan}",
+  year =         2020,
+  month =        mar,
+  handle =       {LSE-390},
+}
+
+@DocuShare{LSE-400,
+  author = {K-T Lim},
+  title = "{Header Service Interface}",
+  year = 2019,
+  handle = {LSE-400},
+  url = {https://lse-400.lsst.io},
+}
+
+@DocuShare{LDO-13,
+  author =      {R. Blum and others},
+  title =       "{LSST Data Policy}",
+  year =        2019,
+  month =       nov,
+  handle =      {LDO-13},
+}
+
+@DocuShare{LDO-31,
+  author =      {R. Blum and others},
+  title =       "{LSST Operations Proposal }",
+  year =        2020,
+  month =       mar,
+  handle =      {LDO-31},
+}
+
+@DocuShare{LSO-011,
+  author = {William O’Mullane and  Phil Marshall and  Leanne Guy},
+  title = "{Release Scenarios for LSST Data}",
+  year = 2019,
+  handle = {LSO-011},
+  url = {https://lso-011.lsst.io},
 }
 
 @DocuShare{LTS-206,
@@ -1024,10 +1490,74 @@
   handle =       {LTS-206},
 }
 
+@DocuShare{LTS-210,
+  author =       {D. Mills},
+  title =        "{Engineering and Facility Database Design Document}",
+  year =         2015,
+  handle =       {LTS-210},
+}
+
+@DocuShare{LTS-487,
+  author =       {P. Ingraham},
+  title =        "{Auxiliary Telescope Spectrograph Statement of Work (SOW)}",
+  year =         2017,
+  handle =       {LTS-487},
+}
+
+@DocuShare{LTS-488,
+  author =       {P. Ingraham},
+  title =        "{Auxiliary Telescope Spectrograph Specifications Document}",
+  year =         2017,
+  handle =       {LTS-488},
+}
+
+@DocuShare{LTS-807,
+  author =       {A. Serio},
+  title =        "{LSST Operations Viszualization Enviroment (LOVE) Requirements }",
+  year =         2018,
+  handle =       {LTS-807},
+}
+
+@DocuShare{Publication-141,
+  author =       {Dhital, S. and others},
+  title =        {{Science White Paper for LSST Deep-Drilling Field Observations Mapping the Milky Way's Ultracool Dwarfs, Subdwarfs, and White Dwarfs}},
+  year =         2011,
+  handle = {Publication-141},
+}
+
+@DocuShare{Publication-142,
+  author =       {Ferguson, H.~C.},
+  title =        {{Science White Paper for LSST Deep-Drilling Field Observations: LSST Deep Drilling for Galaxies}},
+  year =         2011,
+  handle = {Publication-142},
+}
+
+@DocuShare{Publication-143,
+  author =       {Gawiser, E. and others},
+  title =        {{Science White Paper for LSST Deep-Drilling Field Observations: Ultra-deep $ugrizy$ Imaging to Reduce Main Survey Photo-z Systematics and to Probe Faint Galaxy Clustering, AGN, and Strong Lenses}},
+  year =         2011,
+  handle = {Publication-143},
+}
+
+@DocuShare{Publication-144,
+  author =       {Kessler, R. and others},
+  title =        {{Science White Paper for LSST Deep-Drilling Field Observations: Supernova Light Curves}},
+  year =         2011,
+  handle = {Publication-144},
+}
+
+@DocuShare{Publication-145,
+  author =       {Szkody, P. and others},
+  title =        {{Science White Paper for LSST Deep-Drilling Field Observations
+High Cadence Observations of the Magellanic Clouds and Select Galactic Cluster Fields}},
+  year =         2011,
+  handle = {Publication-145},
+}
+
 @DocuShare{Report-142,
   author =       {Tim Jenness and John Swinbank and Simon Krughoff and
                   Gregory Dubois-Felsmann and David Ciardi},
-  title =        {Hot-Wiring the Transient Universe IV},
+  title =        "{Hot-Wiring the Transient Universe IV}",
   year =         2015,
   month =        jun,
   handle =       {Report-142},
@@ -1037,10 +1567,18 @@
 
 @DocuShare{Report-241,
   author =       {{LSST Project Science Team}},
-  title =        {Camera Mixed Focal Plane Option},
+  title =        "{Camera Mixed Focal Plane Option}",
   year =         2015,
   month =        nov,
   handle =       {Report-241},
+}
+
+@DocuShare{Report-561,
+  author =       {{Review Committee}},
+  title =        "{Telescope \& Site (T\&S) Software Review Report}",
+  year =         2018,
+  month =        mar,
+  handle =       {Report-561},
 }
 
 @DocuShare{DMTN-007,
@@ -1070,11 +1608,20 @@
      url = {https://dmtn-015.lsst.io},
 }
 
+@DocuShare{DMTN-018,
+  author = {Andy Salnikov},
+   title = "{Re-visiting L1 Database Design (Draft)}",
+    year = 2016,
+  handle = {DMTN-018},
+     url = {https://dmtn-018.lsst.io/}
+}
+
+
 @DocuShare{DMTN-020,
   author =       {Jacek Becla and Frossie Economou and Margaret Gelman and
                   Jeff Kantor and Simon Krughoff and Kevin Long and Fritz
                   Mueller and John Swinbank and Xiuqin Wu},
-  title =        {Project Management Guide},
+  title =        "{Project Management Guide}",
   year =         2016,
   month =        nov,
   handle =       {DMTN-020},
@@ -1088,6 +1635,33 @@
   handle = {DMTN-021},
     note = {LSST Data Management Technical Note},
      url = {https://dmtn-021.lsst.io},
+}
+
+@DocuShare{DMTN-025,
+  author = {Mikolaj Kowalik and Hsin-Fang Chiang and Greg Daues and Rob Kooper},
+   title = "{A survey of workflow management systems}",
+    year = 2016,
+  handle = {DMTN-025},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-025.lsst.io},
+}
+
+@DocuShare{DMTN-028,
+  author = {Maria T. Patterson},
+  title = "{Benchmarking a distribution system for LSST alerts}",
+    year = 2018,
+  handle = {DMTN-028},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-028.lsst.io},
+}
+
+@DocuShare{DMTN-031,
+  author = {Christopher B. Morrison},
+  title = "{Pessimistic Pattern Matching for LSST}",
+    year = 2018,
+  handle = {DMTN-031},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-031.lsst.io},
 }
 
 @DocuShare{DMTN-035,
@@ -1145,6 +1719,470 @@
      url = {https://dmtn-048.lsst.io},
 }
 
+@DocuShare{DMTN-049,
+  author = {M. L. Graham},
+   title = "{LSST DRP (Level 2) Catalog Photometric Redshifts}",
+    year = 2018,
+  handle = {DMTN-049},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-049.lsst.io},
+}
+
+@DocuShare{DMTN-056,
+   author = {Pim Schellart and  Jim Bosch},
+    title = {Butler Redesign Strawman},
+     year = 2018,
+    month = jan,
+   handle = {DMTN-056},
+      url = {http://DMTN-056.lsst.io}
+}
+
+@DocuShare{DMTN-057,
+  author = {Krzysztof Findeisen},
+   title = "{Integrating Verification Metrics into the LSST DM Stack}",
+    year = 2017,
+   month = oct,
+  handle = {DMTN-057},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-057.lsst.io},
+}
+
+@DocuShare{DMTN-059,
+  author = {Michelle Gower},
+   title = "{Batch Processing Facade Prototype 0.1}",
+    year = 2017,
+   month = sep,
+  handle = {DMTN-059},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-059.lsst.io},
+}
+
+@DocuShare{DMTN-064,
+  author = {J. Meyers},
+   title = "{Hyper Suprime-Cam donut analysis}",
+    year = 2018,
+   month = jan,
+  handle = {DMTN-064},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-064.lsst.io},
+}
+
+@DocuShare{DMTN-065,
+  author = {M. Graham and M. Juri\'{c} and K.-T. Lim and E. Bellm},
+   title = "{Data Management and LSST Special Programs}",
+    year = 2018,
+  handle = {DMTN-065},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-065.lsst.io},
+}
+
+
+
+@DocuShare{DMTN-069,
+  author = {A. C. Becker and K. Simon Krughoff and A. Connolly},
+   title = "{Report on Winter 2014 Production: Image Differencing}",
+    year = 2014,
+   month = may,
+  handle = {DMTN-069},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-069.lsst.io},
+}
+
+@DocuShare{DMTN-070,
+  author = {A. C. Becker and K. Simon Krughoff and A. Connolly},
+   title = "{Report on Summer 2014 Production: Analysis of DCR}",
+    year = 2014,
+   month = oct,
+  handle = {DMTN-070},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-070.lsst.io},
+}
+
+@DocuShare{DMTN-072,
+  author = {William O'Mullane and John Swinbank},
+   title = "{Cloud technical assesment}",
+    year = 2018,
+   month = jan,
+  handle = {DMTN-072},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-072.lsst.io},
+}
+
+@DocuShare{DMTN-074,
+  author = { John Swinbank },
+   title = "{DM QA Status \& Plans}",
+    year = 2018,
+   month = jun,
+  handle = {DMTN-074},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-074.lsst.io},
+}
+
+@DocuShare{DMTN-077,
+  author = { K. Suberlak and C. Slater and \v{Z}. Ivezi\'c},
+   title = "{LSST Fall 2017 Crowded Fields Testing}",
+    year = 2018,
+   month = apr,
+  handle = {DMTN-077},
+    note = {LSST Data Management Technical Note},
+     url = {https:/wdmtn-077.lsst.io},
+}
+
+@DocuShare{DMTN-078,
+  author = {William O'Mullane and John Swinbank and Margaret Gelemann and Xiuqin Wu and Fritz Mueller},
+   title = "{Potential proofs of concept for Google Cloud}",
+    year = 2018,
+   month = apr,
+  handle = {DMTN-078},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-078.lsst.io},
+}
+
+@DocuShare{DMTN-080,
+  author = {AlSayyad, Y.},
+   title = "{Coaddition Artifact Rejection and \texttt{CompareWarp}}",
+    year = 2018,
+   month = jul,
+  handle = {DMTN-080},
+    note = {LSST Data Management Technical Note, draft version},
+     url = {https://dmtn-080.lsst.io},
+}
+
+@DocuShare{DMTN-081,
+  author = {Maria T. Patterson},
+   title = "{Deploying an alert stream mini-broker prototype}",
+    year = 2018,
+   month = jun,
+  handle = {DMTN-081},
+    note = {LSST Data Management Technical Note, draft version},
+     url = {https://dmtn-081.lsst.io},
+}
+
+@DocuShare{DMTN-085,
+  author = {Bellm,~E.C. and Chiang,~H.-F. and Fausti,~A. and Krughoff,~K.S.  and MacArthur,~L.A.M and Morton,~T.D. and Swinbank,~J.D. and Roby,~T.},
+   title = "{QA Strategy Working Group Report}",
+    year = 2018,
+   month = jul,
+  handle = {DMTN-085},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-085.lsst.io},
+}
+
+@DocuShare{DMTN-086,
+  author = {C. Slater},
+   title = "{Next-to-the-Database Processing Use Cases}",
+    year = 2018,
+   month = jul,
+  handle = {DMTN-086},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-086.lsst.io},
+}
+
+@DocuShare{DMTN-087,
+  author = {Juric, M. and Jones, L.},
+   title = "{Proposed Modifications to Solar System Processing and Data Products}",
+    year = 2018,
+   month = jun,
+  handle = {DMTN-087},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-087.lsst.io},
+}
+
+@DocuShare{DMTN-088,
+  author = {Hsin-Fang Chiang Margaret W. G. Johnson},
+   title = "{As-is HSC Reprocessing}",
+    year = 2018,
+   month = jul,
+  handle = {DMTN-088},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-088.lsst.io},
+}
+
+@DocuShare{DMTN-091,
+  author = {Michael Wood-Vasey and Eric Bellm and Jim Bosch and Jeff Carlin and Zeljko Ivezic and Lauren MacArthur and Colin Slater},
+   title = "{Test Datasets for Scientific Performance Monitoring}",
+    year = 2019,
+   month = nov,
+  handle = {DMTN-091},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-091.lsst.io},
+}
+
+@DocuShare{DMTN-093,
+  author = {Maria Patterson and Eric Bellm and John Swinbank},
+   title = "{Design of the LSST Alert Distribution System}",
+    year = 2018,
+   month = oct,
+  handle = {DMTN-093},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-093.lsst.io},
+}
+
+@DocuShare{DMTN-094,
+  author = {Brian Van Klaveren},
+   title = "{LSP Authentication Design}",
+    year = 2019,
+   month = apr,
+  handle = {DMTN-094},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-094.lsst.io},
+}
+
+@DocuShare{DMTN-096,
+  author = {William O'Mullane and John Swinbank and Leanne Guy and Amanda Bauer},
+   title = "{Implementation and impacts of DM scope options}",
+    year = 2018,
+   month = nov,
+  handle = {DMTN-096},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-096.lsst.io},
+}
+
+@DocuShare{DMTN-098,
+  author = {Krzysztof Findeisen},
+   title = "{Metrics Measurement Framework Design}",
+    year = 2018,
+   month = dec,
+  handle = {DMTN-098},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-098.lsst.io},
+}
+
+@DocuShare{DMTN-102,
+  author = {M.~L.~Graham and E.~C.~Bellm and L.~P.~Guy and C.~T.~Slater G.~P.~Dubois-Felsmann and the DM System Science Team},
+   title = "{LSST Alerts: Key Numbers}",
+    year = 2019,
+   month = feb,
+  handle = {DMTN-102},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-102.lsst.io},
+}
+
+@DocuShare{DMTN-104,
+   author = { Gabriele Comoretto },
+    title = {Data Management Detailed Product Tree},
+     year = 2020,
+    month = apr,
+   handle = {DMTN-104},
+      url = {http://DMTN-104.lsst.io } }
+
+@DocuShare{DMTN-106,
+   author = { Gabriele Comoretto },
+    title = {DM Release Process},
+     year = 2019,
+    month = jun,
+   handle = {DMTN-106},
+      url = {http://DMTN-106.lsst.io } }
+
+@DocuShare{DMTN-107,
+  author = {M.~L.~Graham and E.~C.~Bellm and C.~T.~Slater  and the DM System Science Team},
+   title = "{Options for Alert Production in  LSST Operations Year 1}",
+    year = 2019,
+   month = mar,
+  handle = {DMTN-107},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-107.lsst.io},
+}
+
+@DocuShare{DMTN-109,
+   author = {Siegfried Eggl},
+    title = "{LSST discovery estimates for Solar System Objects}",
+     year = 2019,
+    month = jul,
+   handle = {DMTN-109},
+      url = {http://dmtn-109.lsst.io}
+}
+
+@DocuShare{DMTN-110,
+   author = {Gabriele Comoretto},
+    title = "{Conda Environment Proposal for Science Pipelines}",
+     year = 2019,
+    month = jun,
+   handle = {DMTN-110},
+      url = {http://dmtn-110.lsst.io}
+}
+
+@DocuShare{DMTN-111,
+   author = {Kian-Tat Lim },
+    title = { DM Usage in Observatory Operations},
+     year = 2019,
+    month = apr,
+   handle = {DMTN-111},
+      url = {http://dmtn-111.lsst.io}
+}
+
+@DocuShare{DMTN-113,
+   author = {Andy Salnikov},
+    title = {Performance of RDBMS-based PPDB implementation},
+     year = 2019,
+    month = mar,
+   handle = {DMTN-113},
+      url = {http://dmtn-113.lsst.io}
+}
+
+@DocuShare{DMTN-114,
+   author = {Kian-Tat Lim and Leanne Guy and Hsin-Fang Chiang},
+    title = {LSST + Amazon Web Services Proof of Concept},
+     year = 2019,
+    month = apr,
+   handle = {DMTN-114},
+      url = {http://dmtn-114.lsst.io}
+}
+
+@DocuShare{DMTN-119,
+   author = {William O'Mullane and Robert Gruendl and Robert Blum},
+    title = {Report on Operations Rehersal \#1},
+     year = 2019,
+    month = 05,
+   handle = {DMTN-119},
+      url = {http://dmtn-119.lsst.io}
+}
+
+@DocuShare{DMTN-121,
+   author = {Ian Sullivan},
+    title = "{Impact of variable seeing on DCR coadd generation}",
+     year = 2019,
+    month = jun,
+   handle = {DMTN-121},
+      url = {http://dmtn-121.lsst.io}
+}
+
+@DocuShare{DMTN-122,
+   author = { Michelle Gower and Kian-Tat Lim },
+    title = {Data Backbone Design},
+     year = 2019,
+    month = 07,
+   handle = {DMTN-122},
+      url = {http://DMTN-122.lsst.io } }
+
+@DocuShare{DMTN-123,
+   author = { Michelle Gower and Kian-Tat Lim },
+    title = {Batch Production Services Design},
+     year = 2019,
+    month = 08,
+   handle = {DMTN-123},
+      url = {http://DMTN-123.lsst.io } }
+
+@DocuShare{DMTN-125,
+   author = {Kian-Tat Lim},
+    title = "{Google Cloud Engagement Results}",
+     year = 2019,
+    month = jul,
+   handle = {DMTN-125},
+      url = {http://dmtn-125.lsst.io}
+}
+@DocuShare{DMTN-136,
+   author = {      Gregory Dubois-Felsmann },
+    title = {LSST Science Platform Portal Aspect Design and Maintenance Manual},
+     year = 2019,
+    month = nov,
+   handle = {DMTN-136},
+      url = {http://DMTN-136.lsst.io } }
+
+@DocuShare{DMTN-135,
+   author = { Michelle Butler and  Kian Tat Lim and  William O'Mullane },
+    title = {DM sizing model and purchase plan for the remainder of construction.},
+     year = 2019,
+    month = nov,
+   handle = {DMTN-135},
+      url = {http://DMTN-135.lsst.io } }
+
+@DocuShare{DMTN-137,
+   author = { Hsin-Fang Chiang and Dino Bektesevic and the AWS-PoC team },
+    title = {AWS Proof of Concept Project Report},
+     year = 2020,
+    month = jan,
+   handle = {DMTN-137},
+      url = {http://DMTN-137.lsst.io } }
+
+@DocuShare{DMTN-140,
+  author = {G. Comoretto and L. P. Guy and others},
+   title = "{Documentation Automation for the Verification and Validation of Rubin Observatory Software}",
+    year = 2020,
+    month = dec,
+  handle = {DMTN-140},
+     url = {https://dmtn-140.lsst.io/} }
+
+@DocuShare{DMTN-150,
+   author = { Kian-Tat Lim },
+    title = {LSST + Google Cloud Proof of Concept},
+     year = 2020,
+    month = may,
+   handle = {DMTN-150},
+      url = {http://DMTN-150.lsst.io } }
+
+@DocuShare{DMTN-157,
+   author = {Hsin-Fang Chiang and K-T Lim},
+    title = "{Report of Google Cloud Proof of Concept}",
+     year = 2020,
+   handle = {DMTN-157},
+     note = {LSST Data Management Technical Note},
+      url = {https://dmtn-157.lsst.io},
+ }
+
+@DocuShare{DMTN-163,
+ author = {Russ Allbery},
+  title = "{Encryption of Rubin Observatory data}",
+   year = 2020,
+ handle = {DMTN-163},
+   note = {LSST Data Management Technical Note},
+    url = {https://dmtn-163.lsst.io},
+}
+
+@DocuShare{DMTN-165,
+ author = {Eric Bellm and Spencer Nelson},
+  title = "{A Hybrid Notification and Alert Retrieval Service}",
+   year = 2020,
+ handle = {DMTN-165},
+   note = {LSST Data Management Technical Note},
+    url = {https://dmtn-165.lsst.io},
+}
+
+@DocuShare{DMTN-169,
+ author = {Russ Allbery},
+  title = "{A model for Butler registry access control document}",
+   year = 2020,
+ handle = {DMTN-169},
+   note = {LSST Data Management Technical Note},
+    url = {https://dmtn-169.lsst.io},
+}
+
+@DocuShare{DMTN-176,
+   author = {Tim Jenness},
+    title = "{A client/server Butler}",
+     year = 2021,
+   handle = {DMTN-176},
+     note = {LSST Data Management Technical Note},
+      url = {https://dmtn-176.lsst.io},
+ }
+
+@DocuShare{DMTN-177,
+  author = {Tim Jenness},
+   title = "{Limiting Registry Access During Workflow Execution}",
+    year = 2021,
+  handle = {DMTN-177},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-177.lsst.io},
+}
+
+@DocuShare{DMTN-178,
+   author = { Gabriele Comoretto },
+    title = {Docsteady Usecases for Rubin Observatory Construction},
+     year = 2021,
+    month = jan,
+   handle = {DMTN-178},
+      url = {http://DMTN-178.lsst.io } }
+}
+
+@DocuShare{DMTN-182,
+  author = {Russ Allbery},
+   title = "{Possible authorization approaches for Butler}",
+    year = 2021,
+  handle = {DMTN-182},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-182.lsst.io},
+}
+
 @DocuShare{DMTR-11,
   author = {Frossie Economou and John Swinbank and Jim Bosch
             and Simon Krughoff},
@@ -1194,6 +2232,13 @@
   handle = {DMTR-16},
 }
 
+@DocuShare{DMTR-17,
+  author = {Vaikunth~Thukral},
+   title = "{Qserv Fall 17 Large Scale Tests/KPMs}",
+    year = 2018,
+   month = jun,
+  handle = {DMTR-17},
+}
 @DocuShare{DMTR-21,
   author = {Jacek Becla and K-T Lim and Daniel Wang},
    title = "{Early (pre-2013) Large-Scale Qserv Tests}",
@@ -1210,6 +2255,282 @@
   handle = {DMTR-22},
 }
 
+@DocuShare{DMTR-31,
+  author = {H.-F. Chiang and G. Daues and S. Thrush and {The NCSA Team}},
+   title = "{S17B HSC PDR1 Reprocessing Report}",
+    year = 2017,
+   month = aug,
+  handle = {DMTR-31},
+}
+
+@DocuShare{DMTR-41,
+  author = {S. Krughoff and  J. Wood-Vasey},
+   title = "{Characterization Metric Report: Science Pipelines Version 14.0}",
+    year = 2017,
+   month = oct,
+  handle = {DMTR-41},
+}
+
+@DocuShare{DMTR-51,
+  author = {Bosch, J. and Chiang, H.-F. and Gower, M. and Kowalik, M. and Morton, T. and Swinbank, J.D.},
+   title = {LDM-503-02 (HSC Reprocessing) Test Report},
+    year = 2017,
+   month = dec,
+  handle = {DMTR-51},
+}
+
+@DocuShare{DMTR-52,
+  author = {Gregory P. Dubois-Felsmann},
+   title = {LDM-503-01 (WISE Data Loaded in PDAC) Test Report },
+    year = 2018,
+   month = may,
+  handle = {DMTR-52},
+}
+
+@DocuShare{DMTR-53,
+  author = {Bellm, E.C. and Swinbank, J.D.},
+   title = {LDM-503-03 (Alert Generation) Test Report},
+    year = 2018,
+   month = jan,
+  handle = {DMTR-53},
+}
+
+@DocuShare{DMTR-61,
+  author = {Butler, M. and Parsons, J.},
+   title = {LDM-503-04 and LDM-503-04b (Raw Image Archiving Service) Test Report},
+    year = 2018,
+   month = jun,
+  handle = {DMTR-61},
+}
+
+@DocuShare{DMTR-71,
+  author = {Fritz Mueller},
+   title = "{LVV-P46 (2018 qserv large scale testing) Test Plan and Report}",
+    year = 2019,
+   month = jul,
+  handle = {DMTR-71},
+}
+
+@DocuShare{DMTR-82,
+  author = {Vinicius Arcanjo and Albert Astudillo and Jeronimo Bezerra and Luis Corral and Julio Ibarra and Sandra Jaque and Jeff Kantor and Matt Kollross and Ron Lambert},
+   title = "{Network Bandwidth Tests between Chile and the United States}",
+    year = 2018,
+   month = jun,
+  handle = {DMTR-82},
+}
+
+@DocuShare{DMTR-91,
+  author = {Bellm, E.C.},
+   title = {LDM-503-05 (Alert Distribution Validation) Test Report},
+    year = 2018,
+   month = jul,
+  handle = {DMTR-91},
+}
+
+@DocuShare{DMTR-111,
+  author = {Swinbank, J.D.},
+   title = "{LDM-503-09a (Science pipelines fall 2018 release) Test Plan and Report}",
+    year = 2018,
+   month = nov,
+  handle = {DMTR-111},
+}
+
+@DocuShare{DMTR-112,
+  author = {Swinbank, J.D.},
+   title = "{LDM-503-07 (Camera data processing) Test Plan and Report}",
+    year = 2018,
+   month = nov,
+  handle = {DMTR-112},
+}
+@DocuShare{DMTR-102,
+   author = {Michelle Butler},
+    title = {LDM-503-8b (Small Scale CCOB Data Access) Test Plan and Report},
+     year = 2019,
+    month = jul,
+   handle = {DMTR-102},
+      url = {http://dmtr-102.lsst.io}
+}
+
+@DocuShare{DMTR-121,
+   author = {Michelle Butler},
+    title = {LDM-503-8 (Spectrograph Data Acquisition) Test Plan and Report},
+     year = 2019,
+    month = jul,
+   handle = {DMTR-121},
+      url = {http://dmtr-121.lsst.io }
+}
+
+@DocuShare{DMTR-141,
+   author = {G. Comoretto on behalf of Science Pipelines Team},
+    title = {Characterization Metric Report: Science Pipelines Version 18.0.0},
+     year = 2019,
+    month = jul,
+   handle = {DMTR-141},
+      url = {http://dmtr-141.lsst.io }
+}
+
+@DocuShare{DMTR-151,
+  author = {Jeff Kantor},
+   title = "{LVV-P47 (Summit - base network integration) Test Plan and Report}",
+    year = 2019,
+   month = feb,
+  handle = {DMTR-151},
+}
+
+@DocuShare{DMTR-161,
+   author = {Dubois-Felsmann, G.},
+    title = {LDM-503-10a: LSP with Authentication and TAP Test Plan and Report},
+     year = 2020,
+    month = jan,
+   handle = {DMTR-161},
+}
+
+@DocuShare{DMTR-171,
+   author = {Butler, M.},
+    title = {LDM-503-6: ComCam Interface Verification Readiness Test Plan and Report},
+     year = 2020,
+    month = aug,
+   handle = {DMTR-171},
+}
+
+@DocuShare{DMTR-181,
+   author = {Butler, M.},
+    title = {LDM-503-10: DAQ Validation Test Plan and Report},
+     year = 2020,
+    month = aug,
+   handle = {DMTR-181},
+}
+
+@DocuShare{DMTR-182,
+   author = {Butler, M.},
+    title = {LDM-503-10b: Large Scale CCOB Data Access Test Plan and Report},
+     year = 2019,
+    month = oct,
+   handle = {DMTR-182},
+     note = {Draft version},
+      url = {http://dmtr-182.lsst.io }
+}
+
+@DocuShare{DMTR-191,
+   author = {J. Carlin and  K. S. Krughoff and  G. Comoretto},
+    title = {Characterization Metric Report: Science Pipelines Version 19.0.0},
+     year = 2019,
+    month = dec,
+   handle = {DMTR-191},
+      url = {http://dmtr-191.lsst.io }
+}
+
+@DocuShare{DMTR-192,
+   author = {Swinbank, J.},
+    title = {LDM-503-11b: Science Pipelines Fall 2019 Release Test Plan and Report},
+     year = 2019,
+    month = nov,
+   handle = {DMTR-191},
+     note = {Draft version},
+      url = {http://dmtr-191.lsst.io }
+}
+
+@DocuShare{DMTR-201,
+  author = {Fritz Mueller},
+   title = "{LVV-P65 Fall 2019 Pipelines Release Acceptance Test Campaign Test Plan and Report}",
+    year = 2020,
+   month = mar,
+  handle = {DMTR-201},
+}
+
+@DocuShare{DMTR-211,
+  author = {Gregory Dubois-Felsmann},
+   title = "{DM-SUIT-8: Portal Integrated with Workspace Test Plan and Report}",
+    year = 2020,
+   month = may,
+  handle = {DMTR-211},
+}
+
+@DocuShare{DMTR-231,
+   author = {Gruendl, R.},
+    title = {LDM-503-11a: ComCam OPS Readiness Test Plan and Report},
+     year = 2020,
+    month = nov,
+   handle = {DMTR-231},
+}
+
+@DocuShare{DMTR-251,
+   author = {Jeff Carlin},
+    title = {Characterization Metric Report: Science Pipelines Version 20.0.0},
+     year = 2020,
+    month = jun,
+   handle = {DMTR-251},
+      url = {http://dmtr-251.lsst.io }
+}
+
+@DocuShare{DMTR-261,
+   author = {Carlin, J.},
+    title = {Science Pipelines Release 20.0.0 Acceptance Test Campaign Test Plan and Report},
+     year = 2020,
+    month = aug,
+   handle = {DMTR-261},
+}
+
+@DocuShare{DMTR-271,
+   author = { Robert Gruendl },
+    title = {LDM-GEN3: Gen 3 Butler Acceptance Testing Test Plan and Report},
+     year = 2021,
+    month = 05,
+   handle = {DMTR-271},
+      url = {http://DMTR-271.lsst.io } }
+
+@DocuShare{DMTR-301,
+ author = { Gregory Dubois-Felsmann },
+  title = {milestone-dp01},
+   year = 2021,
+  month = Mar,
+ handle = {DMTR-301},
+    url = {https://dmtr-301.lsst.io } }
+
+ @DocuShare{DMTR-302,
+    author = { Yusra AlSayyad },
+     title = {LDM-503-13a},
+      year = 2021,
+     month = Apr,
+    handle = {DMTR-302},
+       url = {https://dmtr-302.lsst.io } }
+
+@DocuShare{SQR-006,
+  author = {Jonathan Sick},
+   title = {The LSST the Docs Platform for Continuous Documentation Delivery},
+    year = 2017,
+   month = jul,
+  handle = {SQR-006},
+     url = {https://sqr-006.lsst.io},
+}
+
+@DocuShare{SQR-009,
+  author = {Angelo Fausti},
+   title = {The SQuaSH metrics dashboard},
+    year = 2017,
+   month = dec,
+  handle = {SQR-009},
+     url = {https://sqr-009.lsst.io},
+}
+
+@DocuShare{SQR-016,
+  author = { Frossie Economou },
+   title = "{Stack release playbook}",
+    year = 2018,
+   month = dec,
+  handle = {SQR-016},
+     url = {https://sqr-016.lsst.io},
+}
+
+@DocuShare{SQR-017,
+  author = {John Parejko and Jonathan Sick},
+   title = "{Validation Metrics Framework}",
+    year = 2017,
+   month = feb,
+  handle = {SQR-017},
+     url = {https://sqr-017.lsst.io},
+}
+
 @DocuShare{SQR-018,
   author = {Frossie Economou},
    title = "{Investigations into JupyterLab as a basis for the LSST Science Platform}",
@@ -1218,3 +2539,437 @@
   handle = {SQR-018},
      url = {https://sqr-018.lsst.io},
 }
+
+@DocuShare{SQR-019,
+  author = {Jonathan Sick and Angelo Fausti},
+   title = "{LSST Verification Framework API Demonstration}",
+    year = 2018,
+   month = apr,
+  handle = {SQR-019},
+     url = {https://sqr-019.lsst.io},
+}
+
+@DocuShare{PSTN-003,
+   author = {William O'Mullane and  Fritz Mueller },
+    title = {Discussion of Object vs. Source table queries and data distribution},
+     year = 2019,
+    month = jun,
+   handle = {PSTN-003},
+      url = {http://PSTN-003.lsst.io } }
+
+@DocuShare{PSTN-005,
+   author = {Jeff Barr},
+    title = {Overview of the LSST Telescope},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-005},
+      url = {http://PSTN-005.lsst.io } }
+
+
+@DocuShare{PSTN-006,
+   author = {Sandrine Thomas},
+    title = {Performance of the LSST Telescope},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-006},
+      url = {http://PSTN-006.lsst.io } }
+
+
+@DocuShare{PSTN-007,
+   author = {Lynne Jones},
+    title = {The LSST Scheduler Overview and Performance},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-007},
+      url = {http://PSTN-007.lsst.io } }
+
+
+@DocuShare{PSTN-008,
+   author = {Bo Xin},
+    title = {Performance of the LSST Active Optics System},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-008},
+      url = {http://PSTN-008.lsst.io } }
+
+
+@DocuShare{PSTN-009,
+   author = {Tiago Ribeiro},
+    title = {LSST Observing System Software Architecture},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-009},
+      url = {http://PSTN-009.lsst.io } }
+
+
+@DocuShare{PSTN-010,
+   author = {Justin Wolfe},
+    title = {LSST Camera Optics},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-010},
+      url = {http://PSTN-010.lsst.io } }
+
+
+@DocuShare{PSTN-011,
+   author = {Chris Stubbs},
+    title = {LSST Camera Rafts},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-011},
+      url = {http://PSTN-011.lsst.io } }
+
+
+@DocuShare{PSTN-012,
+   author = {Steve Ritz},
+    title = {LSST Camera Cryostat},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-012},
+      url = {http://PSTN-012.lsst.io } }
+
+
+@DocuShare{PSTN-013,
+   author = {Ralph Schindler},
+    title = {LSST Camera Refrigeration},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-013},
+      url = {http://PSTN-013.lsst.io } }
+
+
+@DocuShare{PSTN-014,
+   author = {Steve Ritz},
+    title = {LSST Camera Body and Mechanisms},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-014},
+      url = {http://PSTN-014.lsst.io } }
+
+
+@DocuShare{PSTN-015,
+   author = {Mark Huffer and Tony Johnson},
+    title = {LSST Camera Control System and DAQ},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-015},
+      url = {http://PSTN-015.lsst.io } }
+
+
+@DocuShare{PSTN-016,
+   author = {Tim Bond and Aaron Rodman},
+    title = {LSST Camera Integration and Tests},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-016},
+      url = {http://PSTN-016.lsst.io } }
+
+
+@DocuShare{PSTN-017,
+   author = {William O'Mullane and  Leanne Guy},
+    title = {Overview of LSST Data Management},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-017},
+      url = {http://PSTN-017.lsst.io } }
+
+
+@DocuShare{PSTN-018,
+   author = {Michelle Butler},
+    title = {LSST Data Facility},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-018},
+      url = {http://PSTN-018.lsst.io } }
+
+
+@DocuShare{PSTN-019,
+   author = {Tim Jenness},
+    title = {LSST Data Management Software System},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-019},
+      url = {http://PSTN-019.lsst.io } }
+
+
+@DocuShare{PSTN-020,
+   author = {Jim Bosch},
+    title = {LSST Data Release Processing},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-020},
+      url = {http://PSTN-020.lsst.io } }
+
+
+@DocuShare{PSTN-021,
+   author = {Eric Bellm},
+    title = {LSST Prompt Data Products},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-021},
+      url = {http://PSTN-021.lsst.io } }
+
+
+@DocuShare{PSTN-022,
+   author = {Frossie Economou and  Gregory Dubois-Felsmann},
+    title = {LSST Science Platform},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-022},
+      url = {http://PSTN-022.lsst.io } }
+
+
+@DocuShare{PSTN-023,
+   author = {Simon Krughoff},
+    title = {LSST Data Management Quality Assurance and Reliability Engineering},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-023},
+      url = {http://PSTN-023.lsst.io } }
+
+
+@DocuShare{PSTN-024,
+   author = {},
+    title = {LSST Data Management System Verification and Validation},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-024},
+      url = {http://PSTN-024.lsst.io } }
+
+
+@DocuShare{PSTN-025,
+   author = {Mario Juric},
+    title = {LSST Moving Object Processing},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-025},
+      url = {http://PSTN-025.lsst.io } }
+
+
+@DocuShare{PSTN-026,
+   author = {Robert Lupton},
+    title = {LSST Calibration Strategy and Pipelines},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-026},
+      url = {http://PSTN-026.lsst.io } }
+
+
+@DocuShare{PSTN-027,
+   author = {Patrick Ingraham},
+    title = {Performance of the LSST Calibration Systems},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-027},
+      url = {http://PSTN-027.lsst.io } }
+
+
+@DocuShare{PSTN-028,
+   author = {Patrick Ingraham},
+    title = {Atmospheric Properties with the LSST Auxiliary Telescope},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-028},
+      url = {http://PSTN-028.lsst.io } }
+
+
+@DocuShare{PSTN-029,
+   author = {Amanda Bauer},
+    title = {Overview of LSST Education and Public Outreach},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-029},
+      url = {http://PSTN-029.lsst.io } }
+
+
+@DocuShare{PSTN-030,
+   author = {Ardis Herrold},
+    title = {LSST Formal Education Program},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-030},
+      url = {http://PSTN-030.lsst.io } }
+
+
+@DocuShare{PSTN-031,
+   author = {Amanda Bauer},
+    title = {LSST EPO: The User Feedback},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-031},
+      url = {http://PSTN-031.lsst.io } }
+
+
+@DocuShare{PSTN-004,
+   author = {Chuck Claver},
+    title = {LSST Observatory System Operations Readiness Report},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-004},
+      url = {http://PSTN-004.lsst.io } }
+
+
+@DocuShare{PSTN-032,
+   author = {Bo Xin},
+    title = {Performance of Delivered LSST System},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-032},
+      url = {http://PSTN-032.lsst.io } }
+
+
+@DocuShare{PSTN-033,
+   author = {Chuck Claver},
+    title = {Active Optics Performance with LSST Commissiong Camera},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-033},
+      url = {http://PSTN-033.lsst.io } }
+
+
+@DocuShare{PSTN-034,
+   author = {Chuck Claver},
+    title = {LSST Active Optics Performance with the LSST Science Camera},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-034},
+      url = {http://PSTN-034.lsst.io } }
+
+
+@DocuShare{PSTN-035,
+   author = {Brian Stalder},
+    title = {Integration, Test and Commissioning Results from LSST Commissiong Camera},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-035},
+      url = {http://PSTN-035.lsst.io } }
+
+
+@DocuShare{PSTN-036,
+   author = {Kevin Reil},
+    title = {LSST Camera Instrumental Signature Characterization, Calibration and Removal},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-036},
+      url = {http://PSTN-036.lsst.io } }
+
+
+@DocuShare{PSTN-037,
+   author = {Patrick Hascal},
+    title = {Installation and Performance of the LSST Camera Refrigeration System},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-037},
+      url = {http://PSTN-037.lsst.io } }
+
+
+@DocuShare{PSTN-038,
+   author = {Andy Connolly},
+    title = {Science Validation of LSST Alert Processing},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-038},
+      url = {http://PSTN-038.lsst.io } }
+
+
+@DocuShare{PSTN-039,
+   author = {Keith Bechtol},
+    title = {Science Validation of LSST Data Release Processing},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-039},
+      url = {http://PSTN-039.lsst.io } }
+
+
+@DocuShare{PSTN-040,
+   author = {Michael Reuter},
+    title = {Tracking of LSST System Performance with Continuous Integration Methods},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-040},
+      url = {http://PSTN-040.lsst.io } }
+
+
+@DocuShare{PSTN-041,
+   author = {Chuck Claver},
+    title = {The LSST Science Platform as a Commissioning Tool},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-041},
+      url = {http://PSTN-041.lsst.io } }
+
+
+@DocuShare{PSTN-042,
+   author = {Chuck Claver},
+    title = {Commissioning Science Data Quality Analysis Tools, Methods and Procedures},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-042},
+      url = {http://PSTN-042.lsst.io } }
+
+
+@DocuShare{PSTN-043,
+   author = {Lynne Jones},
+    title = {Performance Verification of the LSST Survey Scheduler},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-043},
+      url = {http://PSTN-043.lsst.io } }
+
+@DocuShare{PSTN-046,
+   author = {Steve Ritz},
+    title = {LSST Camera Design and Delivered Performance},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-046},
+      url = {http://PSTN-046.lsst.io } }
+
+
+@DocuShare{ITTN-006,
+   author = {Cristian Silva and Iain Goodenow and William O'Mullane},
+    title = {Rubin Observatory IT mangegement plan},
+     year = 2020,
+    month = may,
+   handle = {ITTN-006},
+      url = {http://ITTN-006.lsst.io } }
+
+@DocuShare{ITTN-002,
+   author = {Joshua Hoblitt},
+    title = {LSST On-Prem Deployment Platform},
+     year = 2019,
+    month = sep,
+   handle = {ITTN-002},
+      url = {http://ITTN-002.lsst.io } }
+
+@DocuShare{LSE-160,
+  author =       {Brian Selvy},
+  title =        "{Verification and Validation Process}",
+  year =         2013,
+  month =        sep,
+  handle =       {LSE-160},
+}
+
+@DocuShare{document-14789,
+  author =       {Jeff Kantor},
+  title =        "{LSST Long-Haul Networks (LHN) End-to-end Test Plan}",
+  year =         2014,
+  month =        sep,
+  handle =       {document-14789},
+}
+
+@DocuShare{RTN-001,
+   author = {William O'Mullane},
+    title = {Data Preview 0: Definition and planning.},
+     year = 2020,
+    month = Jun,
+   handle = {RTN-001},
+      url = {http://RTN-001.lsst.io } }
+
+
+@DocuShare{RTN-013,
+       author = { William O'Mullane and Richard Dubois },
+        title = {Near term workflow for pre-operations with PanDA},
+         year = 2020,
+        month = dec,
+       handle = {RTN-013},
+          url = {http://RTN-013.lsst.io } }

--- a/project_templates/technote_rst/testn-000/lsstbib/refs.bib
+++ b/project_templates/technote_rst/testn-000/lsstbib/refs.bib
@@ -1,5 +1,4 @@
-% General reference not found in ADS
-% Do not put books in this file
+% General reference not found in ADS % Do not put books in this file
 %
 
 @ARTICLE{1991.Spyak.OpticalEngineering,
@@ -1996,6 +1995,29 @@ adsnote = {Provided by the SAO/NASA Astrophysics Data System}
   url = {http://xrootd.org/presentations/xpaper3_cut_journal.pdf},
 }
 
+@ARTICLE{Thain:2005:Condor,
+  author = "Douglas Thain and Todd Tannenbaum and Miron Livny",
+  url = {https://research.cs.wisc.edu/htcondor/doc/condor-practice.pdf},
+  title = "Distributed computing in practice: the Condor experience.",
+  journal = "Concurrency - Practice and Experience",
+  volume = 17,
+  number = "2-4",
+  year = 2005,
+  pages = "323-356",
+}
+
+@ARTICLE{Deelman:2015:Pegasus,
+  author = {Ewa Deelman and Karan Vahi and Gideon Juve and Mats Rynge and Scott Callaghan and Philip J Maechling and Rajiv Mayani and Weiwei Chen and Ferreira da Silva, Rafael and Miron Livny and Kent Wenger},
+  url = {http://pegasus.isi.edu/publications/2014/2014-fgcs-deelman.pdf},
+  title = {Pegasus: a Workflow Management System for Science Automation},
+  journal = {Future Generation Computer Systems},
+  volume = 46,
+  pages = {17-35},
+  year = 2015,
+  note = {Funding Acknowledgements: NSF ACI SDCI 0722019, NSF ACI SI2-SSI 1148515 and NSF OCI-1053575},
+  doi = {10.1016/j.future.2014.10.008}
+}
+
 @INPROCEEDINGS{VanderPlas:6382200,
   author = {J. VanderPlas and A. J. Connolly and {\v Z}. {Ivezi{\'c}} and A. Gray},
   booktitle = {2012 Conference on Intelligent Data Understanding},
@@ -2122,3 +2144,132 @@ adsnote = {Provided by the SAO/NASA Astrophysics Data System}
   address = {New York, NY, USA},
   keywords = {benchmarks, mapreduce, parallel database},
 }
+
+@article{Hohenkerk1985,
+	abstract = {The bending of a light ray as it passes through the atmosphere is cal- culated by numerical evaluation of the refraction integral, expressed in a form that avoids numerical difficulties at a zenith angle of 90 ◦ . A polytropic model atmosphere is used, and the parameters of the model are varied in order to determine the effect on the computed refraction value. Good agreement is obtained with other evaluations of refraction for zenith angles up to 75 ◦ . Beyond that it becomes sen- sitive to the values of the parameters used, particularly the pressure, temperature, temperature lapse rate, and wavelength of the light ray. Good agreement is obtained with other evaluations provided the same parameter values are used.},
+	author = {Hohenkerk, C.Y. and Sinclair, A.T.},
+  journal = {NAO Technical Note},
+	volume = {63},
+	title = {The computation of angular atmospheric refraction at large zenith angles},
+	year = {1985},
+  url = {http://astro.ukho.gov.uk/data/tn/naotn63.pdf},
+}
+
+@article{soton271449,
+  volume = {27},
+  number = {6},
+  month = {June},
+  author = {Luc Moreau and Ben Clifford and Juliana Freire and Joe Futrelle and Yolanda Gil and Paul Groth and Natalia Kwasnikowska and Simon Miles and Paolo Missier and Jim Myers and Beth Plale and Yogesh Simmhan and Eric Stephan and Jan Van den Bussche},
+  title = {The Open Provenance Model core specification (v1.1)},
+  journal = {Future Generation Computer Systems},
+  pages = {743--756},
+  year = {2011},
+  keywords = {provenance, representation, inter-operability},
+  url = {https://eprints.soton.ac.uk/271449/},
+  abstract = {The Open Provenance Model is a model of provenance that is designed to meet the following requirements: (1) To allow provenance information to be exchanged between systems, by means of a compatibility layer based on a shared provenance model. (2) To allow developers to build and share tools that operate on such a provenance model. (3) To define provenance in a precise, technology-agnostic manner. (4) To support a digital representation of provenance for any 'thing', whether produced by computer systems or not. (5) To allow multiple levels of description to coexist. (6) To define a core set of rules that identify the valid inferences that can be made on provenance representation. This document contains the specification of the Open Provenance Model (v1.1) resulting from a community-effort to achieve inter-operability in the Provenance Challenge series.}
+}
+
+@article{JSSv059i10,
+   author = {Hadley Wickham},
+   title = {Tidy Data},
+   journal = {Journal of Statistical Software, Articles},
+   volume = {59},
+   number = {10},
+   year = {2014},
+   keywords = {},
+   abstract = {A huge amount of effort is spent cleaning data to get it ready for analysis, but there has been little research on how to make data cleaning as easy and effective as possible. This paper tackles a small, but important, component of data cleaning: data tidying. Tidy datasets are easy to manipulate, model and visualize, and have a specific structure: each variable is a column, each observation is a row, and each type of observational unit is a table. This framework makes it easy to tidy messy datasets because only a small set of tools are needed to deal with a wide range of un-tidy datasets. This structure also makes it easier to develop tidy tools for data analysis, tools that both input and output tidy datasets. The advantages of a consistent data structure and matching tools are demonstrated with a case study free from mundane data manipulation chores.},
+   issn = {1548-7660},
+   pages = {1--23},
+   doi = {10.18637/jss.v059.i10},
+   url = {https://www.jstatsoft.org/v059/i10}
+}
+
+@article{doi:10.1002/2013JD020914,
+   author = {Ziemke, J. R. and Olsen, M. A. and Witte, J. C. and Douglass, A. R. and Strahan, S. E. and Wargan, K. and Liu, X. and Schoeberl, M. R. and Yang, K. and Kaplan, T. B. and Pawson, S. and Duncan, B. N. and Newman, P. A. and Bhartia, P. K. and Heney, M. K.},
+   title = {Assessment and applications of NASA ozone data products derived from Aura OMI/MLS satellite measurements in context of the GMI chemical transport model},
+   journal = {Journal of Geophysical Research: Atmospheres},
+   volume = {119},
+   number = {9},
+   pages = {5671--5699},
+   keywords = {ozone},
+   doi = {10.1002/2013JD020914},
+   url = {https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1002/2013JD020914},
+   eprint = {https://agupubs.onlinelibrary.wiley.com/doi/pdf/10.1002/2013JD020914},
+   abstract = {AbstractMeasurements from the Ozone Monitoring Instrument (OMI) and Microwave Limb Sounder (MLS), both on board the Aura spacecraft, have been used to produce daily global maps of column and profile ozone since August 2004. Here we compare and evaluate three strategies to obtain daily maps of tropospheric and stratospheric ozone from OMI and MLS measurements: trajectory mapping, direct profile retrieval, and data assimilation. Evaluation is based on an assessment that includes validation using ozonesondes and comparisons with the Global Modeling Initiative (GMI) chemical transport model. We investigate applications of the three ozone data products from near-decadal and interannual time scales to day-to-day case studies. Interannual changes in zonal mean tropospheric ozone from all of the products in any latitude range are of the order 1–2 Dobson units while changes (increases) over the 8 year Aura record investigated vary by 2–4 Dobson units. It is demonstrated that all of the ozone products can measure and monitor exceptional tropospheric ozone events including major forest fire and pollution transport events. Stratospheric ozone during the Aura record has several anomalous interannual events including split stratospheric warmings in the Northern Hemisphere extratropics that are well captured using the data assimilation ozone profile product. Data assimilation with continuous daily global coverage and vertical ozone profile information is the best of the three strategies at generating a global tropospheric and stratospheric ozone product for science applications.}
+}
+
+@article{doi:10.1175/JCLI-D-16-0609.1,
+  author = {Randles, C. A. and da Silva, A. M. and Buchard, V. and Colarco, P. R. and Darmenov, A. and Govindaraju, R. and Smirnov, A. and Holben, B. and Ferrare, R. and Hair, J. and Shinozuka, Y. and Flynn, C. J.},
+   title = {The MERRA-2 Aerosol Reanalysis, 1980 Onward. Part I: System Description and Data Assimilation Evaluation},
+ journal = {Journal of Climate},
+  volume = {30},
+  number = {17},
+   pages = {6823--6850},
+    year = {2017},
+     doi = {10.1175/JCLI-D-16-0609.1},
+     URL = {https://doi.org/10.1175/JCLI-D-16-0609.1},
+  eprint = {https://doi.org/10.1175/JCLI-D-16-0609.1}
+}
+
+
+
+
+@INPROCEEDINGS{bbcp,
+    author = {Andrew Hanushevsky and Artem Trunov and Les Cottrell},
+    title = {Peer-to-Peer Computing for Secure High Performance Data Copying},
+    booktitle = {In Proc. of the 2001 Int. Conf. on Computing in High Energy and Nuclear Physics (CHEP 2001), Beijng},
+    year = {2001},
+    url  = {http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.132.2288&rep=rep1}
+}
+
+@article{abell2009lsst,
+  title={LSST Science Book, Version 2.0},
+  author={Abell, P.~A. and Allison, J. and Anderson, S.~F. and Andrew, J.~R. and Angel, J.~R.~P. and Armus, L. and Arnett, D. and Asztalos, S.~J. and Axelrod, T.~S. and Bailey, S and others},
+  archivePrefix = "arXiv",
+  eprint = {0912.0201},
+  year={2009}
+}
+
+@ARTICLE{nist800-60,
+  author =       {Kevin Stine and  Rich Kissel and William C. Barker and Jim Fahlsing and  Jessica Gulick},
+  title =        {Volume I: Guide for Mapping Types of Information and Information Systems to Security Categories },
+  journal =      {INFORMATION SECURITY},
+  publisher =    {National Institute of Standards and Technology Special Publications},
+  year =         {2008},
+  month =        {aug},
+  volume =       {31},
+  handle =       {NIST.800-60},
+  URL=           {https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-60v1r1.pdf}
+}
+
+@ARTICLE{osn,
+author = {N{\'u}\~{n}ez-Corrales, Santiago and Cragin, Melissa and White (Wonders), Alainna and Norman, Michael and Kickpatrick, Christine and Mchenry, Kenton and Ahalt, Stanley and Shanley, Lea and Goodhue, John and Simmel, Derek and Szalay, Alex},
+year = {2018},
+month = {11},
+pages = {},
+title = {Open Storage Network: national data storage cyberinfrastructure for the 21st},
+doi = {10.13140/RG.2.2.31543.78249}
+}
+
+@MISC{NIST.SP.800-171,
+publisher  = {National Institute of Standards and Technology },
+author = {RON ROSS and PATRICK VISCUSO and GARY GUISSANIE and KELLEY DEMPSEY and MARK RIDDLE},
+title = {Special Publication 800-171, Protecting Controlled Unclassified Information in Nonfederal Systems and Organizations},
+month  = {feb},
+year = {2020},
+handle = {NIST.SP.800-171},
+url = {https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171r2.pdf}
+
+}
+
+@MISC{FIPS200,
+publisher = {National Institute of Standards and Technology Federal Information Processing Standards},
+author = {Computer Security Division},
+title = {Publication 200, Minimum Security Requirements for Federal Information and Information Systems},
+month  = {mar},
+year = {2006},
+handle = {NIST.FIPS.200},
+url = {https://doi.org/10.6028/NIST.FIPS.200}
+}
+
+

--- a/project_templates/technote_rst/testn-000/lsstbib/refs_ads.bib
+++ b/project_templates/technote_rst/testn-000/lsstbib/refs_ads.bib
@@ -14,6 +14,19 @@
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+@ARTICLE{1967ApOpt...6...51O,
+   author = {{Owens}, J.~C.},
+    title = "{Optical refractive index of air: dependence on pressure, temperature, and composition}",
+  journal = {\ao},
+     year = 1967,
+    month = jan,
+   volume = 6,
+    pages = {51},
+      doi = {10.1364/AO.6.000051},
+   adsurl = {http://adsabs.harvard.edu/abs/1967ApOpt...6...51O},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
 @INPROCEEDINGS{1978moas.coll..197L,
   author =       {{Lindegren}, L.},
   title =        "{Photoelectric astrometry - A comparison of methods
@@ -42,6 +55,20 @@
                   {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1982A\%26A...114..278B&db_key=AST},
   adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
                   System}
+}
+
+@ARTICLE{1982PASP...94..715F,
+   author = {{Filippenko}, A.~V.},
+    title = "{The importance of atmospheric differential refraction in spectrophotometry}",
+  journal = {\pasp},
+ keywords = {Atmospheric Refraction, Instrument Errors, Spectrophotometry, Telescopes, Ambient Temperature, Atmospheric Pressure, Error Analysis, Optimization, Pressure Effects, Temperature Effects},
+     year = 1982,
+    month = aug,
+   volume = 94,
+    pages = {715-721},
+      doi = {10.1086/131052},
+   adsurl = {http://adsabs.harvard.edu/abs/1982PASP...94..715F},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @ARTICLE{1983A&A...120..197S,
@@ -178,6 +205,20 @@
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+@ARTICLE{1991PASP..103.1033K,
+   author = {{Krisciunas}, K. and {Schaefer}, B.~E.},
+    title = "{A model of the brightness of moonlight}",
+  journal = {\pasp},
+ keywords = {Astronomical Models, Atmospheric Scattering, Lunar Luminescence, Sky Brightness, Charge Coupled Devices, Reflected Waves, Scattering Functions},
+     year = 1991,
+    month = sep,
+   volume = 103,
+    pages = {1033-1039},
+      doi = {10.1086/132921},
+   adsurl = {http://adsabs.harvard.edu/abs/1991PASP..103.1033K},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
 @ARTICLE{1994A&A...287..338N,
   author =       {{Nordstroem}, B. and {Latham}, D.~W. and {Morse},
                   J.~A. and ƒ {Milone}, A.~A.~E. and {Kurucz},
@@ -255,9 +296,6 @@
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-
-% Rickman:2001
-
 @ARTICLE{1995A&A...304...61L,
   author =       {{Lindegren}, L.},
   title =        "{Estimating the external accuracy of HIPPARCOS
@@ -273,8 +311,6 @@
                   {http://cdsads.u-strasbg.fr/abs/1995A\%26A...304...61L},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
-
-% Soffel:et:al:2003
 
 @INPROCEEDINGS{1995ASPC...77..429R,
   author =       {{Rose}, J. and {Akella}, R. and {Binegar}, S. and
@@ -296,8 +332,6 @@
                   System}
 }
 
-% Klioner:Soffel:2000
-
 @ARTICLE{1996A&A...305..146G,
   author =       {{Gunn}, A.~G. and {Hall}, J.~C. and {Lockwood},
                   G.~W. and {Doyle}, J.~G.  },
@@ -315,6 +349,21 @@
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+@ARTICLE{1996AJ....112.2872T,
+   author = {{Tomaney}, A.~B. and {Crotts}, A.~P.~S.},
+    title = "{Expanding the Realm of Microlensing Surveys with Difference Image Photometry}",
+  journal = {\aj},
+   eprint = {astro-ph/9610066},
+ keywords = {GRAVITATIONAL LENSING, SURVEYS},
+     year = 1996,
+    month = dec,
+   volume = 112,
+    pages = {2872},
+      doi = {10.1086/118228},
+   adsurl = {http://adsabs.harvard.edu/abs/1996AJ....112.2872T},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
 @ARTICLE{1996PASP..108..851S,
    author = {{Stetson}, P.~B.},
     title = "{On the Automatic Determination of Light-Curve Parameters for Cepheid Variables}",
@@ -326,6 +375,20 @@
     pages = {851},
       doi = {10.1086/133808},
    adsurl = {http://adsabs.harvard.edu/abs/1996PASP..108..851S},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{1996PASP..108.1051S,
+   author = {{Stone}, R.~C.},
+    title = "{An Accurate Method for Computing Atmospheric Refraction}",
+  journal = {\pasp},
+ keywords = {ATMOSPHERIC EFFECTS, METHODS: NUMERICAL},
+     year = 1996,
+    month = nov,
+   volume = 108,
+    pages = {1051-1058},
+      doi = {10.1086/133831},
+   adsurl = {http://adsabs.harvard.edu/abs/1996PASP..108.1051S},
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
@@ -344,8 +407,6 @@
                   System}
 }
 
-% Klioner:2004
-
 @ARTICLE{1997A&A...327.1253M,
   author =       {{Moreno}, F. and {Molina}, A. and {Ortiz}, J.~L.},
   title =        "{The 1993 south equatorial belt revival and other
@@ -360,8 +421,6 @@
   adsurl =       {http://adsabs.harvard.edu/abs/1997A\%26A...327.1253M},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
-
-% Klioner:2003
 
 @INPROCEEDINGS{1997ESASP.402..767D,
   author =       {{de Felice}, F. and {Lattanzi}, M.~G. and
@@ -381,9 +440,6 @@
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-
-% Klioner:Peip:2003
-
 @PROCEEDINGS{1997ESASP1200.....P,
   title =        "{The HIPPARCOS and TYCHO catalogues. Astrometric and
                   photometric star catalogues derived from the ESA
@@ -399,9 +455,6 @@
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-
-% deFelice:2004
-
 @ARTICLE{1997SSRv...81..201V,
   author =       {{van Leeuwen}, F.},
   title =        "{The HIPPARCOS Mission}",
@@ -416,9 +469,6 @@
                   System}
 }
 
-
-% defelice1
-
 @INPROCEEDINGS{1997hipp.conf..467E,
   author =       {{Eyer}, L. and {Grenon}, M.},
   title =        "{Photometric {V}ariability in the {HR} {D}iagram}",
@@ -430,8 +480,6 @@
   adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
                   System}
 }
-
-% vecchia2
 
 @INPROCEEDINGS{1997hipp.conf..621G,
   author =       {{Gomez}, A.~E. and {Grenier}, S. and {Udry}, S. and
@@ -447,8 +495,6 @@
   adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
                   System}
 }
-
-% bini1
 
 @ARTICLE{1998A&A...332.1133D,
   author =       {{de Felice}, F. and {Lattanzi}, M.~G. and
@@ -466,8 +512,6 @@
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-% defelice2
-
 @ARTICLE{1998A&A...340..309M,
   author =       {{Makarov}, V.~V.},
   title =        "{Absolute measurements of trigonometric parallaxes
@@ -482,8 +526,6 @@
                   System}
 }
 
-% Lattanzi-2005:a
-
 @ARTICLE{1998A&AS..130...65L,
   author =       {{Lejeune}, T. and {Cuisinier}, F. and {Buser}, R.},
   title =        "{A standard stellar library for evolutionary
@@ -496,6 +538,20 @@
   pages =        {65-75},
   adsurl =
                   {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1998A\%26AS..130...65L&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+@ARTICLE{1998ARA&A..36...99K,
+  author =       {{Kovalevsky}, J.},
+  title =        "{First Results from HIPPARCOS}",
+  journal =      {\araa},
+  year =         1998,
+  volume =       36,
+  pages =        {99-130},
+  doi =          {10.1146/annurev.astro.36.1.99},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1998ARA\%26A..36...99K&db_key=AST},
   adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
                   System}
 }
@@ -515,22 +571,6 @@
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-@ARTICLE{1998ARA&A..36...99K,
-  author =       {{Kovalevsky}, J.},
-  title =        "{First Results from HIPPARCOS}",
-  journal =      {\araa},
-  year =         1998,
-  volume =       36,
-  pages =        {99-130},
-  doi =          {10.1146/annurev.astro.36.1.99},
-  adsurl =
-                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1998ARA\%26A..36...99K&db_key=AST},
-  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
-                  System}
-}
-
-% Sozzetti-2001:a
-
 @ARTICLE{1998MNRAS.298..387D,
   author =       {{Dehnen}, W. and {Binney}, J.~J.},
   title =        "{Local stellar kinematics from HIPPARCOS data}",
@@ -548,8 +588,6 @@
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-% paper:gaiascience
-
 @ARTICLE{1998PASP..110..863P,
   author =       {{Pickles}, A.~J.},
   title =        "{A Stellar Spectral Flux Library: 1150-25000 {\AA}}",
@@ -564,7 +602,20 @@
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-% Lattanzi-2000:a
+@INPROCEEDINGS{1998SPIE.3355...36C,
+   author = {{Cuby}, J.~G. and {Bottini}, D. and {Picat}, J.~P.},
+    title = "{Handling atmospheric dispersion and differential refraction effects in large-field multiobject spectroscopic observations}",
+booktitle = {Optical Astronomical Instrumentation},
+     year = 1998,
+   series = {\procspie},
+   volume = 3355,
+   editor = {{D'Odorico}, S.},
+    month = jul,
+    pages = {36-47},
+      doi = {10.1117/12.316769},
+   adsurl = {http://adsabs.harvard.edu/abs/1998SPIE.3355...36C},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
 
 @ARTICLE{1999A&AS..137..521M,
   author =       {{Munari}, U. and {Tomasella}, L.},
@@ -582,7 +633,25 @@
                   System}
 }
 
-% kov1
+@ARTICLE{1999ApJ...521..602A,
+   author = {{Alcock}, C. and {Allsman}, R.~A. and {Alves}, D. and {Axelrod}, T.~S. and
+	{Becker}, A.~C. and {Bennett}, D.~P. and {Cook}, K.~H. and {Drake}, A.~J. and
+	{Freeman}, K.~C. and {Griest}, K. and {Lehner}, M.~J. and {Marshall}, S.~L. and
+	{Minniti}, D. and {Peterson}, B.~A. and {Pratt}, M.~R. and {Quinn}, P.~J. and
+	{Stubbs}, C.~W. and {Sutherland}, W. and {Tomaney}, A. and {Vandehei}, T. and
+	{Welch}, D.~L. and {MACHO Collaboration}},
+    title = "{Difference Image Analysis of Galactic Microlensing. I. Data Analysis}",
+  journal = {\apj},
+   eprint = {astro-ph/9903215},
+ keywords = {ATMOSPHERIC EFFECTS, GALAXY: STELLAR CONTENT, COSMOLOGY: GRAVITATIONAL LENSING, TECHNIQUES: IMAGE PROCESSING, Atmospheric Effects, Galaxy: Stellar Content, Cosmology: Gravitational Lensing, Techniques: Image Processing},
+     year = 1999,
+    month = aug,
+   volume = 521,
+    pages = {602-612},
+      doi = {10.1086/307567},
+   adsurl = {http://adsabs.harvard.edu/abs/1999ApJ...521..602A},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
 
 @ARTICLE{1999BaltA...8...57O,
   author =       {{O'Mullane}, W. and {Lindegren}, L.},
@@ -597,7 +666,6 @@
                   System}
 }
 
-% Pourbaix-2002:b
 
 @ARTICLE{1999MNRAS.310..645W,
   author =       {{Wilkinson}, M.~I. and {Evans}, N.~W.},
@@ -614,9 +682,6 @@
                   System}
 }
 
-
-% Smolcic-2004:a
-
 @ARTICLE{2000A&A...354..522M,
   author =       {{Mignard}, F.},
   title =        "{Local galactic kinematics from Hipparcos proper
@@ -632,8 +697,6 @@
   adsurl =       {http://adsabs.harvard.edu/abs/2000A\%26A...354..522M},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
-
-% Bretagnon1988
 
 @ARTICLE{2000A&A...355L..27H,
   author =       {{H{\o}g}, E. and {Fabricius}, C. and {Makarov},
@@ -652,7 +715,6 @@
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-% Bretagnon1982
 
 @ARTICLE{2000A&AS..143...33B,
   author =       {{Bonnarel}, F. and {Fernique}, P. and
@@ -674,7 +736,20 @@
 }
 
 
-% Simon1983
+@ARTICLE{2000AJ....119.2472A,
+   author = {{Auer}, L.~H. and {Standish}, E.~M.},
+    title = "{Astronomical Refraction: Computational Method for All Zenith Angles}",
+  journal = {\aj},
+ keywords = {METHODS: NUMERICAL},
+     year = 2000,
+    month = may,
+   volume = 119,
+    pages = {2472-2474},
+      doi = {10.1086/301325},
+   adsurl = {http://adsabs.harvard.edu/abs/2000AJ....119.2472A},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
 
 @INPROCEEDINGS{2000ASPC..203...71E,
   author =       {{Eyer}, L. and {Cuypers}, J.},
@@ -692,7 +767,6 @@
                   System}
 }
 
-% astro:besanconmodel
 
 @INPROCEEDINGS{2000ASPC..216..419O,
   author =       {{O'Mullane}, W. and {Hazell}, A. and {Bennett},
@@ -709,7 +783,6 @@
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-% astro:extinctionmodel
 
 @INPROCEEDINGS{2000ASSL..252..201G,
   author =       {{Groom}, D.~E. and {Eberhard}, P.~H. and {Holland},
@@ -727,6 +800,7 @@
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+
 @ARTICLE{2000ApJ...536..571B,
    author = {{Ben{\'{\i}}tez}, N.},
     title = "{Bayesian Photometric Redshift Estimation}",
@@ -741,6 +815,7 @@
    adsurl = {http://adsabs.harvard.edu/abs/2000ApJ...536..571B},
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
+
 
 @ARTICLE{2000MNRAS.317..211L,
   author =       {{Lattanzi}, M.~G. and {Spagna}, A. and {Sozzetti},
@@ -759,7 +834,6 @@
                   System}
 }
 
-% gomez1997
 
 @ARTICLE{2000MNRAS.319..657H,
   author =       {{Helmi}, A. and {de Zeeuw}, P.~T.},
@@ -777,7 +851,7 @@
                   System}
 }
 
-% cu6:skew_technique
+
 
 @ARTICLE{2000PhRvD..62b4019K,
   author =       {{Klioner}, S.~A. and {Soffel}, M.~H.},
@@ -795,8 +869,6 @@
   adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
                   System}
 }
-
-% koval98
 
 @INPROCEEDINGS{2000SPIE.4013..453G,
   author =       {{Gilmore}, G.~F. and {de Boer}, K.~S. and {Favata},
@@ -819,8 +891,6 @@
                   System}
 }
 
-% paper:hipquality
-
 @ARTICLE{2001A&A...369..339P,
   author =       {{Perryman}, M.~A.~C. and {de Boer}, K.~S. and
                   {Gilmore}, G. and {H{\o}g}, E. and {Lattanzi},
@@ -841,8 +911,6 @@
                   System}
 }
 
-% paper:hipreproc
-
 @ARTICLE{2001A&A...373..336D,
   author =       {{de Felice}, F. and {Bucciarelli}, B. and
                   {Lattanzi}, M.~G. and {Vecchiato}, A.},
@@ -860,8 +928,6 @@
   adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
                   System}
 }
-
-% fvl97
 
 @ARTICLE{2001A&A...373L..21S,
   author =       {{Sozzetti}, A. and {Casertano}, S. and {Lattanzi},
@@ -881,7 +947,6 @@
                   System}
 }
 
-% paper:RBBdL06
 
 @INPROCEEDINGS{2001ASPC..225..201O,
   author =       {{O'Mullane}, W. and {Luri}, X.},
@@ -898,7 +963,6 @@
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-% helmi2000
 
 @ARTICLE{2001ApJ...556..181D,
   author =       {{Drimmel}, R. and {Spergel}, D.~N.},
@@ -917,8 +981,6 @@
                   System}
 }
 
-
-% pickles1998
 
 @ARTICLE{2001IAUTr..24B....R,
   author =       {{Rickman}, H.},
@@ -966,6 +1028,7 @@ keywords =       {Instrumentation: Detectors,
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+
 @INPROCEEDINGS{2001misk.conf..631K,
    author = {{Kunszt}, P.~Z. and {Szalay}, A.~S. and {Thakar}, A.~R.},
     title = "{The Hierarchical Triangular Mesh}",
@@ -991,7 +1054,6 @@ booktitle = {Mining the Sky},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-% wilkinson1999
 
 @ARTICLE{2002A&A...385..686P,
   author =       {{Pourbaix}, D.},
@@ -1011,7 +1073,22 @@ booktitle = {Mining the Sky},
                   System}
 }
 
-% wilkinson2004a
+
+@ARTICLE{2002AJ....123..583B,
+   author = {{Bernstein}, G.~M. and {Jarvis}, M.},
+    title = "{Shapes and Shears, Stars and Smears: Optimal Measurements for Weak Lensing}",
+  journal = {\aj},
+   eprint = {astro-ph/0107431},
+ keywords = {Cosmology: Gravitational Lensing, Methods: Data Analysis, Techniques: Image Processing},
+     year = 2002,
+    month = feb,
+   volume = 123,
+    pages = {583-618},
+      doi = {10.1086/338085},
+   adsurl = {http://adsabs.harvard.edu/abs/2002AJ....123..583B},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
 
 @INPROCEEDINGS{2002ASPC..259..160E,
   author =       {{Eyer}, L. and {Blake}, C.},
@@ -1029,7 +1106,6 @@ booktitle = {Mining the Sky},
                   System}
 }
 
-% wilkinson2004b
 
 @ARTICLE{2002AcA....52..241E,
   author =       {{Eyer}, L.},
@@ -1046,20 +1122,6 @@ booktitle = {Mining the Sky},
                   System}
 }
 
-@ARTICLE{2002AJ....123..583B,
-   author = {{Bernstein}, G.~M. and {Jarvis}, M.},
-    title = "{Shapes and Shears, Stars and Smears: Optimal Measurements for Weak Lensing}",
-  journal = {\aj},
-   eprint = {astro-ph/0107431},
- keywords = {Cosmology: Gravitational Lensing, Methods: Data Analysis, Techniques: Image Processing},
-     year = 2002,
-    month = feb,
-   volume = 123,
-    pages = {583-618},
-      doi = {10.1086/338085},
-   adsurl = {http://adsabs.harvard.edu/abs/2002AJ....123..583B},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
 
 @ARTICLE{2002Ap&SS.280...21B,
   author =       {{Bailer-Jones}, C.~A.~L.},
@@ -1075,7 +1137,6 @@ booktitle = {Mining the Sky},
                   System}
 }
 
-% paper:tdi
 
 @INPROCEEDINGS{2002EAS.....2..107M,
   author =       {{Mignard}, F.},
@@ -1090,6 +1151,7 @@ booktitle = {Mining the Sky},
   adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
                   System}
 }
+
 
 @ARTICLE{2002Icar..158..106B,
   author =       {{Bus}, S.~J. and {Binzel}, R.~P.},
@@ -1107,7 +1169,6 @@ booktitle = {Mining the Sky},
                   System}
 }
 
-% defelice3
 
 @ARTICLE{2002Icar..158..146B,
   author =       {{Bus}, S.~J. and {Binzel}, R.~P.},
@@ -1125,7 +1186,6 @@ booktitle = {Mining the Sky},
                   System}
 }
 
-% busonero1
 
 @INPROCEEDINGS{2002SPIE.4836..333S,
   author =       {{Szalay}, A.~S. and {Gray}, J. and {VandenBerg}, J.},
@@ -1145,7 +1205,6 @@ booktitle = {Mining the Sky},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-% gai2
 
 @ARTICLE{2002cs........2013S,
   author =       {{Szalay}, A.~S. and {Gray}, J. and {Thakar},
@@ -1165,7 +1224,6 @@ booktitle = {Mining the Sky},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-% paper:jfc06QSO
 
 @ARTICLE{2003A&A...399..337V,
   author =       {{Vecchiato}, A. and {Lattanzi}, M.~G. and
@@ -1186,7 +1244,6 @@ booktitle = {Mining the Sky},
                   System}
 }
 
-% paper:gtr04QSO
 
 @ARTICLE{2003A&A...409..523R,
   author =       {{Robin}, A.~C. and {Reyl{\'e}}, C. and
@@ -1206,7 +1263,6 @@ booktitle = {Mining the Sky},
                   System}
 }
 
-% paper:le02QSO
 
 @ARTICLE{2003A&A...410.1063K,
   author =       {{Klioner}, S.~A. and {Peip}, M.},
@@ -1225,7 +1281,6 @@ booktitle = {Mining the Sky},
                   System}
 }
 
-% munari1999
 
 @ARTICLE{2003A&A...412..105M,
   author =       {{Moniez}, M.},
@@ -1244,7 +1299,6 @@ booktitle = {Mining the Sky},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-% paper:sozzrev
 
 @ARTICLE{2003AJ....125.1580K,
   author =       {{Klioner}, S.~A.},
@@ -1261,7 +1315,6 @@ booktitle = {Mining the Sky},
                   System}
 }
 
-% paper:c1bc1m
 
 @ARTICLE{2003AJ....126.2687S,
   author =       {{Soffel}, M. and {Klioner}, S.~A. and {Petit},
@@ -1290,7 +1343,6 @@ booktitle = {Mining the Sky},
                   System}
 }
 
-% brettetal2004
 
 @INPROCEEDINGS{2003ASPC..295..261M,
   author =       {{Miller}, III, W.~W. and {Sontag}, C. and {Rose},
@@ -1310,7 +1362,7 @@ booktitle = {Mining the Sky},
                   System}
 }
 
-% evansbelokurov2005
+
 
 @INPROCEEDINGS{2003ASPC..298..199B,
   author =       {{Bailer-Jones}, C.~A.~L.},
@@ -1328,7 +1380,6 @@ booktitle = {Mining the Sky},
                   System}
 }
 
-% eyergrenon1997
 
 @ARTICLE{2003CQGra..20.4695B,
   author =       {{Bini}, D. and {Crosta}, M.~T. and {de Felice}, F.},
@@ -1346,7 +1397,6 @@ booktitle = {Mining the Sky},
                   System}
 }
 
-% eyercuypers2000
 
 @ARTICLE{2003MNRAS.342..151V,
   author =       {{Vande Putte}, D. and {Smith}, R.~C. and {Hawkins},
@@ -1366,7 +1416,6 @@ booktitle = {Mining the Sky},
                   System}
 }
 
-% eyerblake2002
 
 @ARTICLE{2004A&A...419..385B,
   author =       {{Bailer-Jones}, C.~A.~L.},
@@ -1385,7 +1434,6 @@ booktitle = {Mining the Sky},
                   System}
 }
 
-% eyer2005
 
 @INPROCEEDINGS{2004ASPC..314..293Y,
   author =       {{Yasuda}, N. and {Mizumoto}, Y. and {Ohishi}, M. and
@@ -1408,7 +1456,6 @@ booktitle = {Mining the Sky},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-% eyerblake2005
 
 @INPROCEEDINGS{2004ASPC..314..376W,
   author =       {{Wieprecht}, E. and {Brumfit}, J. and {Bakker},
@@ -1433,7 +1480,6 @@ booktitle = {Mining the Sky},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-% eyermignard2005
 
 @INPROCEEDINGS{2004ASPC..314..585P,
   author =       {{Plante}, R. and {Greene}, G. and {Hanisch}, R. and
@@ -1454,8 +1500,6 @@ booktitle = {Mining the Sky},
 }
 
 
-% eyer2006a
-
 @ARTICLE{2004ApJ...607..580D,
   author =       {{de Felice}, F. and {Crosta}, M.~T. and {Vecchiato},
                   A. and {Lattanzi}, M.~G. and {Bucciarelli}, B.},
@@ -1475,7 +1519,6 @@ booktitle = {Mining the Sky},
                   System}
 }
 
-% eyer2006b
 
 @ARTICLE{2004ApJ...615L.141S,
   author =       {{Smol{\v c}i{\'c}}, V. and {Ivezi{\'c}}, {\v Z}. and
@@ -1500,7 +1543,6 @@ booktitle = {Mining the Sky},
                   System}
 }
 
-% protopapasetal2006
 
 @ARTICLE{2004ApJS..155..257R,
   author =       {{Richards}, G.~T. and {Nichol}, R.~C. and {Gray},
@@ -1527,7 +1569,6 @@ booktitle = {Mining the Sky},
                   System}
 }
 
-% moniez2003
 
 @ARTICLE{2004MNRAS.353..369B,
   author =       {{Brett}, D.~R. and {West}, R.~G. and {Wheatley},
@@ -1547,7 +1588,6 @@ booktitle = {Mining the Sky},
                   System}
 }
 
-% cu8:cbjparis
 
 @ARTICLE{2004PhR...400..209K,
   author =       {{Kopeikin}, S. and {Vlasov}, I.},
@@ -1567,7 +1607,6 @@ booktitle = {Mining the Sky},
                   System}
 }
 
-% cu8:cbjhfd
 
 @ARTICLE{2004PhRvD..69l4001K,
   author =       {{Klioner}, S.~A.},
@@ -1588,20 +1627,18 @@ booktitle = {Mining the Sky},
                   System}
 }
 
-% cu8:cbjvilnius
+%conf:gaiaeurospaceproject
 
 @INPROCEEDINGS{2004SPIE.5494..529B,
   author =       {{Baccaro}, S. and {Cecilia}, A. and {Di Sarcina},
                   I. and {Piegari}, A.~M.  },
   title =        "{Optical coating behavior under y irradiation for
                   space applications}",
-  booktitle =    {Society of Photo-Optical Instrumentation Engineers
-                  (SPIE) Conference Series},
+  booktitle =    {Optical Fabrication, Metrology, and Material Advancements for Telescopes},
   year =         2004,
-  series =       {Presented at the Society of Photo-Optical
-                  Instrumentation Engineers (SPIE) Conference},
+  series =       {\procspie},
   volume =       5494,
-  editor =       "{E.~Atad-Ettedgui \& P.~Dierickx}",
+  editor =       "{E.~Atad-Ettedgui and P.~Dierickx}",
   month =        sep,
   pages =        {529-535},
   doi =          {10.1117/12.553602},
@@ -1609,7 +1646,6 @@ booktitle = {Mining the Sky},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-% cu8:baselmethod
 
 @INPROCEEDINGS{2004SPIE.5495...23J,
   author =       {{Jessen}, N.~C. and {N{\o}rgaard-Nielsen}, H.~U. and
@@ -1617,13 +1653,11 @@ booktitle = {Mining the Sky},
                   J. and {Hastings}, P.},
   title =        "{The CFRP primary structure of the MIRI instrument
                   onboard the James Webb Space Telescope}",
-  booktitle =    {Society of Photo-Optical Instrumentation Engineers
-                  (SPIE) Conference Series},
+  booktitle =    {Astronomical Structures and Mechanisms Technology},
   year =         2004,
-  series =       {Presented at the Society of Photo-Optical
-                  Instrumentation Engineers (SPIE) Conference},
+  series =       {\procspie},
   volume =       5495,
-  editor =       "{J.~Antebi \& D.~Lemke}",
+  editor =       "{J.~Antebi and D.~Lemke}",
   month =        sep,
   pages =        {23-30},
   doi =          {10.1117/12.550023},
@@ -1631,7 +1665,6 @@ booktitle = {Mining the Sky},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-% mpclass:bus2002b
 
 @INPROCEEDINGS{2004SPIE.5497..461G,
   author =       {{Gardiol}, D. and {Loreggia}, D. and {Mannu}, S. and
@@ -1639,10 +1672,8 @@ booktitle = {Mining the Sky},
                   {Lattanzi}, M.~G.},
   title =        "{End-to-end optomechanical simulation for
                   high-precision global astrometry}",
-  booktitle =    {Modeling and Systems Engineering for Astronomy.
-                  Edited by Craig, Simon C.; Cullum, Martin J.
-                  Proceedings of the SPIE, Volume 5497, pp. 461-470
-                  (2004).},
+  booktitle =    {Modeling and Systems Engineering for Astronomy},
+  series =       {\procspie},
   year =         2004,
   editor =       {{Craig}, S.~C. and {Cullum}, M.~J.},
   month =        sep,
@@ -1654,7 +1685,20 @@ booktitle = {Mining the Sky},
                   System}
 }
 
-% mpclass:bus2002a
+@INPROCEEDINGS{2004SPIE.5497..290B,
+   author = {{Britton}, M.~C.},
+    title = "{Arroyo}",
+booktitle = {Modeling and Systems Engineering for Astronomy},
+     year = 2004,
+   series = {\procspie},
+   volume = 5497,
+   editor = {{Craig}, S.~C. and {Cullum}, M.~J.},
+    month = sep,
+    pages = {290-300},
+      doi = {10.1117/12.552316},
+   adsurl = {http://adsabs.harvard.edu/abs/2004SPIE.5497..290B},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
 
 @ARTICLE{2005A&A...438..745B,
   author =       {{Bastian}, U. and {Biermann}, M.},
@@ -1672,8 +1716,6 @@ booktitle = {Mining the Sky},
                   System}
 }
 
-% mpclass:Zellner
-
 @ARTICLE{2005A&A...439..791V,
   author =       {{van Leeuwen}, F. and {Fantino}, E.},
   title =        "{A new reduction of the raw Hipparcos data}",
@@ -1689,8 +1731,6 @@ booktitle = {Mining the Sky},
   adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
                   System}
 }
-
-% cu3:Bruen
 
 @ARTICLE{2005A&A...439..805V,
   author =       {{van Leeuwen}, F.},
@@ -1709,7 +1749,19 @@ booktitle = {Mining the Sky},
                   System}
 }
 
-% conf:gaiascience
+@INPROCEEDINGS{2005ASPC..338..134C,
+   author = {{Chambers}, K.~C.},
+    title = "{Astrometry with Pan-STARRS and PS1: Pushing the limits of atmospheric refraction, dispersion, and extinction corrections for wide field imaging.}",
+booktitle = {Astrometry in the Age of the Next Generation of Large Telescopes},
+     year = 2005,
+   series = {Astronomical Society of the Pacific Conference Series},
+   volume = 338,
+   editor = {{Seidelmann}, P.~K. and {Monet}, A.~K.~B.},
+    month = oct,
+    pages = {134},
+   adsurl = {http://adsabs.harvard.edu/abs/2005ASPC..338..134C},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
 
 @ARTICLE{2005ApJ...622..759G,
   author =       {{G{\'o}rski}, K.~M. and {Hivon}, E. and {Banday},
@@ -1729,8 +1781,6 @@ booktitle = {Mining the Sky},
   doi =          {10.1086/427976}
 }
 
-%conf:gaiaeurospaceproject
-
 @PROCEEDINGS{2005ESASP.576.....T,
   title =        "{The Three-Dimensional Universe with Gaia}",
   booktitle =    {The Three-Dimensional Universe with Gaia},
@@ -1743,8 +1793,6 @@ booktitle = {Mining the Sky},
   adsurl =       {http://adsabs.harvard.edu/abs/2005ESASP.576.....T},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
-
-% conf:inpopephem
 
 @INPROCEEDINGS{2005ESASP.576...29L,
   author =       {{Lindegren}, L.},
@@ -1760,8 +1808,6 @@ booktitle = {Mining the Sky},
   adsurl =       {http://adsabs.harvard.edu/abs/2005ESASP.576...29L},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
-
-% cu5:photometry-paris
 
 @INPROCEEDINGS{2005ESASP.576...67D,
   author =       {{de Bruijne}, J.~H.~J. and {Lammers}, U. and
@@ -2415,6 +2461,21 @@ booktitle = {Mining the Sky},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+@ARTICLE{2006astro.ph..9591A,
+   author = {{Albrecht}, A. and {Bernstein}, G. and {Cahn}, R. and {Freedman}, W.~L. and
+        {Hewitt}, J. and {Hu}, W. and {Huth}, J. and {Kamionkowski}, M. and
+        {Kolb}, E.~W. and {Knox}, L. and {Mather}, J.~C. and {Staggs}, S. and
+        {Suntzeff}, N.~B.},
+    title = "{Report of the Dark Energy Task Force}",
+  journal = {ArXiv Astrophysics e-prints},
+   eprint = {astro-ph/0609591},
+ keywords = {Astrophysics},
+     year = 2006,
+    month = sep,
+   adsurl = {http://adsabs.harvard.edu/abs/2006astro.ph..9591A},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
 @ARTICLE{2006astro.ph.11885O,
   author =       {{O'Mullane}, W. and {Lammers}, U. and
                   {Bailer-Jones}, C. and {Bastian}, U. and {Brown},
@@ -2627,36 +2688,6 @@ archivePrefix = "arXiv",
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-@ARTICLE{2008ApJ...679..301B,
-   author = {{Budav{\'a}ri}, T. and {Szalay}, A.~S.},
-    title = "{Probabilistic Cross-Identification of Astronomical Sources}",
-  journal = {\apj},
-archivePrefix = "arXiv",
-   eprint = {0707.1611},
- keywords = {astrometry, catalogs, galaxies: statistics, methods: statistical },
-     year = 2008,
-    month = may,
-   volume = 679,
-      eid = {301-309},
-    pages = {301-309},
-      doi = {10.1086/587156},
-   adsurl = {http://adsabs.harvard.edu/abs/2008ApJ...679..301B},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2008arXiv0805.2366I,
-   author = {{Ivezic}, Z. and others},
-    title = "{LSST: from Science Drivers to Reference Design and Anticipated Data Products}",
-  journal = {ArXiv e-prints},
-archivePrefix = "arXiv",
-   eprint = {0805.2366},
- keywords = {Astrophysics},
-     year = 2008,
-    month = may,
-   adsurl = {http://adsabs.harvard.edu/abs/2008arXiv0805.2366I},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
 @INPROCEEDINGS{2008AIPC.1082..331H,
   author =       {{Hogg}, D.~W. and {Lang}, D.},
   title =        "{Astronomical imaging: The theory of everything}",
@@ -2732,6 +2763,23 @@ archivePrefix = "arXiv",
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+@ARTICLE{2008ApJ...679..301B,
+   author = {{Budav{\'a}ri}, T. and {Szalay}, A.~S.},
+    title = "{Probabilistic Cross-Identification of Astronomical Sources}",
+  journal = {\apj},
+archivePrefix = "arXiv",
+   eprint = {0707.1611},
+ keywords = {astrometry, catalogs, galaxies: statistics, methods: statistical },
+     year = 2008,
+    month = may,
+   volume = 679,
+      eid = {301-309},
+    pages = {301-309},
+      doi = {10.1086/587156},
+   adsurl = {http://adsabs.harvard.edu/abs/2008ApJ...679..301B},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
 @ARTICLE{2008CSE....10....9T,
   author =       {{Thakar}, A.~R.},
   title =        "{The Sloan Digital Sky Survey: Drinking from the
@@ -2797,6 +2845,272 @@ archivePrefix = "arXiv",
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+@ARTICLE{2008arXiv0805.2366I,
+       author = {{Ivezi{\'c}}, {\v{Z}}eljko and {Kahn}, Steven M. and
+         {Tyson}, J. Anthony and {Abel}, Bob and {Acosta}, Emily and
+         {Allsman}, Robyn and {Alonso}, David and {AlSayyad}, Yusra and
+         {Anderson}, Scott F. and {Andrew}, John and {Angel}, James Roger P. and
+         {Angeli}, George Z. and {Ansari}, Reza and {Antilogus}, Pierre and
+         {Araujo}, Constanza and {Armstrong}, Robert and {Arndt}, Kirk T. and
+         {Astier}, Pierre and {Aubourg}, {\'E}ric and {Auza}, Nicole and
+         {Axelrod}, Tim S. and {Bard}, Deborah J. and {Barr}, Jeff D. and
+         {Barrau}, Aurelian and {Bartlett}, James G. and {Bauer}, Amanda E. and
+         {Bauman}, Brian J. and {Baumont}, Sylvain and {Bechtol}, Ellen and
+         {Bechtol}, Keith and {Becker}, Andrew C. and {Becla}, Jacek and
+         {Beldica}, Cristina and {Bellavia}, Steve and {Bianco}, Federica B. and
+         {Biswas}, Rahul and {Blanc}, Guillaume and {Blazek}, Jonathan and {Bland
+        ford}, Roger D. and {Bloom}, Josh S. and {Bogart}, Joanne and
+         {Bond}, Tim W. and {Booth}, Michael T. and {Borgland}, Anders W. and
+         {Borne}, Kirk and {Bosch}, James F. and {Boutigny}, Dominique and
+         {Brackett}, Craig A. and {Bradshaw}, Andrew and {Brand
+        t}, William Nielsen and {Brown}, Michael E. and {Bullock}, James S. and
+         {Burchat}, Patricia and {Burke}, David L. and {Cagnoli}, Gianpietro and
+         {Calabrese}, Daniel and {Callahan}, Shawn and {Callen}, Alice L. and
+         {Carlin}, Jeffrey L. and {Carlson}, Erin L. and {Chand
+        rasekharan}, Srinivasan and {Charles-Emerson}, Glenaver and
+         {Chesley}, Steve and {Cheu}, Elliott C. and {Chiang}, Hsin-Fang and
+         {Chiang}, James and {Chirino}, Carol and {Chow}, Derek and
+         {Ciardi}, David R. and {Claver}, Charles F. and {Cohen-Tanugi}, Johann and
+         {Cockrum}, Joseph J. and {Coles}, Rebecca and {Connolly}, Andrew J. and
+         {Cook}, Kem H. and {Cooray}, Asantha and {Covey}, Kevin R. and
+         {Cribbs}, Chris and {Cui}, Wei and {Cutri}, Roc and {Daly}, Philip N. and
+         {Daniel}, Scott F. and {Daruich}, Felipe and {Daubard}, Guillaume and
+         {Daues}, Greg and {Dawson}, William and {Delgado}, Francisco and
+         {Dellapenna}, Alfred and {de Peyster}, Robert and
+         {de Val-Borro}, Miguel and {Digel}, Seth W. and {Doherty}, Peter and
+         {Dubois}, Richard and {Dubois-Felsmann}, Gregory P. and
+         {Durech}, Josef and {Economou}, Frossie and {Eifler}, Tim and
+         {Eracleous}, Michael and {Emmons}, Benjamin L. and
+         {Fausti Neto}, Angelo and {Ferguson}, Henry and {Figueroa}, Enrique and
+         {Fisher-Levine}, Merlin and {Focke}, Warren and {Foss}, Michael D. and
+         {Frank}, James and {Freemon}, Michael D. and {Gangler}, Emmanuel and
+         {Gawiser}, Eric and {Geary}, John C. and {Gee}, Perry and
+         {Geha}, Marla and {Gessner}, Charles J.~B. and {Gibson}, Robert R. and
+         {Gilmore}, D. Kirk and {Glanzman}, Thomas and {Glick}, William and
+         {Goldina}, Tatiana and {Goldstein}, Daniel A. and {Goodenow}, Iain and
+         {Graham}, Melissa L. and {Gressler}, William J. and {Gris}, Philippe and
+         {Guy}, Leanne P. and {Guyonnet}, Augustin and {Haller}, Gunther and
+         {Harris}, Ron and {Hascall}, Patrick A. and {Haupt}, Justine and {Hernand
+        ez}, Fabio and {Herrmann}, Sven and {Hileman}, Edward and
+         {Hoblitt}, Joshua and {Hodgson}, John A. and {Hogan}, Craig and
+         {Howard}, James D. and {Huang}, Dajun and {Huffer}, Michael E. and
+         {Ingraham}, Patrick and {Innes}, Walter R. and {Jacoby}, Suzanne H. and
+         {Jain}, Bhuvnesh and {Jammes}, Fabrice and {Jee}, M. James and
+         {Jenness}, Tim and {Jernigan}, Garrett and {Jevremovi{\'c}}, Darko and
+         {Johns}, Kenneth and {Johnson}, Anthony S. and
+         {Johnson}, Margaret W.~G. and {Jones}, R. Lynne and
+         {Juramy-Gilles}, Claire and {Juri{\'c}}, Mario and {Kalirai}, Jason S. and
+         {Kallivayalil}, Nitya J. and {Kalmbach}, Bryce and
+         {Kantor}, Jeffrey P. and {Karst}, Pierre and {Kasliwal}, Mansi M. and
+         {Kelly}, Heather and {Kessler}, Richard and {Kinnison}, Veronica and
+         {Kirkby}, David and {Knox}, Lloyd and {Kotov}, Ivan V. and
+         {Krabbendam}, Victor L. and {Krughoff}, K. Simon and
+         {Kub{\'a}nek}, Petr and {Kuczewski}, John and {Kulkarni}, Shri and
+         {Ku}, John and {Kurita}, Nadine R. and {Lage}, Craig S. and
+         {Lambert}, Ron and {Lange}, Travis and {Langton}, J. Brian and
+         {Le Guillou}, Laurent and {Levine}, Deborah and {Liang}, Ming and
+         {Lim}, Kian-Tat and {Lintott}, Chris J. and {Long}, Kevin E. and
+         {Lopez}, Margaux and {Lotz}, Paul J. and {Lupton}, Robert H. and
+         {Lust}, Nate B. and {MacArthur}, Lauren A. and {Mahabal}, Ashish and {Mand
+        elbaum}, Rachel and {Markiewicz}, Thomas W. and {Marsh}, Darren S. and
+         {Marshall}, Philip J. and {Marshall}, Stuart and {May}, Morgan and
+         {McKercher}, Robert and {McQueen}, Michelle and {Meyers}, Joshua and
+         {Migliore}, Myriam and {Miller}, Michelle and {Mills}, David J. and
+         {Miraval}, Connor and {Moeyens}, Joachim and {Moolekamp}, Fred E. and
+         {Monet}, David G. and {Moniez}, Marc and {Monkewitz}, Serge and
+         {Montgomery}, Christopher and {Morrison}, Christopher B. and
+         {Mueller}, Fritz and {Muller}, Gary P. and
+         {Mu{\~n}oz Arancibia}, Freddy and {Neill}, Douglas R. and
+         {Newbry}, Scott P. and {Nief}, Jean-Yves and {Nomerotski}, Andrei and
+         {Nordby}, Martin and {O'Connor}, Paul and {Oliver}, John and
+         {Olivier}, Scot S. and {Olsen}, Knut and {O'Mullane}, William and
+         {Ortiz}, Sandra and {Osier}, Shawn and {Owen}, Russell E. and
+         {Pain}, Reynald and {Palecek}, Paul E. and {Parejko}, John K. and
+         {Parsons}, James B. and {Pease}, Nathan M. and {Peterson}, J. Matt and
+         {Peterson}, John R. and {Petravick}, Donald L. and
+         {Libby Petrick}, M.~E. and {Petry}, Cathy E. and
+         {Pierfederici}, Francesco and {Pietrowicz}, Stephen and {Pike}, Rob and
+         {Pinto}, Philip A. and {Plante}, Raymond and {Plate}, Stephen and
+         {Plutchak}, Joel P. and {Price}, Paul A. and {Prouza}, Michael and
+         {Radeka}, Veljko and {Rajagopal}, Jayadev and {Rasmussen}, Andrew P. and
+         {Regnault}, Nicolas and {Reil}, Kevin A. and {Reiss}, David J. and
+         {Reuter}, Michael A. and {Ridgway}, Stephen T. and {Riot}, Vincent J. and
+         {Ritz}, Steve and {Robinson}, Sean and {Roby}, William and
+         {Roodman}, Aaron and {Rosing}, Wayne and {Roucelle}, Cecille and
+         {Rumore}, Matthew R. and {Russo}, Stefano and {Saha}, Abhijit and
+         {Sassolas}, Benoit and {Schalk}, Terry L. and {Schellart}, Pim and
+         {Schindler}, Rafe H. and {Schmidt}, Samuel and {Schneider}, Donald P. and
+         {Schneider}, Michael D. and {Schoening}, William and
+         {Schumacher}, German and {Schwamb}, Megan E. and {Sebag}, Jacques and
+         {Selvy}, Brian and {Sembroski}, Glenn H. and {Seppala}, Lynn G. and
+         {Serio}, Andrew and {Serrano}, Eduardo and {Shaw}, Richard A. and
+         {Shipsey}, Ian and {Sick}, Jonathan and {Silvestri}, Nicole and
+         {Slater}, Colin T. and {Smith}, J. Allyn and {Smith}, R. Chris and
+         {Sobhani}, Shahram and {Soldahl}, Christine and
+         {Storrie-Lombardi}, Lisa and {Stover}, Edward and
+         {Strauss}, Michael A. and {Street}, Rachel A. and
+         {Stubbs}, Christopher W. and {Sullivan}, Ian S. and {Sweeney}, Donald and
+         {Swinbank}, John D. and {Szalay}, Alexander and {Takacs}, Peter and
+         {Tether}, Stephen A. and {Thaler}, Jon J. and {Thayer}, John Gregg and
+         {Thomas}, Sandrine and {Thornton}, Adam J. and {Thukral}, Vaikunth and
+         {Tice}, Jeffrey and {Trilling}, David E. and {Turri}, Max and
+         {Van Berg}, Richard and {Vanden Berk}, Daniel and {Vetter}, Kurt and
+         {Virieux}, Francoise and {Vucina}, Tomislav and {Wahl}, William and
+         {Walkowicz}, Lucianne and {Walsh}, Brian and {Walter}, Christopher W. and
+         {Wang}, Daniel L. and {Wang}, Shin-Yawn and {Warner}, Michael and
+         {Wiecha}, Oliver and {Willman}, Beth and {Winters}, Scott E. and
+         {Wittman}, David and {Wolff}, Sidney C. and {Wood-Vasey}, W. Michael and
+         {Wu}, Xiuqin and {Xin}, Bo and {Yoachim}, Peter and {Zhan}, Hu},
+        title = "{LSST: From Science Drivers to Reference Design and Anticipated Data Products}",
+      journal = {\apj},
+     keywords = {astrometry, cosmology: observations, Galaxy: general, methods: observational, stars: general, surveys, Astrophysics},
+         year = "2019",
+        month = "Mar",
+       volume = {873},
+       number = {2},
+          eid = {111},
+        pages = {111},
+          doi = {10.3847/1538-4357/ab042c},
+archivePrefix = {arXiv},
+       eprint = {0805.2366},
+ primaryClass = {astro-ph},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2019ApJ...873..111I},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2019ApJ...873..111I,
+       author = {{Ivezi{\'c}}, {\v{Z}}eljko and {Kahn}, Steven M. and
+         {Tyson}, J. Anthony and {Abel}, Bob and {Acosta}, Emily and
+         {Allsman}, Robyn and {Alonso}, David and {AlSayyad}, Yusra and
+         {Anderson}, Scott F. and {Andrew}, John and {Angel}, James Roger P. and
+         {Angeli}, George Z. and {Ansari}, Reza and {Antilogus}, Pierre and
+         {Araujo}, Constanza and {Armstrong}, Robert and {Arndt}, Kirk T. and
+         {Astier}, Pierre and {Aubourg}, {\'E}ric and {Auza}, Nicole and
+         {Axelrod}, Tim S. and {Bard}, Deborah J. and {Barr}, Jeff D. and
+         {Barrau}, Aurelian and {Bartlett}, James G. and {Bauer}, Amanda E. and
+         {Bauman}, Brian J. and {Baumont}, Sylvain and {Bechtol}, Ellen and
+         {Bechtol}, Keith and {Becker}, Andrew C. and {Becla}, Jacek and
+         {Beldica}, Cristina and {Bellavia}, Steve and {Bianco}, Federica B. and
+         {Biswas}, Rahul and {Blanc}, Guillaume and {Blazek}, Jonathan and {Bland
+        ford}, Roger D. and {Bloom}, Josh S. and {Bogart}, Joanne and
+         {Bond}, Tim W. and {Booth}, Michael T. and {Borgland}, Anders W. and
+         {Borne}, Kirk and {Bosch}, James F. and {Boutigny}, Dominique and
+         {Brackett}, Craig A. and {Bradshaw}, Andrew and {Brand
+        t}, William Nielsen and {Brown}, Michael E. and {Bullock}, James S. and
+         {Burchat}, Patricia and {Burke}, David L. and {Cagnoli}, Gianpietro and
+         {Calabrese}, Daniel and {Callahan}, Shawn and {Callen}, Alice L. and
+         {Carlin}, Jeffrey L. and {Carlson}, Erin L. and {Chand
+        rasekharan}, Srinivasan and {Charles-Emerson}, Glenaver and
+         {Chesley}, Steve and {Cheu}, Elliott C. and {Chiang}, Hsin-Fang and
+         {Chiang}, James and {Chirino}, Carol and {Chow}, Derek and
+         {Ciardi}, David R. and {Claver}, Charles F. and {Cohen-Tanugi}, Johann and
+         {Cockrum}, Joseph J. and {Coles}, Rebecca and {Connolly}, Andrew J. and
+         {Cook}, Kem H. and {Cooray}, Asantha and {Covey}, Kevin R. and
+         {Cribbs}, Chris and {Cui}, Wei and {Cutri}, Roc and {Daly}, Philip N. and
+         {Daniel}, Scott F. and {Daruich}, Felipe and {Daubard}, Guillaume and
+         {Daues}, Greg and {Dawson}, William and {Delgado}, Francisco and
+         {Dellapenna}, Alfred and {de Peyster}, Robert and
+         {de Val-Borro}, Miguel and {Digel}, Seth W. and {Doherty}, Peter and
+         {Dubois}, Richard and {Dubois-Felsmann}, Gregory P. and
+         {Durech}, Josef and {Economou}, Frossie and {Eifler}, Tim and
+         {Eracleous}, Michael and {Emmons}, Benjamin L. and
+         {Fausti Neto}, Angelo and {Ferguson}, Henry and {Figueroa}, Enrique and
+         {Fisher-Levine}, Merlin and {Focke}, Warren and {Foss}, Michael D. and
+         {Frank}, James and {Freemon}, Michael D. and {Gangler}, Emmanuel and
+         {Gawiser}, Eric and {Geary}, John C. and {Gee}, Perry and
+         {Geha}, Marla and {Gessner}, Charles J.~B. and {Gibson}, Robert R. and
+         {Gilmore}, D. Kirk and {Glanzman}, Thomas and {Glick}, William and
+         {Goldina}, Tatiana and {Goldstein}, Daniel A. and {Goodenow}, Iain and
+         {Graham}, Melissa L. and {Gressler}, William J. and {Gris}, Philippe and
+         {Guy}, Leanne P. and {Guyonnet}, Augustin and {Haller}, Gunther and
+         {Harris}, Ron and {Hascall}, Patrick A. and {Haupt}, Justine and {Hernand
+        ez}, Fabio and {Herrmann}, Sven and {Hileman}, Edward and
+         {Hoblitt}, Joshua and {Hodgson}, John A. and {Hogan}, Craig and
+         {Howard}, James D. and {Huang}, Dajun and {Huffer}, Michael E. and
+         {Ingraham}, Patrick and {Innes}, Walter R. and {Jacoby}, Suzanne H. and
+         {Jain}, Bhuvnesh and {Jammes}, Fabrice and {Jee}, M. James and
+         {Jenness}, Tim and {Jernigan}, Garrett and {Jevremovi{\'c}}, Darko and
+         {Johns}, Kenneth and {Johnson}, Anthony S. and
+         {Johnson}, Margaret W.~G. and {Jones}, R. Lynne and
+         {Juramy-Gilles}, Claire and {Juri{\'c}}, Mario and {Kalirai}, Jason S. and
+         {Kallivayalil}, Nitya J. and {Kalmbach}, Bryce and
+         {Kantor}, Jeffrey P. and {Karst}, Pierre and {Kasliwal}, Mansi M. and
+         {Kelly}, Heather and {Kessler}, Richard and {Kinnison}, Veronica and
+         {Kirkby}, David and {Knox}, Lloyd and {Kotov}, Ivan V. and
+         {Krabbendam}, Victor L. and {Krughoff}, K. Simon and
+         {Kub{\'a}nek}, Petr and {Kuczewski}, John and {Kulkarni}, Shri and
+         {Ku}, John and {Kurita}, Nadine R. and {Lage}, Craig S. and
+         {Lambert}, Ron and {Lange}, Travis and {Langton}, J. Brian and
+         {Le Guillou}, Laurent and {Levine}, Deborah and {Liang}, Ming and
+         {Lim}, Kian-Tat and {Lintott}, Chris J. and {Long}, Kevin E. and
+         {Lopez}, Margaux and {Lotz}, Paul J. and {Lupton}, Robert H. and
+         {Lust}, Nate B. and {MacArthur}, Lauren A. and {Mahabal}, Ashish and {Mand
+        elbaum}, Rachel and {Markiewicz}, Thomas W. and {Marsh}, Darren S. and
+         {Marshall}, Philip J. and {Marshall}, Stuart and {May}, Morgan and
+         {McKercher}, Robert and {McQueen}, Michelle and {Meyers}, Joshua and
+         {Migliore}, Myriam and {Miller}, Michelle and {Mills}, David J. and
+         {Miraval}, Connor and {Moeyens}, Joachim and {Moolekamp}, Fred E. and
+         {Monet}, David G. and {Moniez}, Marc and {Monkewitz}, Serge and
+         {Montgomery}, Christopher and {Morrison}, Christopher B. and
+         {Mueller}, Fritz and {Muller}, Gary P. and
+         {Mu{\~n}oz Arancibia}, Freddy and {Neill}, Douglas R. and
+         {Newbry}, Scott P. and {Nief}, Jean-Yves and {Nomerotski}, Andrei and
+         {Nordby}, Martin and {O'Connor}, Paul and {Oliver}, John and
+         {Olivier}, Scot S. and {Olsen}, Knut and {O'Mullane}, William and
+         {Ortiz}, Sandra and {Osier}, Shawn and {Owen}, Russell E. and
+         {Pain}, Reynald and {Palecek}, Paul E. and {Parejko}, John K. and
+         {Parsons}, James B. and {Pease}, Nathan M. and {Peterson}, J. Matt and
+         {Peterson}, John R. and {Petravick}, Donald L. and
+         {Libby Petrick}, M.~E. and {Petry}, Cathy E. and
+         {Pierfederici}, Francesco and {Pietrowicz}, Stephen and {Pike}, Rob and
+         {Pinto}, Philip A. and {Plante}, Raymond and {Plate}, Stephen and
+         {Plutchak}, Joel P. and {Price}, Paul A. and {Prouza}, Michael and
+         {Radeka}, Veljko and {Rajagopal}, Jayadev and {Rasmussen}, Andrew P. and
+         {Regnault}, Nicolas and {Reil}, Kevin A. and {Reiss}, David J. and
+         {Reuter}, Michael A. and {Ridgway}, Stephen T. and {Riot}, Vincent J. and
+         {Ritz}, Steve and {Robinson}, Sean and {Roby}, William and
+         {Roodman}, Aaron and {Rosing}, Wayne and {Roucelle}, Cecille and
+         {Rumore}, Matthew R. and {Russo}, Stefano and {Saha}, Abhijit and
+         {Sassolas}, Benoit and {Schalk}, Terry L. and {Schellart}, Pim and
+         {Schindler}, Rafe H. and {Schmidt}, Samuel and {Schneider}, Donald P. and
+         {Schneider}, Michael D. and {Schoening}, William and
+         {Schumacher}, German and {Schwamb}, Megan E. and {Sebag}, Jacques and
+         {Selvy}, Brian and {Sembroski}, Glenn H. and {Seppala}, Lynn G. and
+         {Serio}, Andrew and {Serrano}, Eduardo and {Shaw}, Richard A. and
+         {Shipsey}, Ian and {Sick}, Jonathan and {Silvestri}, Nicole and
+         {Slater}, Colin T. and {Smith}, J. Allyn and {Smith}, R. Chris and
+         {Sobhani}, Shahram and {Soldahl}, Christine and
+         {Storrie-Lombardi}, Lisa and {Stover}, Edward and
+         {Strauss}, Michael A. and {Street}, Rachel A. and
+         {Stubbs}, Christopher W. and {Sullivan}, Ian S. and {Sweeney}, Donald and
+         {Swinbank}, John D. and {Szalay}, Alexander and {Takacs}, Peter and
+         {Tether}, Stephen A. and {Thaler}, Jon J. and {Thayer}, John Gregg and
+         {Thomas}, Sandrine and {Thornton}, Adam J. and {Thukral}, Vaikunth and
+         {Tice}, Jeffrey and {Trilling}, David E. and {Turri}, Max and
+         {Van Berg}, Richard and {Vanden Berk}, Daniel and {Vetter}, Kurt and
+         {Virieux}, Francoise and {Vucina}, Tomislav and {Wahl}, William and
+         {Walkowicz}, Lucianne and {Walsh}, Brian and {Walter}, Christopher W. and
+         {Wang}, Daniel L. and {Wang}, Shin-Yawn and {Warner}, Michael and
+         {Wiecha}, Oliver and {Willman}, Beth and {Winters}, Scott E. and
+         {Wittman}, David and {Wolff}, Sidney C. and {Wood-Vasey}, W. Michael and
+         {Wu}, Xiuqin and {Xin}, Bo and {Yoachim}, Peter and {Zhan}, Hu},
+        title = "{LSST: From Science Drivers to Reference Design and Anticipated Data Products}",
+      journal = {\apj},
+     keywords = {astrometry, cosmology: observations, Galaxy: general, methods: observational, stars: general, surveys, Astrophysics},
+         year = "2019",
+        month = "Mar",
+       volume = {873},
+       number = {2},
+          eid = {111},
+        pages = {111},
+          doi = {10.3847/1538-4357/ab042c},
+archivePrefix = {arXiv},
+       eprint = {0805.2366},
+ primaryClass = {astro-ph},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2019ApJ...873..111I},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
 @ARTICLE{2009A&A...496..577Z,
    author = {{Zechmeister}, M. and {K{\"u}rster}, M.},
     title = "{The generalised Lomb-Scargle periodogram. A new formalism for the floating-mean and Keplerian periodograms}",
@@ -2811,20 +3125,6 @@ archivePrefix = "arXiv",
     pages = {577-584},
       doi = {10.1051/0004-6361:200811296},
    adsurl = {http://adsabs.harvard.edu/abs/2009A\%26A...496..577Z},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2009arXiv0912.0201L,
-   author = {{LSST Science Collaboration}},
-    title = "{LSST Science Book, Version 2.0}",
-  journal = {ArXiv e-prints},
-archivePrefix = "arXiv",
-   eprint = {0912.0201},
- primaryClass = "astro-ph.IM",
- keywords = {Astrophysics - Instrumentation and Methods for Astrophysics, Astrophysics - Cosmology and Extragalactic Astrophysics, Astrophysics - Earth and Planetary Astrophysics, Astrophysics - Galaxy Astrophysics, Astrophysics - Solar and Stellar Astrophysics},
-     year = 2009,
-    month = dec,
-   adsurl = {http://adsabs.harvard.edu/abs/2009arXiv0912.0201L},
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
@@ -3001,6 +3301,20 @@ archivePrefix = "arXiv",
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+@ARTICLE{2009arXiv0912.0201L,
+   author = {{LSST Science Collaboration}},
+    title = "{LSST Science Book, Version 2.0}",
+  journal = {ArXiv e-prints},
+archivePrefix = "arXiv",
+   eprint = {0912.0201},
+ primaryClass = "astro-ph.IM",
+ keywords = {Astrophysics - Instrumentation and Methods for Astrophysics, Astrophysics - Cosmology and Extragalactic Astrophysics, Astrophysics - Earth and Planetary Astrophysics, Astrophysics - Galaxy Astrophysics, Astrophysics - Solar and Stellar Astrophysics},
+     year = 2009,
+    month = dec,
+   adsurl = {http://adsabs.harvard.edu/abs/2009arXiv0912.0201L},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
 @ARTICLE{2010A&A...516A..77B,
   author =       {{Bombrun}, A. and {Lindegren}, L. and {Holl}, B. and
                   {Jordan}, S.  },
@@ -3035,29 +3349,6 @@ archivePrefix = "arXiv",
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-@ARTICLE{2010A&A...523A..48J,
-  author =       {{Jordi}, C. and {Gebran}, M. and {Carrasco},
-                  J.~M. and {de Bruijne}, J.  and {Voss}, H. and
-                  {Fabricius}, C. and {Knude}, J. and {Vallenari},
-                  A. and {Kohley}, R. and {Mora}, A.},
-  title =        "{Gaia broad band photometry}",
-  journal =      {\aap},
-  archivePrefix ="arXiv",
-  eprint =       {1008.0815},
-  primaryClass = "astro-ph.IM",
-  keywords =     {instrumentation: photometers, techniques:
-                  photometric, Galaxy: general, dust, extinction,
-                  stars: evolution},
-  year =         2010,
-  month =        nov,
-  volume =       523,
-  eid =          {A48},
-  pages =        {A48},
-  doi =          {10.1051/0004-6361/201015441},
-  adsurl =       {http://adsabs.harvard.edu/abs/2010A\%26A...523A..48J},
-  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
-}
-
 @ARTICLE{2010A&A...523A..31H,
    author = {{Hildebrandt}, H. and {Arnouts}, S. and {Capak}, P. and {Moustakas}, L.~A. and
 	{Wolf}, C. and {Abdalla}, F.~B. and {Assef}, R.~J. and {Banerji}, M. and
@@ -3079,6 +3370,29 @@ archivePrefix = "arXiv",
       doi = {10.1051/0004-6361/201014885},
    adsurl = {http://adsabs.harvard.edu/abs/2010A\%26A...523A..31H},
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2010A&A...523A..48J,
+  author =       {{Jordi}, C. and {Gebran}, M. and {Carrasco},
+                  J.~M. and {de Bruijne}, J.  and {Voss}, H. and
+                  {Fabricius}, C. and {Knude}, J. and {Vallenari},
+                  A. and {Kohley}, R. and {Mora}, A.},
+  title =        "{Gaia broad band photometry}",
+  journal =      {\aap},
+  archivePrefix ="arXiv",
+  eprint =       {1008.0815},
+  primaryClass = "astro-ph.IM",
+  keywords =     {instrumentation: photometers, techniques:
+                  photometric, Galaxy: general, dust, extinction,
+                  stars: evolution},
+  year =         2010,
+  month =        nov,
+  volume =       523,
+  eid =          {A48},
+  pages =        {A48},
+  doi =          {10.1051/0004-6361/201015441},
+  adsurl =       {http://adsabs.harvard.edu/abs/2010A\%26A...523A..48J},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @INPROCEEDINGS{2010AAS...21641512W,
@@ -3157,6 +3471,17 @@ archivePrefix = "arXiv",
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+@ARTICLE{2010ISSIR...9..279L,
+  author =       {{Lindegren}, L.},
+  title =        "{High-accuracy positioning: astrometry}",
+  journal =      {ISSI Scientific Reports Series},
+  year =         2010,
+  volume =       9,
+  pages =        {279-291},
+  adsurl =       {http://adsabs.harvard.edu/abs/2010ISSIR...9..279L},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
 @ARTICLE{2010Icar..209..542M,
    author = {{Muinonen}, K. and {Belskaya}, I.~N. and {Cellino}, A. and {Delb{\`o}}, M. and
     {Levasseur-Regourd}, A.-C. and {Penttil{\"a}}, A. and {Tedesco}, E.~F.
@@ -3170,17 +3495,6 @@ archivePrefix = "arXiv",
       doi = {10.1016/j.icarus.2010.04.003},
    adsurl = {http://adsabs.harvard.edu/abs/2010Icar..209..542M},
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2010ISSIR...9..279L,
-  author =       {{Lindegren}, L.},
-  title =        "{High-accuracy positioning: astrometry}",
-  journal =      {ISSI Scientific Reports Series},
-  year =         2010,
-  volume =       9,
-  pages =        {279-291},
-  adsurl =       {http://adsabs.harvard.edu/abs/2010ISSIR...9..279L},
-  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @ARTICLE{2010MNRAS.403...96B,
@@ -3311,6 +3625,41 @@ ral},
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+@INPROCEEDINGS{2011ASPC..442..351O,
+  author =       {{O'Mullane}, W. and {Lammers}, U. and {Hernandez},
+                  J.},
+  title =        "{Gaia: Processing to Archive}",
+  booktitle =    {Astronomical Data Analysis Software and Systems XX},
+  year =         2011,
+  series =       {Astronomical Society of the Pacific Conference
+                  Series},
+  volume =       442,
+  editor =       "{I.~N.~Evans, A.~Accomazzi, D.~J.~Mink, \&
+                  A.~H.~Rots}",
+  month =        jul,
+  pages =        351,
+  adsurl =       {http://adsabs.harvard.edu/abs/2011ASPC..442..351O},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2011ASPC..442..443C,
+  author =       {{Connolly}, A.~J. and {Smith}, I. and {Krughoff},
+                  K.~S. and {Gibson}, R.},
+  title =        "{Using the Browser for Science: A Collaborative
+                  Toolkit for Astronomy}",
+  booktitle =    {Astronomical Data Analysis Software and Systems XX},
+  year =         2011,
+  series =       {Astronomical Society of the Pacific Conference
+                  Series},
+  volume =       442,
+  editor =       {{Evans}, I.~N. and {Accomazzi}, A. and {Mink},
+                  D.~J. and {Rots}, A.~H.  },
+  month =        jul,
+  pages =        443,
+  adsurl =       {http://adsabs.harvard.edu/abs/2011ASPC..442..443C},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
 @ARTICLE{2011ApJ...733...10R,
    author = {{Richards}, J.~W. and {Starr}, D.~L. and {Butler}, N.~R. and
         {Bloom}, J.~S. and {Brewer}, J.~M. and {Crellin-Quick}, A. and
@@ -3348,41 +3697,6 @@ archivePrefix = "arXiv",
       doi = {10.1088/0004-637X/734/1/36},
    adsurl = {http://cdsads.u-strasbg.fr/abs/2011ApJ...734...36A},
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@INPROCEEDINGS{2011ASPC..442..351O,
-  author =       {{O'Mullane}, W. and {Lammers}, U. and {Hernandez},
-                  J.},
-  title =        "{Gaia: Processing to Archive}",
-  booktitle =    {Astronomical Data Analysis Software and Systems XX},
-  year =         2011,
-  series =       {Astronomical Society of the Pacific Conference
-                  Series},
-  volume =       442,
-  editor =       "{I.~N.~Evans, A.~Accomazzi, D.~J.~Mink, \&
-                  A.~H.~Rots}",
-  month =        jul,
-  pages =        351,
-  adsurl =       {http://adsabs.harvard.edu/abs/2011ASPC..442..351O},
-  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@INPROCEEDINGS{2011ASPC..442..443C,
-  author =       {{Connolly}, A.~J. and {Smith}, I. and {Krughoff},
-                  K.~S. and {Gibson}, R.},
-  title =        "{Using the Browser for Science: A Collaborative
-                  Toolkit for Astronomy}",
-  booktitle =    {Astronomical Data Analysis Software and Systems XX},
-  year =         2011,
-  series =       {Astronomical Society of the Pacific Conference
-                  Series},
-  volume =       442,
-  editor =       {{Evans}, I.~N. and {Accomazzi}, A. and {Mink},
-                  D.~J. and {Rots}, A.~H.  },
-  month =        jul,
-  pages =        443,
-  adsurl =       {http://adsabs.harvard.edu/abs/2011ASPC..442..443C},
-  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @INPROCEEDINGS{2011EAS....45..109L,
@@ -3770,6 +4084,22 @@ archivePrefix = "arXiv",
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+@ARTICLE{2012PASP..124.1113A,
+   author = {{Alejandro Plazas}, A. and {Bernstein}, G.},
+    title = "{Atmospheric Dispersion Effects in Weak Lensing Measurements}",
+  journal = {\pasp},
+archivePrefix = "arXiv",
+   eprint = {1204.1346},
+ primaryClass = "astro-ph.IM",
+     year = 2012,
+    month = oct,
+   volume = 124,
+    pages = {1113},
+      doi = {10.1086/668294},
+   adsurl = {http://adsabs.harvard.edu/abs/2012PASP..124.1113A},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
 @ARTICLE{2012PASP..124.1175B,
    author = {{Bloom}, J.~S. and {Richards}, J.~W. and {Nugent}, P.~E. and
 	{Quimby}, R.~M. and {Kasliwal}, M.~M. and {Starr}, D.~L. and
@@ -3956,16 +4286,17 @@ archivePrefix = "arXiv",
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-@MISC{2013ascl.soft04011C,
-   author = {{Carrasco Kind}, M. and {Brunner}, R.},
-    title = "{TPZ: Trees for Photo-Z}",
- keywords = {Software},
-howpublished = {Astrophysics Source Code Library},
+@ARTICLE{2013arXiv1304.3455G,
+   author = {{Gould}, A.},
+    title = "{LSST's DC Bias Against Planets and Galactic-Plane Science}",
+  journal = {ArXiv e-prints},
+archivePrefix = "arXiv",
+   eprint = {1304.3455},
+ primaryClass = "astro-ph.GA",
+ keywords = {Astrophysics - Galaxy Astrophysics, Astrophysics - Earth and Planetary Astrophysics, Astrophysics - Solar and Stellar Astrophysics},
      year = 2013,
     month = apr,
-archivePrefix = "ascl",
-   eprint = {1304.011},
-   adsurl = {http://adsabs.harvard.edu/abs/2013ascl.soft04011C},
+   adsurl = {http://adsabs.harvard.edu/abs/2013arXiv1304.3455G},
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
@@ -4167,6 +4498,19 @@ archivePrefix = "arXiv",
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+@MISC{2013ascl.soft04011C,
+   author = {{Carrasco Kind}, M. and {Brunner}, R.},
+    title = "{TPZ: Trees for Photo-Z}",
+ keywords = {Software},
+howpublished = {Astrophysics Source Code Library},
+     year = 2013,
+    month = apr,
+archivePrefix = "ascl",
+   eprint = {1304.011},
+   adsurl = {http://adsabs.harvard.edu/abs/2013ascl.soft04011C},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
 @ARTICLE{2014A&A...566A.119L,
   author =       {{Luri}, X. and {Palmer}, M. and {Arenou}, F. and
                   {Masana}, E. and {de Bruijne}, J. and {Antiche},
@@ -4237,6 +4581,35 @@ archivePrefix = "arXiv",
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+@ARTICLE{2014ApJ...794...23D,
+   author = {{Drout}, M.~R. and {Chornock}, R. and {Soderberg}, A.~M. and
+  {Sanders}, N.~E. and {McKinnon}, R. and {Rest}, A. and {Foley}, R.~J. and
+  {Milisavljevic}, D. and {Margutti}, R. and {Berger}, E. and
+  {Calkins}, M. and {Fong}, W. and {Gezari}, S. and {Huber}, M.~E. and
+  {Kankare}, E. and {Kirshner}, R.~P. and {Leibler}, C. and {Lunnan}, R. and
+  {Mattila}, S. and {Marion}, G.~H. and {Narayan}, G. and {Riess}, A.~G. and
+  {Roth}, K.~C. and {Scolnic}, D. and {Smartt}, S.~J. and {Tonry}, J.~L. and
+  {Burgett}, W.~S. and {Chambers}, K.~C. and {Hodapp}, K.~W. and
+  {Jedicke}, R. and {Kaiser}, N. and {Magnier}, E.~A. and {Metcalfe}, N. and
+  {Morgan}, J.~S. and {Price}, P.~A. and {Waters}, C.},
+    title = "{Rapidly Evolving and Luminous Transients from Pan-STARRS1}",
+  journal = {\apj},
+archivePrefix = "arXiv",
+   eprint = {1405.3668},
+ primaryClass = "astro-ph.HE",
+ keywords = {supernovae: general},
+     year = 2014,
+    month = oct,
+   volume = 794,
+      eid = {23},
+    pages = {23},
+      doi = {10.1088/0004-637X/794/1/23},
+   adsurl = {http://adsabs.harvard.edu/abs/2014ApJ...794...23D},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+
+
 @ARTICLE{2014ApJS..212...18B,
    author = {{Brown}, M.~J.~I. and {Moustakas}, J. and {Smith}, J.-D.~T. and
 	{da Cunha}, E. and {Jarrett}, T.~H. and {Imanishi}, M. and {Armus}, L. and
@@ -4268,17 +4641,6 @@ archivePrefix = "arXiv",
   doi =          {10.1051/eas/1567003},
   adsurl =       {http://adsabs.harvard.edu/abs/2014EAS....67...15P},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@BOOK{2014sdmm.book.....I,
-   author = {{Ivezi{\'c}}, {\v Z}. and {Connolly}, A.~J. and {VanderPlas}, J.~T. and
-        {Gray}, A.},
-    title = "{Statistics, Data Mining, and Machine Learning in Astronomy}",
-booktitle = {Statistics, Data Mining, and Machine Learning in Astronomy},
-     year = 2014,
-publisher = {Princeton University Press},
-   adsurl = {http://adsabs.harvard.edu/abs/2014sdmm.book.....I},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @ARTICLE{2014MNRAS.439..264G,
@@ -4423,6 +4785,17 @@ archivePrefix = "arXiv",
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+@BOOK{2014sdmm.book.....I,
+   author = {{Ivezi{\'c}}, {\v Z}. and {Connolly}, A.~J. and {VanderPlas}, J.~T. and
+        {Gray}, A.},
+    title = "{Statistics, Data Mining, and Machine Learning in Astronomy}",
+booktitle = {Statistics, Data Mining, and Machine Learning in Astronomy},
+     year = 2014,
+publisher = {Princeton University Press},
+   adsurl = {http://adsabs.harvard.edu/abs/2014sdmm.book.....I},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
 @ARTICLE{2015A&A...574A.115M,
   author =       {{Michalik}, D. and {Lindegren}, L. and {Hobbs}, D.},
   title =        "{The Tycho-Gaia astrometric solution . How to get
@@ -4495,6 +4868,23 @@ archivePrefix = "arXiv",
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+@ARTICLE{2015ApJ...807..182M,
+   author = {{Meyers}, J.~E. and {Burchat}, P.~R.},
+    title = "{Impact of Atmospheric Chromatic Effects on Weak Lensing Measurements}",
+  journal = {\apj},
+archivePrefix = "arXiv",
+   eprint = {1409.6273},
+ keywords = {atmospheric effects, cosmology: observations, gravitational lensing: weak, techniques: image processing},
+     year = 2015,
+    month = jul,
+   volume = 807,
+      eid = {182},
+    pages = {182},
+      doi = {10.1088/0004-637X/807/2/182},
+   adsurl = {http://adsabs.harvard.edu/abs/2015ApJ...807..182M},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
 @ARTICLE{2015ApJ...812...18V,
    author = {{VanderPlas}, J.~T. and {Ivezi{\'c}}, {\v Z}.},
     title = "{Periodograms for Multiband Astronomical Time Series}",
@@ -4513,6 +4903,29 @@ archivePrefix = "arXiv",
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+@ARTICLE{2015ApJS..218...14P,
+   author = {{Peterson}, J.~R. and {Jernigan}, J.~G. and {Kahn}, S.~M. and
+	{Rasmussen}, A.~P. and {Peng}, E. and {Ahmad}, Z. and {Bankert}, J. and
+	{Chang}, C. and {Claver}, C. and {Gilmore}, D.~K. and {Grace}, E. and
+	{Hannel}, M. and {Hodge}, M. and {Lorenz}, S. and {Lupu}, A. and
+	{Meert}, A. and {Nagarajan}, S. and {Todd}, N. and {Winans}, A. and
+	{Young}, M.},
+    title = "{Simulation of Astronomical Images from Optical Survey Telescopes Using a Comprehensive Photon Monte Carlo Approach}",
+  journal = {\apjs},
+archivePrefix = "arXiv",
+   eprint = {1504.06570},
+ primaryClass = "astro-ph.IM",
+ keywords = {atmospheric effects, cosmology: observations, Galaxy: structure, instrumentation: detectors, surveys, telescopes},
+     year = 2015,
+    month = may,
+   volume = 218,
+      eid = {14},
+    pages = {14},
+      doi = {10.1088/0067-0049/218/1/14},
+   adsurl = {http://adsabs.harvard.edu/abs/2015ApJS..218...14P},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
 @ARTICLE{2015JInst..10C5010O,
    author = {{O'Connor}, P.},
     title = "{Crosstalk in multi-output CCDs for LSST}",
@@ -4527,6 +4940,22 @@ archivePrefix = "arXiv",
     pages = {C05010},
       doi = {10.1088/1748-0221/10/05/C05010},
    adsurl = {http://adsabs.harvard.edu/abs/2015JInst..10C5010O},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2015PASP..127...74M,
+   author = {{Mangum}, J.~G. and {Wallace}, P.},
+    title = "{Atmospheric Refractive Electromagnetic Wave Bending and Propagation Delay}",
+  journal = {\pasp},
+archivePrefix = "arXiv",
+   eprint = {1411.1617},
+ primaryClass = "astro-ph.IM",
+     year = 2015,
+    month = jan,
+   volume = 127,
+    pages = {74},
+      doi = {10.1086/679582},
+   adsurl = {http://adsabs.harvard.edu/abs/2015PASP..127...74M},
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
@@ -4644,6 +5073,39 @@ archivePrefix = "arXiv",
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+@INPROCEEDINGS{2016SPIE.9911E..25R,
+   author = {{Reuter}, M.~A. and {Cook}, K.~H. and {Delgado}, F. and {Petry}, C.~E. and
+	{Ridgway}, S.~T.},
+    title = "{Simulating the LSST OCS for conducting survey simulations using the LSST scheduler}",
+booktitle = {Modeling, Systems Engineering, and Project Management for Astronomy VI},
+     year = 2016,
+   series = {\procspie},
+   volume = 9911,
+    month = aug,
+      eid = {991125},
+    pages = {991125},
+      doi = {10.1117/12.2232680},
+   adsurl = {http://adsabs.harvard.edu/abs/2016SPIE.9911E..25R},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2016SPIE.9910E..13D,
+   author = {{Delgado}, F. and {Reuter}, M.~A.},
+    title = "{The LSST Scheduler from design to construction}",
+booktitle = {Observatory Operations: Strategies, Processes, and Systems VI},
+     year = 2016,
+   series = {\procspie},
+   volume = 9910,
+    month = jul,
+      eid = {991013},
+    pages = {991013},
+      doi = {10.1117/12.2233630},
+   adsurl = {http://adsabs.harvard.edu/abs/2016SPIE.9910E..13D},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+
+
 @TECHREPORT{2016acs..rept....1B,
    author = {{Borncamp}, D. and {Lim}, P.~L.},
     title = "{Satellite Detection in Advanced Camera for Surveys/Wide Field Channel Images}",
@@ -4653,20 +5115,6 @@ institution = {STScI},
      year = 2016,
     month = jan,
    adsurl = {http://adsabs.harvard.edu/abs/2016acs..rept....1B},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2017arXiv170309824V,
-   author = {{VanderPlas}, J.~T.},
-    title = "{Understanding the Lomb-Scargle Periodogram}",
-  journal = {ArXiv e-prints},
-archivePrefix = "arXiv",
-   eprint = {1703.09824},
- primaryClass = "astro-ph.IM",
- keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
-     year = 2017,
-    month = mar,
-   adsurl = {http://adsabs.harvard.edu/abs/2017arXiv170309824V},
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
@@ -4685,4 +5133,1202 @@ archivePrefix = "arXiv",
       doi = {10.3847/1538-4357/aa6332},
    adsurl = {http://adsabs.harvard.edu/abs/2017ApJ...838....5L},
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2017arXiv170208449A,
+   author = {{Aihara}, H. and {Armstrong}, R. and {Bickerton}, S. and {Bosch}, J. and
+	{Coupon}, J. and {Furusawa}, H. and {Hayashi}, Y. and {Ikeda}, H. and
+	{Kamata}, Y. and {Karoji}, H. and {Kawanomoto}, S. and {Koike}, M. and
+	{Komiyama}, Y. and {Lupton}, R.~H. and {Mineo}, S. and {Miyatake}, H. and
+	{Miyazaki}, S. and {Morokuma}, T. and {Obuchi}, Y. and {Oishi}, Y. and
+	{Okura}, Y. and {Price}, P.~A. and {Takata}, T. and {Tanaka}, M.~M. and
+	{Tanaka}, M. and {Tanaka}, Y. and {Uchida}, T. and {Uraguchi}, F. and
+	{Utsumi}, Y. and {Wang}, S.-Y. and {Yamada}, Y. and {Yamanoi}, H. and
+	{Yasuda}, N. and {Arimoto}, N. and {Chiba}, M. and {Finet}, F. and
+	{Fujimori}, H. and {Fujimoto}, S. and {Furusawa}, J. and {Goto}, T. and
+	{Goulding}, A. and {Gunn}, J.~E. and {Harikane}, Y. and {Hattori}, T. and
+	{Hayashi}, M. and {Helminiak}, K.~G. and {Higuchi}, R. and {Hikage}, C. and
+	{Ho}, P.~T.~P. and {Hsieh}, B.-C. and {Huang}, K. and {Huang}, S. and
+	{Imanishi}, M. and {Iwata}, I. and {Jaelani}, A.~T. and {Jian}, H.-Y. and
+	{Kashikawa}, N. and {Katayama}, N. and {Kojima}, T. and {Konno}, A. and
+	{Koshida}, S. and {Kusakabe}, H. and {Leauthaud}, A. and {Lee}, C.-H. and
+	{Lin}, L. and {Lin}, Y.-T. and {Mandelbaum}, R. and {Matsuoka}, Y. and
+	{Medezinski}, E. and {Miyama}, S. and {Momose}, R. and {More}, A. and
+	{More}, S. and {Mukae}, S. and {Murata}, R. and {Murayama}, H. and
+	{Nagao}, T. and {Nakata}, F. and {Niikura}, H. and {Nishizawa}, A.~J. and
+	{Oguri}, M. and {Okabe}, N. and {Ono}, Y. and {Onodera}, M. and
+	{Onoue}, M. and {Ouchi}, M. and {Pyo}, T.-S. and {Shibuya}, T. and
+	{Shimasaku}, K. and {Simet}, M. and {Speagle}, J. and {Spergel}, D.~N. and
+	{Strauss}, M.~A. and {Sugahara}, Y. and {Sugiyama}, N. and {Suto}, Y. and
+	{Suzuki}, N. and {Tait}, P.~J. and {Takada}, M. and {Terai}, T. and
+	{Toba}, Y. and {Turner}, E.~L. and {Uchiyama}, H. and {Umetsu}, K. and
+	{Urata}, Y. and {Usuda}, T. and {Yeh}, S. and {Yuma}, S.},
+    title = "{First Data Release of the Hyper Suprime-Cam Subaru Strategic Program}",
+  journal = {ArXiv e-prints},
+archivePrefix = "arXiv",
+   eprint = {1702.08449},
+ primaryClass = "astro-ph.IM",
+ keywords = {Astrophysics - Instrumentation and Methods for Astrophysics, Astrophysics - Earth and Planetary Astrophysics, Astrophysics - Astrophysics of Galaxies, Astrophysics - High Energy Astrophysical Phenomena, Astrophysics - Solar and Stellar Astrophysics},
+     year = 2017,
+    month = feb,
+   adsurl = {http://adsabs.harvard.edu/abs/2017arXiv170208449A},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+@ARTICLE{2017arXiv170309824V,
+   author = {{VanderPlas}, J.~T.},
+    title = "{Understanding the Lomb-Scargle Periodogram}",
+  journal = {ArXiv e-prints},
+archivePrefix = "arXiv",
+   eprint = {1703.09824},
+ primaryClass = "astro-ph.IM",
+ keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+     year = 2017,
+    month = mar,
+   adsurl = {http://adsabs.harvard.edu/abs/2017arXiv170309824V},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2017arXiv170804058L,
+   author = {{LSST Science Collaboration} and {Marshall}, P. and {Anguita}, T. and
+	{Bianco}, F.~B. and {Bellm}, E.~C. and {Brandt}, N. and {Clarkson}, W. and
+	{Connolly}, A. and {Gawiser}, E. and {Ivezic}, Z. and {Jones}, L. and
+	{Lochner}, M. and {Lund}, M.~B. and {Mahabal}, A. and {Nidever}, D. and
+	{Olsen}, K. and {Ridgway}, S. and {Rhodes}, J. and {Shemmer}, O. and
+	{Trilling}, D. and {Vivas}, K. and {Walkowicz}, L. and {Willman}, B. and
+	{Yoachim}, P. and {Anderson}, S. and {Antilogus}, P. and {Angus}, R. and
+	{Arcavi}, I. and {Awan}, H. and {Biswas}, R. and {Bell}, K.~J. and
+	{Bennett}, D. and {Britt}, C. and {Buzasi}, D. and {Casetti-Dinescu}, D.~I. and
+	{Chomiuk}, L. and {Claver}, C. and {Cook}, K. and {Davenport}, J. and
+	{Debattista}, V. and {Digel}, S. and {Doctor}, Z. and {Firth}, R.~E. and
+	{Foley}, R. and {Fong}, W.-f. and {Galbany}, L. and {Giampapa}, M. and
+	{Gizis}, J.~E. and {Graham}, M.~L. and {Grillmair}, C. and {Gris}, P. and
+	{Haiman}, Z. and {Hartigan}, P. and {Hawley}, S. and {Hlozek}, R. and
+	{Jha}, S.~W. and {Johns-Krull}, C. and {Kanbur}, S. and {Kalogera}, V. and
+	{Kashyap}, V. and {Kasliwal}, V. and {Kessler}, R. and {Kim}, A. and
+	{Kurczynski}, P. and {Lahav}, O. and {Liu}, M.~C. and {Malz}, A. and
+	{Margutti}, R. and {Matheson}, T. and {McEwen}, J.~D. and {McGehee}, P. and
+	{Meibom}, S. and {Meyers}, J. and {Monet}, D. and {Neilsen}, E. and
+	{Newman}, J. and {O'Dowd}, M. and {Peiris}, H.~V. and {Penny}, M.~T. and
+	{Peters}, C. and {Poleski}, R. and {Ponder}, K. and {Richards}, G. and
+	{Rho}, J. and {Rubin}, D. and {Schmidt}, S. and {Schuhmann}, R.~L. and
+	{Shporer}, A. and {Slater}, C. and {Smith}, N. and {Soares-Santos}, M. and
+	{Stassun}, K. and {Strader}, J. and {Strauss}, M. and {Street}, R. and
+	{Stubbs}, C. and {Sullivan}, M. and {Szkody}, P. and {Trimble}, V. and
+	{Tyson}, T. and {de Val-Borro}, M. and {Valenti}, S. and {Wagoner}, R. and
+	{Wood-Vasey}, W.~M. and {Zauderer}, B.~A.},
+    title = "{Science-Driven Optimization of the LSST Observing Strategy}",
+  journal = {ArXiv e-prints},
+archivePrefix = "arXiv",
+   eprint = {1708.04058},
+ primaryClass = "astro-ph.IM",
+ keywords = {Astrophysics - Instrumentation and Methods for Astrophysics, Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Earth and Planetary Astrophysics, Astrophysics - Astrophysics of Galaxies, Astrophysics - Solar and Stellar Astrophysics},
+     year = 2017,
+    month = aug,
+   adsurl = {http://adsabs.harvard.edu/abs/2017arXiv170804058L},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2017PASP..129g4503B,
+   author = {{Bernstein}, G.~M. and {Armstrong}, R. and {Plazas}, A.~A. and
+	{Walker}, A.~R. and {Abbott}, T.~M.~C. and {Allam}, S. and {Bechtol}, K. and
+	{Benoit-L{\'e}vy}, A. and {Brooks}, D. and {Burke}, D.~L. and
+	{Carnero Rosell}, A. and {Carrasco Kind}, M. and {Carretero}, J. and
+	{Cunha}, C.~E. and {da Costa}, L.~N. and {DePoy}, D.~L. and
+	{Desai}, S. and {Diehl}, H.~T. and {Eifler}, T.~F. and {Fernandez}, E. and
+	{Fosalba}, P. and {Frieman}, J. and {Garc{\'{\i}}a-Bellido}, J. and
+	{Gerdes}, D.~W. and {Gruen}, D. and {Gruendl}, R.~A. and {Gschwend}, J. and
+	{Gutierrez}, G. and {Honscheid}, K. and {James}, D.~J. and {Kent}, S. and
+	{Krause}, E. and {Kuehn}, K. and {Kuropatkin}, N. and {Li}, T.~S. and
+	{Maia}, M.~A.~G. and {March}, M. and {Marshall}, J.~L. and {Menanteau}, F. and
+	{Miquel}, R. and {Ogando}, R.~L.~C. and {Reil}, K. and {Roodman}, A. and
+	{Rykoff}, E.~S. and {Sanchez}, E. and {Scarpine}, V. and {Schindler}, R. and
+	{Schubnell}, M. and {Sevilla-Noarbe}, I. and {Smith}, M. and
+	{Smith}, R.~C. and {Soares-Santos}, M. and {Sobreira}, F. and
+	{Suchyta}, E. and {Swanson}, M.~E.~C. and {Tarle}, G. and {DES Collaboration}
+	},
+    title = "{Astrometric Calibration and Performance of the Dark Energy Camera}",
+  journal = {\pasp},
+archivePrefix = "arXiv",
+   eprint = {1703.01679},
+ primaryClass = "astro-ph.IM",
+     year = 2017,
+    month = jul,
+   volume = 129,
+   number = 7,
+    pages = {074503},
+      doi = {10.1088/1538-3873/aa6c55},
+   adsurl = {http://adsabs.harvard.edu/abs/2017PASP..129g4503B},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2016A&C....15...33B,
+   author = {{Berry}, D.~S. and {Warren-Smith}, R.~F. and {Jenness}, T.},
+    title = "{AST: A library for modelling and manipulating coordinate systems}",
+  journal = {Astronomy and Computing},
+archivePrefix = "arXiv",
+   eprint = {1602.06681},
+ primaryClass = "astro-ph.IM",
+ keywords = {World Coordinate Systems, Data models, Starlink},
+     year = 2016,
+    month = apr,
+   volume = 15,
+    pages = {33-49},
+      doi = {10.1016/j.ascom.2016.02.003},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2005ASPC..347..491S,
+   author = {{Shupe}, D.~L. and {Moshir}, M. and {Li}, J. and {Makovoz}, D. and
+	{Narron}, R. and {Hook}, R.~N.},
+    title = "{The SIP Convention for Representing Distortion in FITS Image Headers}",
+booktitle = {Astronomical Data Analysis Software and Systems XIV},
+     year = 2005,
+   series = {Astronomical Society of the Pacific Conference Series},
+   volume = 347,
+   editor = {{Shopbell}, P. and {Britton}, M. and {Ebert}, R.},
+    month = dec,
+    pages = {491},
+   adsurl = {http://adsabs.harvard.edu/abs/2005ASPC..347..491S},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2002A&A...395.1061G,
+   author = {{Greisen}, E.~W. and {Calabretta}, M.~R.},
+    title = "{Representations of world coordinates in FITS}",
+  journal = {\aap},
+   eprint = {astro-ph/0207407},
+ keywords = {methods: data analysis, techniques: image processing, astronomical data bases: miscellaneous},
+     year = 2002,
+    month = dec,
+   volume = 395,
+    pages = {1061-1075},
+      doi = {10.1051/0004-6361:20021326},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2016SPIE.9910E..1AY,
+   author = {{Yoachim}, P. and {Coughlin}, M. and {Angeli}, G.~Z. and {Claver}, C.~F. and
+	{Connolly}, A.~J. and {Cook}, K. and {Daniel}, S. and {Ivezi{\'c}}, {\v Z}. and
+	{Jones}, R.~L. and {Petry}, C. and {Reuter}, M. and {Stubbs}, C. and
+	{Xin}, B.},
+    title = "{An optical to IR sky brightness model for the LSST}",
+booktitle = {Observatory Operations: Strategies, Processes, and Systems VI},
+     year = 2016,
+   series = {\procspie},
+   volume = 9910,
+    month = jul,
+      eid = {99101A},
+    pages = {99101A},
+      doi = {10.1117/12.2232947},
+   adsurl = {http://adsabs.harvard.edu/abs/2016SPIE.9910E..1AY},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2017arXiv170202968M,
+   author = {{Mohammadi}, M. and {Bazhirov}, T.},
+    title = "{Comparative benchmarking of cloud computing vendors with High Performance Linpack}",
+  journal = {ArXiv e-prints},
+archivePrefix = "arXiv",
+   eprint = {1702.02968},
+ primaryClass = "cs.PF",
+ keywords = {Computer Science - Performance, Computer Science - Distributed, Parallel, and Cluster Computing},
+     year = 2017,
+    month = feb,
+   adsurl = {http://adsabs.harvard.edu/abs/2017arXiv170202968M},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2004PASP..116..133L,
+   author = {{Lupton}, R. and {Blanton}, M.~R. and {Fekete}, G. and {Hogg}, D.~W. and
+	{O'Mullane}, W. and {Szalay}, A. and {Wherry}, N.},
+    title = "{Preparing Red-Green-Blue Images from CCD Data}",
+  journal = {\pasp},
+   eprint = {astro-ph/0312483},
+ keywords = {Techniques: Image Processing, Techniques: Photometric},
+     year = 2004,
+    month = feb,
+   volume = 116,
+    pages = {133-137},
+      doi = {10.1086/382245},
+   adsurl = {http://adsabs.harvard.edu/abs/2004PASP..116..133L},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2016ApJ...832..155F,
+   author = {{F{\"o}rster}, F. and {Maureira}, J.~C. and {San Mart{\'{\i}}n}, J. and
+	{Hamuy}, M. and {Mart{\'{\i}}nez}, J. and {Huijse}, P. and {Cabrera}, G. and
+	{Galbany}, L. and {de Jaeger}, T. and {Gonz{\'a}lez{\ndash}Gait{\'a}n}, S. and
+	{Anderson}, J.~P. and {Kunkarayakti}, H. and {Pignata}, G. and
+	{Bufano}, F. and {Litt{\'{\i}}n}, J. and {Olivares}, F. and
+	{Medina}, G. and {Smith}, R.~C. and {Vivas}, A.~K. and {Est{\'e}vez}, P.~A. and
+	{Mu{\~n}oz}, R. and {Vera}, E.},
+    title = "{The High Cadence Transient Survey (HITS). I. Survey Design and Supernova Shock Breakout Constraints}",
+  journal = {\apj},
+archivePrefix = "arXiv",
+   eprint = {1609.03567},
+ primaryClass = "astro-ph.SR",
+ keywords = {methods: data analysis, supernovae: general, surveys, techniques: image processing},
+     year = 2016,
+    month = dec,
+   volume = 832,
+      eid = {155},
+    pages = {155},
+      doi = {10.3847/0004-637X/832/2/155},
+   adsurl = {http://adsabs.harvard.edu/abs/2016ApJ...832..155F},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2016A&A...595A...2G,
+   author = {{Gaia Collaboration} and {Brown}, A.~G.~A. and {Vallenari}, A. and
+	{Prusti}, T. and {de Bruijne}, J.~H.~J. and {Mignard}, F. and
+	{Drimmel}, R. and {Babusiaux}, C. and {Bailer-Jones}, C.~A.~L. and
+	{Bastian}, U. and et al.},
+    title = "{Gaia Data Release 1. Summary of the astrometric, photometric, and survey properties}",
+  journal = {\aap},
+archivePrefix = "arXiv",
+   eprint = {1609.04172},
+ primaryClass = "astro-ph.IM",
+ keywords = {catalogs, astrometry, parallaxes, proper motions, surveys},
+     year = 2016,
+    month = nov,
+   volume = 595,
+      eid = {A2},
+    pages = {A2},
+      doi = {10.1051/0004-6361/201629512},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+@INPROCEEDINGS{2001misk.conf..638O,
+   author = {{O'Mullane}, W. and {Banday}, A.~J. and {G{\'o}rski}, K.~M. and
+	{Kunszt}, P. and {Szalay}, A.~S.},
+    title = "{Splitting the Sky - HTM and HEALPix}",
+booktitle = {Mining the Sky},
+     year = 2001,
+   editor = {{Banday}, A.~J. and {Zaroubi}, S. and {Bartelmann}, M.},
+    pages = {638},
+      doi = {10.1007/10849171_84},
+   adsurl = {http://ads.nao.ac.jp/abs/2001misk.conf..638O},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+
+@INPROCEEDINGS{2004ASPC..314..372O,
+   author = {{O'Mullane}, W. and {Gray}, J. and {Li}, N. and {Budav{\'a}ri}, T. and
+	{Nieto-Santisteban}, M.~A. and {Szalay}, A.~S.},
+    title = "{Batch Query System with Interactive Local Storage for SDSS and the VO}",
+booktitle = {Astronomical Data Analysis Software and Systems (ADASS) XIII},
+     year = 2004,
+   series = {Astronomical Society of the Pacific Conference Series},
+   volume = 314,
+   editor = {{Ochsenbein}, F. and {Allen}, M.~G. and {Egret}, D.},
+    month = jul,
+    pages = {372},
+   adsurl = {http://ads.nao.ac.jp/abs/2004ASPC..314..372O},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2018ApJ...860L..11K,
+       author = {{Koppelman}, Helmer and {Helmi}, Amina and {Veljanoski}, Jovan},
+        title = "{One Large Blob and Many Streams Frosting the nearby Stellar Halo in
+        Gaia~DR2}",
+      journal = {\apj},
+     keywords = {Galaxy: halo, Galaxy: kinematics and dynamics, solar neighborhood,
+        Astrophysics - Astrophysics of Galaxies},
+         year = 2018,
+        month = Jun,
+       volume = {860},
+          eid = {L11},
+        pages = {L11},
+          doi = {10.3847/2041-8213/aac882},
+       adsurl = {https://ui.adsabs.harvard.edu/#abs/2018ApJ...860L..11K},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2017arXiv170202600H,
+   author = {{Huff}, E. and {Mandelbaum}, R.},
+    title = "{Metacalibration: Direct Self-Calibration of Biases in Shear Measurement}",
+  journal = {ArXiv e-prints},
+archivePrefix = "arXiv",
+   eprint = {1702.02600},
+ keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics},
+     year = 2017,
+    month = feb,
+   adsurl = {http://adsabs.harvard.edu/abs/2017arXiv170202600H},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2014MNRAS.438.1880B,
+   author = {{Bernstein}, G.~M. and {Armstrong}, R.},
+    title = "{Bayesian lensing shear measurement}",
+  journal = {\mnras},
+archivePrefix = "arXiv",
+   eprint = {1304.1843},
+ keywords = {gravitational lensing: weak, methods: data analysis},
+     year = 2014,
+    month = feb,
+   volume = 438,
+    pages = {1880-1893},
+      doi = {10.1093/mnras/stt2326},
+   adsurl = {http://adsabs.harvard.edu/abs/2014MNRAS.438.1880B},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2018SPIE10707E..09J,
+   author = {Tim Jenness and Frossie Economou and Krzysztof Findeisen and
+             Fabio Hernandez and Josh Hoblitt and others},
+    title = "{LSST data management software development practices and tools}",
+booktitle = {Software and Cyberinfrastructure for Astronomy V},
+     year = 2018,
+   series = {\procspie},
+   volume = 10707,
+    month = jul,
+      eid = {1070709},
+    pages = {1070709},
+      doi = {10.1117/12.2312157},
+   adsurl = {http://adsabs.harvard.edu/abs/2018SPIE10707E..09J},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2015ASPC..495..101B,
+   author = {{Beaumont}, C. and {Goodman}, A. and {Greenfield}, P.},
+    title = "{Hackable User Interfaces In Astronomy with Glue}",
+booktitle = {Astronomical Data Analysis Software an Systems XXIV (ADASS XXIV)},
+     year = 2015,
+   series = {Astronomical Society of the Pacific Conference Series},
+   volume = 495,
+   editor = {{Taylor}, A.~R. and {Rosolowsky}, E.},
+    month = sep,
+    pages = {101},
+   adsurl = {http://adsabs.harvard.edu/abs/2015ASPC..495..101B},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2013A&A...549A...8B,
+   author = {{Buton}, C. and {Copin}, Y. and {Aldering}, G. and {Antilogus}, P. and
+             {Aragon}, C. and {Bailey}, S. and {Baltay}, C. and {Bongard}, S.
+             and {Canto}, A. and {Cellier-Holzem}, F. and {Childress}, M. and
+             {Chotard}, N. and {Fakhouri}, H.~K. and {Gangler}, E. and {Guy},
+             J. and {Hsiao}, E.~Y. and {Kerschhaggl}, M. and {Kowalski}, M.
+             and {Loken}, S. and {Nugent}, P. and {Paech}, K. and {Pain}, R.
+             and {P{\'e}contal}, E. and {Pereira}, R. and {Perlmutter}, S.
+             and {Rabinowitz}, D. and {Rigault}, M. and {Runge}, K. and
+             {Scalzo}, R. and {Smadja}, G. and {Tao}, C. and {Thomas}, R.~C.
+             and {Weaver}, B.~A. and {Wu}, C. and {Nearby SuperNova Factory}},
+    title = "{Atmospheric extinction properties above Mauna Kea from the Nearby
+              SuperNova Factory spectro-photometric data set}",
+  journal = {\aap},
+     year = 2013,
+    month = Jan,
+   volume = {549},
+      eid = {A8},
+    pages = {A8},
+      doi = {10.1051/0004-6361/201219834},
+   eprint = {1210.2619},
+   adsurl = {https://ui.adsabs.harvard.edu/#abs/2013A&A...549A...8B},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2018SPIE10704E..20C,
+   author = {{Coughlin}, Michael W. and {Deustua}, Susana and {Guyonnet}, Augustin
+             and {Mondrik}, Nicholas and {Rice}, Joseph P. and {Stubbs},
+             Christopher W. and {Woodward}, John T.},
+    title = "{Testing of the LSST's photometric calibration strategy at the CTIO 0.9
+              meter telescope}",
+ keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+booktitle = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
+     year = 2018,
+   volume = {10704},
+    month = Jul,
+      eid = {1070420},
+    pages = {1070420},
+      doi = {10.1117/12.2309582},
+   adsurl = {https://ui.adsabs.harvard.edu/#abs/2018SPIE10704E..20C},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2018MNRAS.477.5477P,
+   author = {{P{\'e}rez-Jord{\'a}n}, w. and {Castro-Almaz{\'a}n}, J.~A. and {Mu{\~n}oz-Tu{\~n}{\'o}n}, C.},
+    title = "{Precipitable water vapour forecasting: a tool for optimizing IR observations at Roque de los Muchachos Observatory}",
+  journal = {\mnras},
+   eprint = {1804.05200},
+ keywords = {atmospheric effects, methods: data analysis, methods: numerical, methods: statistical, site testing, infrared: general},
+     year = 2018,
+    month = jul,
+   volume = 477,
+    pages = {5477-5485},
+      doi = {10.1093/mnras/sty943},
+   adsurl = {http://adsabs.harvard.edu/abs/2018MNRAS.477.5477P},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@MISC{2011ivoa.spec.0711S,
+   author = {{Seaman}, R. and {Williams}, R. and {Allan}, A. and {Barthelmy}, S. and
+	{Bloom}, J. and {Brewer}, J. and {Denny}, R. and {Fitzpatrick}, M. and
+	{Graham}, M. and {Gray}, N. and {Hessman}, F. and {Marka}, S. and
+	{Rots}, A. and {Vestrand}, T. and {Wozniak}, P.},
+    title = "{Sky Event Reporting Metadata Version 2.0}",
+howpublished = {IVOA Recommendation 11 July 2011},
+     year = 2011,
+    month = jul,
+archivePrefix = "arXiv",
+   eprint = {1110.0523},
+ primaryClass = "astro-ph.IM",
+   editor = {{Seaman}, R. and {Williams}, R.},
+   adsurl = {http://adsabs.harvard.edu/abs/2011ivoa.spec.0711S},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2017arXiv170901264A,
+   author = {{Allan}, A. and {Denny}, R.~B. and {Swinbank}, J.~D.},
+    title = "{IVOA Recommendation: VOEvent Transport Protocol Version 2.0}",
+  journal = {arXiv e-prints},
+archivePrefix = "arXiv",
+   eprint = {1709.01264},
+ primaryClass = "astro-ph.IM",
+ keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+     year = 2017,
+    month = sep,
+   adsurl = {http://adsabs.harvard.edu/abs/2017arXiv170901264A},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2014A&C.....7...12S,
+   author = {{Swinbank}, J.},
+    title = "{Comet: A VOEvent broker}",
+  journal = {Astronomy and Computing},
+archivePrefix = "arXiv",
+   eprint = {1409.4805},
+ primaryClass = "astro-ph.IM",
+ keywords = {VOEvent, Astronomical transients, Time domain astrophysics, Network protocol design},
+     year = 2014,
+    month = nov,
+   volume = 7,
+    pages = {12-26},
+      doi = {10.1016/j.ascom.2014.09.001},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2018SPIE10707E..11S,
+       author = {{Street}, R.~A. and {Bowman}, M. and {Saunders}, E.~S. and {Boroson}, T.},
+        title = "{General-purpose software for managing astronomical observing programs in the LSST era}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+    booktitle = {Software and Cyberinfrastructure for Astronomy V},
+         year = 2018,
+       series = {Proc.\ SPIE},
+       volume = {10707},
+        month = Jul,
+          eid = {1070711},
+        pages = {1070711},
+          doi = {10.1117/12.2312293},
+archivePrefix = {arXiv},
+       eprint = {1806.09557},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/\#abs/2018SPIE10707E..11S},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2002cs........8011G,
+       author = {{Gray}, Jim and {Chong}, Wyman and {Barclay}, Tom and {Szalay}, Alex and
+        {vandenBerg}, Jan},
+        title = "{TeraScale SneakerNet: Using Inexpensive Disks for Backup, Archiving, and Data Exchange}",
+      journal = {arXiv e-prints},
+     keywords = {Computer Science - Networking and Internet Architecture, Computer Science - Distributed, Parallel, and Cluster Computing, C.2.0, C.2.4, C.4.4, H.3, K.6},
+         year = 2002,
+        month = Aug,
+          eid = {cs/0208011},
+        pages = {cs/0208011},
+archivePrefix = {arXiv},
+       eprint = {cs/0208011},
+ primaryClass = {cs.NI},
+       adsurl = {https://ui.adsabs.harvard.edu/\#abs/2002cs........8011G},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2019AAS...23324505B,
+       author = {{Bektesevic}, Dino and {Mehta}, Parmita and {Juric}, Mario and
+         {Slater}, Colin and {Balazinska}, Magdalena and {Connolly}, Andrew},
+        title = "{Cloud Services as an environment for large scale astronomical image analytics.}",
+    booktitle = {American Astronomical Society Meeting Abstracts \#233},
+         year = "2019",
+       series = {American Astronomical Society Meeting Abstracts},
+       volume = {233},
+        month = "Jan",
+          eid = {245.05},
+        pages = {245.05},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2019AAS...23324505B},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2019AAS...23345706M,
+       author = {{Momcheva}, Ivelina and {Smith}, Arfon M. and {Fox}, Mike},
+        title = "{Hubble in the Cloud}",
+    booktitle = {American Astronomical Society Meeting Abstracts \#233},
+         year = "2019",
+       series = {American Astronomical Society Meeting Abstracts},
+       volume = {233},
+        month = "Jan",
+          eid = {457.06},
+        pages = {457.06},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2019AAS...23345706M},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2019arXiv190505116B,
+       author = {{Bauer}, Amanda E. and {Bellm}, Eric C. and {Bolton}, Adam S. and
+         {Chaudhuri}, Surajit and {Connolly}, A.~J. and {Cruz}, Kelle L. and
+         {Desai}, Vandana and {Drlica-Wagner}, Alex and {Economou}, Frossie and
+         {Gaffney}, Niall and {Kavelaars}, J. and {Kinney}, J. and
+         {Li}, Ting S. and {Lundgren}, B. and {Margutti}, R. and {Narayan}, G. and
+         {Nord}, B. and {Norman}, Dara J. and {O'Mullane}, W. and {Padhi}, S. and
+         {Peek}, J.~E.~G. and {Schafer}, C. and {Schwamb}, Megan E. and
+         {Smith}, Arfon M. and {Tollerud}, Erik J. and {Weijmans}, Anne-Marie and
+         {Szalay}, Alexander S.},
+        title = "{Petabytes to Science}",
+      journal = {arXiv e-prints},
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+         year = "2019",
+        month = "May",
+          eid = {arXiv:1905.05116},
+        pages = {arXiv:1905.05116},
+archivePrefix = {arXiv},
+       eprint = {1905.05116},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2019arXiv190505116B},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+
+@ARTICLE{2018AJ....155...41B,
+       author = {{Burke}, D.~L. and {Rykoff}, E.~S. and {Allam}, S. and {Annis}, J. and
+         {Bechtol}, K. and {Bernstein}, G.~M. and {Drlica-Wagner}, A. and
+         {Finley}, D.~A. and {Gruendl}, R.~A. and {James}, D.~J.},
+        title = "{Forward Global Photometric Calibration of the Dark Energy Survey}",
+      journal = {\aj},
+     keywords = {methods: observational, techniques: photometric, Astrophysics - Instrumentation and Methods for Astrophysics},
+         year = "2018",
+        month = "Jan",
+       volume = {155},
+       number = {1},
+          eid = {41},
+        pages = {41},
+          doi = {10.3847/1538-3881/aa9f22},
+archivePrefix = {arXiv},
+       eprint = {1706.01542},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2018AJ....155...41B},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+
+@ARTICLE{2018arXiv181208085J,
+       author = {{Jenness}, Tim and {Bosch}, James F. and {Schellart}, Pim and
+         {Lim}, Kian-Ta and {Salnikov}, Andrei and {Gower}, Michelle},
+        title = "{Abstracting the storage and retrieval of image data at the LSST}",
+      journal = {arXiv e-prints},
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+         year = "2018",
+        month = "Dec",
+          eid = {arXiv:1812.08085},
+        pages = {arXiv:1812.08085},
+archivePrefix = {arXiv},
+       eprint = {1812.08085},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2018arXiv181208085J},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+
+@INPROCEEDINGS{2007ASPC..376..347D,
+       author = {{Dowler}, P.~D. and {Gaudet}, S. and {Durand}, D. and {Redman}, R. and
+         {Hill}, N. and {Goliath}, S.},
+        title = "{Common Archive Observation Model}",
+    booktitle = {Astronomical Data Analysis Software and Systems XVI},
+         year = "2007",
+       editor = {{Shaw}, R.~A. and {Hill}, F. and {Bell}, D.~J.},
+       series = {Astronomical Society of the Pacific Conference Series},
+       volume = {376},
+        month = "Oct",
+        pages = {347},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2007ASPC..376..347D},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2018AJ....156..135H,
+   author = {{Holman}, M.~J. and {Payne}, M.~J. and {Blankley}, P. and {Janssen}, R. and
+	{Kuindersma}, S.},
+    title = "{HelioLinC: A Novel Approach to the Minor Planet Linking Problem}",
+  journal = {\aj},
+ keywords = {astrometry, celestial mechanics, ephemerides, minor planets, asteroids: general},
+     year = 2018,
+    month = sep,
+   volume = 156,
+      eid = {135},
+    pages = {135},
+      doi = {10.3847/1538-3881/aad69a},
+   adsurl = {https://ui.adsabs.harvard.edu/abs/2018AJ....156..135H},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2018A&C....24..129M,
+   author = {{Melchior}, P. and {Moolekamp}, F. and {Jerdee}, M. and {Armstrong}, R. and
+	{Sun}, A.-L. and {Bosch}, J. and {Lupton}, R.},
+    title = "{SCARLET: Source separation in multi-band images by Constrained Matrix Factorization}",
+  journal = {Astronomy and Computing},
+archivePrefix = "arXiv",
+   eprint = {1802.10157},
+ primaryClass = "astro-ph.IM",
+ keywords = {Methods, Data analysis, Techniques, Image processing, Galaxies, Non-negative matrix factorization},
+     year = 2018,
+    month = jul,
+   volume = 24,
+    pages = {129--142},
+      doi = {10.1016/j.ascom.2018.07.001},
+   adsurl = {https://ui.adsabs.harvard.edu/abs/2018A%26C....24..129M},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2014JInst...9C3048A,
+   author = {{Antilogus}, P. and {Astier}, P. and {Doherty}, P. and {Guyonnet}, A. and
+	{Regnault}, N.},
+    title = "{The brighter-fatter effect and pixel correlations in CCD sensors}",
+  journal = {Journal of Instrumentation},
+archivePrefix = "arXiv",
+   eprint = {1402.0725},
+ primaryClass = "astro-ph.IM",
+     year = 2014,
+    month = mar,
+   volume = 9,
+      eid = {C03048},
+    pages = {C03048},
+      doi = {10.1088/1748-0221/9/03/C03048},
+   adsurl = {https://ui.adsabs.harvard.edu/abs/2014JInst...9C3048A},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2018arXiv181004815N,
+       author = {{Naghib}, Elahesadat and {Yoachim}, Peter and {Vanderbei}, Robert J. and
+        {Connolly}, Andrew J. and {Jones}, R. Lynne},
+        title = "{A Framework for Telescope Schedulers: With Applications to the Large Synoptic Survey Telescope}",
+      journal = {arXiv e-prints},
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+         year = 2018,
+        month = Oct,
+          eid = {arXiv:1810.04815},
+        pages = {arXiv:1810.04815},
+archivePrefix = {arXiv},
+       eprint = {1810.04815},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/\#abs/2018arXiv181004815N},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2018Icar..303..181J,
+   author = {{Jones}, R.~L. and {Slater}, C.~T. and {Moeyens}, J. and {Allen}, L. and
+	{Axelrod}, T. and {Cook}, K. and {Ivezi{\'c}}, {\v Z}. and {Juri{\'c}}, M. and
+	{Myers}, J. and {Petry}, C.~E.},
+    title = "{The Large Synoptic Survey Telescope as a Near-Earth Object discovery machine}",
+  journal = {\icarus},
+archivePrefix = "arXiv",
+   eprint = {1711.10621},
+ primaryClass = "astro-ph.EP",
+ keywords = {Near-Earth objects, Image processing, Asteroids},
+     year = 2018,
+    month = mar,
+   volume = 303,
+    pages = {181-202},
+      doi = {10.1016/j.icarus.2017.11.033},
+   adsurl = {http://adsabs.harvard.edu/abs/2018Icar..303..181J},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2015arXiv151207914J,
+       author = {{Juri{\'c}}, M. and {Kantor}, J. and {Lim}, K. -T. and {Lupton}, R.~H. and
+         {Dubois-Felsmann}, G. and {Jenness}, T. and {Axelrod}, T.~S. and
+         {Aleksi{\'c}}, J. and {Allsman}, R.~A. and {AlSayyad}, Y. and
+         {Alt}, J. and {Armstrong}, R. and {Basney}, J. and {Becker}, A.~C. and
+         {Becla}, J. and {Biswas}, R. and {Bosch}, J. and {Boutigny}, D. and
+         {Kind}, M.~C. and {Ciardi}, D.~R. and {Connolly}, A.~J. and
+         {Daniel}, S.~F. and {Daues}, G.~E. and {Economou}, F. and
+         {Chiang}, H. -F. and {Fausti}, A. and {Fisher-Levine}, M. and
+         {Freemon}, D.~M. and {Gris}, P. and {Hernandez}, F. and {Hoblitt}, J. and
+         {Ivezi{\'c}}, Z. and {Jammes}, F. and {Jevremovi{\'c}}, D. and
+         {Jones}, R.~L. and {Kalmbach}, J.~B. and {Kasliwal}, V.~P. and
+         {Krughoff}, K.~S. and {Lurie}, J. and {Lust}, N.~B. and
+         {MacArthur}, L.~A. and {Melchior}, P. and {Moeyens}, J. and
+         {Nidever}, D.~L. and {Owen}, R. and {Parejko}, J.~K. and
+         {Peterson}, J.~M. and {Petravick}, D. and {Pietrowicz}, S.~R. and
+         {Price}, P.~A. and {Reiss}, D.~J. and {Shaw}, R.~A. and {Sick}, J. and
+         {Slater}, C.~T. and {Strauss}, M.~A. and {Sullivan}, I.~S. and
+         {Swinbank}, J.~D. and {Van Dyk}, S. and {Vuj{\v{c}}i{\'c}}, V. and
+         {Withers}, A. and {Yoachim}, P.},
+        title = "{The LSST Data Management System}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+    booktitle = {Astronomical Data Analysis Software and Systems XXV},
+         year = "2017",
+       editor = {{Lorente}, N.~P.~F. and {Shortridge}, K. and {Wayth}, R.},
+       series = {ASP Conf.\ Ser.},
+       volume = {512},
+        month = "Dec",
+        pages = {279},
+archivePrefix = {arXiv},
+       eprint = {1512.07914},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2017ASPC..512..279J},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2017ASPC..512..279J,
+       author = {{Juri{\'c}}, M. and {Kantor}, J. and {Lim}, K. -T. and {Lupton}, R.~H. and
+         {Dubois-Felsmann}, G. and {Jenness}, T. and {Axelrod}, T.~S. and
+         {Aleksi{\'c}}, J. and {Allsman}, R.~A. and {AlSayyad}, Y. and
+         {Alt}, J. and {Armstrong}, R. and {Basney}, J. and {Becker}, A.~C. and
+         {Becla}, J. and {Biswas}, R. and {Bosch}, J. and {Boutigny}, D. and
+         {Kind}, M.~C. and {Ciardi}, D.~R. and {Connolly}, A.~J. and
+         {Daniel}, S.~F. and {Daues}, G.~E. and {Economou}, F. and
+         {Chiang}, H. -F. and {Fausti}, A. and {Fisher-Levine}, M. and
+         {Freemon}, D.~M. and {Gris}, P. and {Hernandez}, F. and {Hoblitt}, J. and
+         {Ivezi{\'c}}, Z. and {Jammes}, F. and {Jevremovi{\'c}}, D. and
+         {Jones}, R.~L. and {Kalmbach}, J.~B. and {Kasliwal}, V.~P. and
+         {Krughoff}, K.~S. and {Lurie}, J. and {Lust}, N.~B. and
+         {MacArthur}, L.~A. and {Melchior}, P. and {Moeyens}, J. and
+         {Nidever}, D.~L. and {Owen}, R. and {Parejko}, J.~K. and
+         {Peterson}, J.~M. and {Petravick}, D. and {Pietrowicz}, S.~R. and
+         {Price}, P.~A. and {Reiss}, D.~J. and {Shaw}, R.~A. and {Sick}, J. and
+         {Slater}, C.~T. and {Strauss}, M.~A. and {Sullivan}, I.~S. and
+         {Swinbank}, J.~D. and {Van Dyk}, S. and {Vuj{\v{c}}i{\'c}}, V. and
+         {Withers}, A. and {Yoachim}, P.},
+        title = "{The LSST Data Management System}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+    booktitle = {Astronomical Data Analysis Software and Systems XXV},
+         year = "2017",
+       editor = {{Lorente}, N.~P.~F. and {Shortridge}, K. and {Wayth}, R.},
+       series = {ASP Conf.\ Ser.},
+       volume = {512},
+        month = "Dec",
+        pages = {279},
+archivePrefix = {arXiv},
+       eprint = {1512.07914},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2017ASPC..512..279J},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2014SPIE.9145E..1AG,
+   author = {{Gressler}, W. and {DeVries}, J. and {Hileman}, E. and {Neill}, D.~R. and {Sebag}, J. and {Wiecha}, O. and {Andrew}, J. and {Lotz}, P. and  {Schoening}, W.},
+   title = "{LSST Telescope and site status}",
+   series = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
+   booktitle = {Ground-based and Airborne Telescopes V},
+   editor = {Larry M. Stepp and Roberto Gilmozzi and Helen J. Hall},
+   year = 2014,
+   volume = 9145,
+   month = jul,
+   eid = {91451A},
+   pages = {1},
+   doi = {10.1117/12.2056711},
+   adsurl = {http://adsabs.harvard.edu/abs/2014SPIE.9145E..1AG},
+   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+   }
+
+@INPROCEEDINGS{2014SPIE.9150E..0MC,
+   author = {{Claver}, C.~F. and {Selvy}, B.~M. and {Angeli}, G. and {Delgado}, F. and
+	{Dubois-Felsmann}, G. and {Hascall}, P. and {Lotz}, P. and {Marshall}, S. and
+	{Schumacher}, G. and {Sebag}, J.},
+    title = "{Systems engineering in the Large Synoptic Survey Telescope project: an application of model based systems engineering}",
+   series = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
+booktitle = {Modeling, Systems Engineering, and Project Management for Astronomy VI},
+   editor = {George Z. Angeli and Philippe Dierickx},
+     year = 2014,
+   volume = 9150,
+      eid = {91500M},
+    pages = {0},
+      doi = {10.1117/12.2056781},
+   adsurl = {http://adsabs.harvard.edu/abs/2014SPIE.9150E..0MC},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+
+@INPROCEEDINGS{2014SPIE.9149E..0BJ,
+   author = {{Jones}, R.~L. and {Yoachim}, P. and {Chandrasekharan}, S. and {Connolly}, A.~J. and {Cook}, K.~H. and {Ivezic}, {\v Z}. and  {Krughoff}, K.~S. and {Petry}, C. and {Ridgway}, S.~T.},
+    title = "{The LSST metrics analysis framework (MAF)}",
+    series = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
+    booktitle = {Observatory Operations: Strategies, Processes, and Systems V},
+    editor = {Alison B. Peck and Chris R. Benn and Robert L. Seaman},
+    year = 2014,
+    volume = 9149,
+    eid = {91490B},
+    pages = {0},
+    doi = {10.1117/12.2056835},
+    adsurl = {http://adsabs.harvard.edu/abs/2014SPIE.9149E..0BJ},
+   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+
+@INPROCEEDINGS{2014SPIE.9150E..15D,
+   author = {{Delgado}, F. and {Saha}, A. and {Chandrasekharan}, S. and {Cook}, K. and {Petry}, C. and {Ridgway}, S.},
+    title = "{The LSST operations simulator}",
+    series = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
+    booktitle = {Modeling, Systems Engineering, and Project Management for Astronomy VI},
+    editor = {George Z. Angeli and Philippe Dierickx},
+    year = {2014},
+    volume = 9150,
+    eid = {915015},
+    pages = {15},
+    doi = {10.1117/12.2056898},
+    adsurl = {http://adsabs.harvard.edu/abs/2014SPIE.9150E..15D},
+   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2010SPIE.7735E..0JK,
+   author = {{Kahn}, S.~M. and {Kurita}, N. and {Gilmore}, K. and {Nordby}, M. and
+	{O'Connor}, P. and {Schindler}, R. and {Oliver}, J. and {Van Berg}, R. and
+	{Olivier}, S. and {Riot}, V. and {Antilogus}, P. and {Schalk}, T. and
+	{Huffer}, M. and {Bowden}, G. and {Singal}, J. and {Foss}, M.
+	},
+    title = "{Design and development of the 3.2 gigapixel camera for the Large Synoptic Survey Telescope}",
+   series = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
+booktitle = {Ground-based and Airborne Instrumentation for Astronomy III},
+   editor = {Ian S. McLean and Suzanne K. Ramsay and Hideki Takami},
+     year = 2010,
+   volume = 7735,
+      eid = {77350J},
+    pages = {0},
+      doi = {10.1117/12.857920},
+   adsurl = {http://adsabs.harvard.edu/abs/2010SPIE.7735E..0JK},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2014SPIE.9150E..14C,
+   author = {{Connolly}, A.~J. and {Angeli}, G.~Z. and {Chandrasekharan}, S. and {Claver}, C.~F. and {Cook}, K. and {Ivezic}, Z. and {Jones}, R.~L. and   {Krughoff}, K.~S. and {Peng}, E.-H. and {Peterson}, J. and {Petry}, C. and    {Rasmussen}, A.~P. and {Ridgway}, S.~T. and {Saha}, A. and {Sembroski}, G. and    {vanderPlas}, J. and {Yoachim}, P.},
+    title = "{An end-to-end simulation framework for the Large Synoptic Survey Telescope}",
+    series = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
+    booktitle = {Modeling, Systems Engineering, and Project Management for Astronomy VI},
+    editor = {George Z. Angeli and Philippe Dierickx},
+    year = 2014,
+    volume = 9150,
+    eid = {915014},
+    pages = {14},
+    doi = {10.1117/12.2054953},
+    adsurl = {http://adsabs.harvard.edu/abs/2014SPIE.9150E..14C},
+    adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2014SPIE.9150E..0NS,
+   author = {{Selvy}, B.~M. and {Claver}, C. and {Angeli}, G.},
+    title = "{Using SysML for verification and validation planning on the Large Synoptic Survey Telescope (LSST)}",
+   series = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
+booktitle = {Modeling, Systems Engineering, and Project Management for Astronomy VI},
+   editor = {George Z. Angeli and Philippe Dierickx},
+     year = 2014,
+   volume = 9150,
+      eid = {91500N},
+    pages = {0},
+      doi = {10.1117/12.2056773},
+   adsurl = {http://adsabs.harvard.edu/abs/2014SPIE.9150E..0NS},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2018PASJ...70S...5B,
+   author = {{Bosch}, J. and {Armstrong}, R. and {Bickerton}, S. and {Furusawa}, H. and
+        {Ikeda}, H. and {Koike}, M. and {Lupton}, R. and {Mineo}, S. and
+        {Price}, P. and {Takata}, T. and {Tanaka}, M. and {Yasuda}, N. and
+        {AlSayyad}, Y. and {Becker}, A.~C. and {Coulton}, W. and {Coupon}, J. and
+        {Garmilla}, J. and {Huang}, S. and {Krughoff}, K.~S. and {Lang}, D. and
+        {Leauthaud}, A. and {Lim}, K.-T. and {Lust}, N.~B. and {MacArthur}, L.~A. and
+        {Mandelbaum}, R. and {Miyatake}, H. and {Miyazaki}, S. and {Murata}, R. and
+        {More}, S. and {Okura}, Y. and {Owen}, R. and {Swinbank}, J.~D. and
+        {Strauss}, M.~A. and {Yamada}, Y. and {Yamanoi}, H.},
+    title = "{The Hyper Suprime-Cam software pipeline}",
+  journal = {\pasj},
+archivePrefix = "arXiv",
+   eprint = {1705.06766},
+ primaryClass = "astro-ph.IM",
+ keywords = {methods: data analysis, surveys, techniques: image processing},
+     year = 2018,
+    month = jan,
+   volume = 70,
+      eid = {S5},
+    pages = {S5},
+      doi = {10.1093/pasj/psx080},
+   adsurl = {http://adsabs.harvard.edu/abs/2018PASJ...70S...5B},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2018AJ....156..123A,
+       author = {{Astropy Collaboration} and {Price-Whelan}, A.~M. and
+         {Sip{\H{o}}cz}, B.~M. and {G{\"u}nther}, H.~M. and {Lim}, P.~L. and
+         {Crawford}, S.~M. and {Conseil}, S. and {Shupe}, D.~L. and
+         {Craig}, M.~W. and {Dencheva}, N. and {Ginsburg}, A. and {Vand
+        erPlas}, J.~T. and {Bradley}, L.~D. and {P{\'e}rez-Su{\'a}rez}, D. and
+         {de Val-Borro}, M. and {Aldcroft}, T.~L. and {Cruz}, K.~L. and
+         {Robitaille}, T.~P. and {Tollerud}, E.~J. and {Ardelean}, C. and
+         {Babej}, T. and {Bach}, Y.~P. and {Bachetti}, M. and {Bakanov}, A.~V. and
+         {Bamford}, S.~P. and {Barentsen}, G. and {Barmby}, P. and
+         {Baumbach}, A. and {Berry}, K.~L. and {Biscani}, F. and {Boquien}, M. and
+         {Bostroem}, K.~A. and {Bouma}, L.~G. and {Brammer}, G.~B. and
+         {Bray}, E.~M. and {Breytenbach}, H. and {Buddelmeijer}, H. and
+         {Burke}, D.~J. and {Calderone}, G. and {Cano Rodr{\'\i}guez}, J.~L. and
+         {Cara}, M. and {Cardoso}, J.~V.~M. and {Cheedella}, S. and {Copin}, Y. and
+         {Corrales}, L. and {Crichton}, D. and {D'Avella}, D. and {Deil}, C. and
+         {Depagne}, {\'E}. and {Dietrich}, J.~P. and {Donath}, A. and
+         {Droettboom}, M. and {Earl}, N. and {Erben}, T. and {Fabbro}, S. and
+         {Ferreira}, L.~A. and {Finethy}, T. and {Fox}, R.~T. and
+         {Garrison}, L.~H. and {Gibbons}, S.~L.~J. and {Goldstein}, D.~A. and
+         {Gommers}, R. and {Greco}, J.~P. and {Greenfield}, P. and
+         {Groener}, A.~M. and {Grollier}, F. and {Hagen}, A. and {Hirst}, P. and
+         {Homeier}, D. and {Horton}, A.~J. and {Hosseinzadeh}, G. and {Hu}, L. and
+         {Hunkeler}, J.~S. and {Ivezi{\'c}}, {\v{Z}}. and {Jain}, A. and
+         {Jenness}, T. and {Kanarek}, G. and {Kendrew}, S. and {Kern}, N.~S. and
+         {Kerzendorf}, W.~E. and {Khvalko}, A. and {King}, J. and {Kirkby}, D. and
+         {Kulkarni}, A.~M. and {Kumar}, A. and {Lee}, A. and {Lenz}, D. and
+         {Littlefair}, S.~P. and {Ma}, Z. and {Macleod}, D.~M. and
+         {Mastropietro}, M. and {McCully}, C. and {Montagnac}, S. and
+         {Morris}, B.~M. and {Mueller}, M. and {Mumford}, S.~J. and {Muna}, D. and
+         {Murphy}, N.~A. and {Nelson}, S. and {Nguyen}, G.~H. and
+         {Ninan}, J.~P. and {N{\"o}the}, M. and {Ogaz}, S. and {Oh}, S. and
+         {Parejko}, J.~K. and {Parley}, N. and {Pascual}, S. and {Patil}, R. and
+         {Patil}, A.~A. and {Plunkett}, A.~L. and {Prochaska}, J.~X. and
+         {Rastogi}, T. and {Reddy Janga}, V. and {Sabater}, J. and
+         {Sakurikar}, P. and {Seifert}, M. and {Sherbert}, L.~E. and
+         {Sherwood-Taylor}, H. and {Shih}, A.~Y. and {Sick}, J. and
+         {Silbiger}, M.~T. and {Singanamalla}, S. and {Singer}, L.~P. and
+         {Sladen}, P.~H. and {Sooley}, K.~A. and {Sornarajah}, S. and
+         {Streicher}, O. and {Teuben}, P. and {Thomas}, S.~W. and
+         {Tremblay}, G.~R. and {Turner}, J.~E.~H. and {Terr{\'o}n}, V. and
+         {van Kerkwijk}, M.~H. and {de la Vega}, A. and {Watkins}, L.~L. and
+         {Weaver}, B.~A. and {Whitmore}, J.~B. and {Woillez}, J. and
+         {Zabalza}, V. and {Astropy Contributors}},
+        title = "{The Astropy Project: Building an Open-science Project and Status of the v2.0 Core Package}",
+      journal = {\aj},
+     keywords = {methods: data analysis, methods: miscellaneous, methods: statistical, reference systems, Astrophysics - Instrumentation and Methods for Astrophysics},
+         year = "2018",
+        month = "Sep",
+       volume = {156},
+       number = {3},
+          eid = {123},
+        pages = {123},
+          doi = {10.3847/1538-3881/aabc4f},
+archivePrefix = {arXiv},
+       eprint = {1801.02634},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2018AJ....156..123A},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2005Scons1377085,
+   author = {S. Knight},
+  journal = {Computing in Science Engineering},
+    title = "{Building software with SCons}",
+     year = {2005},
+   volume = {7},
+   number = {1},
+    pages = {79-88},
+ keywords = {configuration management;programming environments;software libraries;software tools;SCons;commercial packages;har
+dware platforms;next-generation software build tool;open-source packages;operating systems;software building;software creation
+;software libraries;software package;software programming;software projects;source code;Buildings;Open source software;Operati
+ng systems;Packaging;Program processors;Software libraries;Software packages;libraries;programming;software},
+      doi = {10.1109/MCSE.2005.11},
+     ISSN = {1521-9615},
+}
+
+@MISC{2017ivoa.spec.0519F,
+   author = {{Fernique}, P. and {Allen}, M. and {Boch}, T. and {Donaldson}, T. and
+	{Durand}, D. and {Ebisawa}, K. and {Michel}, L. and {Salgado}, J. and
+	{Stoehr}, F.},
+    title = "{HiPS - Hierarchical Progressive Survey Version 1.0}",
+howpublished = {IVOA Recommendation 19 May 2017},
+     year = 2017,
+    month = may,
+archivePrefix = "arXiv",
+   eprint = {1708.09704},
+ primaryClass = "astro-ph.IM",
+   editor = {{Fernique}, P.},
+      doi = {10.5479/ADS/bib/2017ivoa.spec.0519F},
+   adsurl = {https://ui.adsabs.harvard.edu/abs/2017ivoa.spec.0519F},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2019arXiv190713060O,
+       author = {{O'Mullane}, William and {Gaffney}, Niall and {Economou}, Frossie and
+         {Smith}, Arfon M. and {Thomson}, J. Ross and {Jenness}, Tim},
+        title = "{The demise of the filesystem and multi level service architecture}",
+      journal = {arXiv e-prints},
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics, Computer Science - Databases},
+         year = "2019",
+        month = "Jul",
+          eid = {arXiv:1907.13060},
+        pages = {arXiv:1907.13060},
+archivePrefix = {arXiv},
+       eprint = {1907.13060},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2019arXiv190713060O},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2015ApOpt..54.9045X,
+       author = {{Xin}, Bo and {Claver}, Chuck and {Liang}, Ming and {Chand
+        rasekharan}, Srinivasan and {Angeli}, George and {Shipsey}, Ian},
+        title = "{Curvature wavefront sensing for the large synoptic survey telescope}",
+      journal = {\ao},
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+         year = "2015",
+        month = "Oct",
+       volume = {54},
+       number = {30},
+        pages = {9045},
+          doi = {10.1364/AO.54.009045},
+archivePrefix = {arXiv},
+       eprint = {1506.04839},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2015ApOpt..54.9045X},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INBOOK{2016SPIE.9911E..18A,
+       author = {{Angeli}, G.~Z. and {Xin}, B. and {Claver}, C. and {Cho}, M. and
+         {Dribusch}, C. and {Neill}, D. and {Peterson}, J. and {Sebag}, J. and
+         {Thomas}, S.},
+        title = "{An integrated modeling framework for the Large Synoptic Survey Telescope (LSST)}",
+    booktitle = {\procspie},
+         year = "2016",
+       volume = {9911},
+       series = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
+          eid = {991118},
+        pages = {991118},
+          doi = {10.1117/12.2234078},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2016SPIE.9911E..18A},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2018SPIE10705E..0PX,
+       author = {{Xin}, Bo and {Claver}, Chuck F. and {Ivezi{\'c}}, {\v{Z}}eljko and
+         {Jones}, Lynne and {Peterson}, John and {Selvy}, Brian and
+         {Daniel}, Scott and {Yoachim}, Peter},
+        title = "{Monitoring LSST system performance during construction}",
+    booktitle = {\procspie},
+         year = "2018",
+       series = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
+       volume = {10705},
+        month = "Jul",
+          eid = {107050P},
+        pages = {107050P},
+          doi = {10.1117/12.2313880},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2018SPIE10705E..0PX},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INBOOK{2016SPIE.9906E..4JX,
+       author = {{Xin}, Bo and {Roodman}, Aaron and {Angeli}, George and {Claver}, Chuck and
+         {Thomas}, Sandrine},
+        title = "{Comparison of LSST and DECam wavefront recovery algorithms}",
+    booktitle = {\procspie},
+         year = "2016",
+       volume = {9906},
+       series = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
+          eid = {99064J},
+        pages = {99064J},
+          doi = {10.1117/12.2234456},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2016SPIE.9906E..4JX},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INBOOK{2014SPIE.9150E..0HA,
+       author = {{Angeli}, George Z. and {Xin}, Bo and {Claver}, Charles and
+         {MacMartin}, Douglas and {Neill}, Douglas and {Britton}, Matthew and
+         {Sebag}, Jacques and {Chandrasekharan}, Srinivasan},
+        title = "{Real time wavefront control system for the Large Synoptic Survey Telescope (LSST)}",
+    booktitle = {\procspie},
+         year = "2014",
+       volume = {9150},
+       series = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
+          eid = {91500H},
+        pages = {91500H},
+          doi = {10.1117/12.2055390},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2014SPIE.9150E..0HA},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INBOOK{2012SPIE.8444E..4PC,
+       author = {{Claver}, Charles F. and {Chandrasekharan}, Srinivasan and
+         {Liang}, Ming and {Xin}, Bo and {Alagoz}, Enver and {Arndt}, Kirk and
+         {Shipsey}, Ian P.},
+        title = "{Prototype pipeline for LSST wavefront sensing and reconstruction}",
+    booktitle = {\procspie},
+         year = "2012",
+       volume = {8444},
+       series = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
+          eid = {84444P},
+        pages = {84444P},
+          doi = {10.1117/12.926472},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2012SPIE.8444E..4PC},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2011PASP..123..812S,
+       author = {{Schechter}, Paul L. and {Sobel Levinson}, Rebecca},
+        title = "{Generic Misalignment Aberration Patterns in Wide-Field Telescopes}",
+      journal = {\pasp},
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+         year = "2011",
+        month = "Jul",
+       volume = {123},
+       number = {905},
+        pages = {812},
+          doi = {10.1086/661111},
+archivePrefix = {arXiv},
+       eprint = {1009.0708},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2011PASP..123..812S},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INBOOK{2012SPIE.8444E..55S,
+       author = {{Schechter}, Paul L. and {Levinson}, Rebecca Sobel},
+        title = "{Generic misalignment aberration patterns and the subspace of benign misalignment}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+    booktitle = {\procspie},
+         year = "2012",
+       volume = {8444},
+       series = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
+          eid = {844455},
+        pages = {844455},
+          doi = {10.1117/12.925075},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2012SPIE.8444E..55S},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2017ApJ...841...24S,
+       author = {{Sheldon}, Erin S. and {Huff}, Eric M.},
+        title = "{Practical Weak-lensing Shear Measurement with Metacalibration}",
+      journal = {\apj},
+     keywords = {cosmology: observations, gravitational lensing: weak, methods: observational, Astrophysics - Cosmology and Nongalactic Astrophysics},
+         year = "2017",
+        month = "May",
+       volume = {841},
+       number = {1},
+          eid = {24},
+        pages = {24},
+          doi = {10.3847/1538-4357/aa704b},
+archivePrefix = {arXiv},
+       eprint = {1702.02601},
+ primaryClass = {astro-ph.CO},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2017ApJ...841...24S},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2016MNRAS.459.4467B,
+       author = {{Bernstein}, Gary M. and {Armstrong}, Robert and {Krawiec}, Christina and
+         {March}, Marisa C.},
+        title = "{An accurate and practical method for inference of weak gravitational lensing from galaxy images}",
+      journal = {\mnras},
+     keywords = {gravitational lensing: weak, methods: data analysis, Astrophysics - Instrumentation and Methods for Astrophysics, Astrophysics - Cosmology and Nongalactic Astrophysics},
+         year = "2016",
+        month = "Jul",
+       volume = {459},
+       number = {4},
+        pages = {4467-4484},
+          doi = {10.1093/mnras/stw879},
+archivePrefix = {arXiv},
+       eprint = {1508.05655},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2016MNRAS.459.4467B},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }

--- a/project_templates/technote_rst/{{cookiecutter.repo_name}}/.gitattributes
+++ b/project_templates/technote_rst/{{cookiecutter.repo_name}}/.gitattributes
@@ -1,0 +1,1 @@
+lsstbib/*  linguist-generated=true

--- a/project_templates/technote_rst/{{cookiecutter.repo_name}}/lsstbib/books.bib
+++ b/project_templates/technote_rst/{{cookiecutter.repo_name}}/lsstbib/books.bib
@@ -285,3 +285,77 @@
   publisher = {Manning Publications Co.},
   address = {Greenwich, CT, USA},
 }
+
+@BOOK{NAP9839,
+  author    = "{National Research Council}",
+  title     = "Astronomy and Astrophysics in the New Millennium",
+  isbn      = "978-0-309-07031-7",
+  doi       = "10.17226/9839",
+  abstract  = "In this new book, a distinguished panel makes recommendations for the nation's programs in astronomy and astrophysics, including a number of new initiatives for observing the universe.  With the goal of optimum value, the recommendations address the role of federal research agencies, allocation of funding, training for scientists, competition and collaboration among space facilities, and much more.\n\n\nThe book identifies the most pressing science questions and explains how specific efforts, from the Next Generation Space Telescope to theoretical studies, will help reveal the answers.  Discussions of how emerging information technologies can help scientists make sense of the wealth of data available are also included.\n\n\nAstronomy has significant impact on science in general as well as on public imagination. The committee discusses how to integrate astronomical discoveries into our education system and our national life.\n\n\nIn preparing the New Millennium report, the AASC made use of a series of panel reports that address various aspects of ground- and space-based astronomy and astrophysics.  These reports provide in-depth technical detail.\nAstronomy and Astrophysics in the New Millenium: An Overview summarizes the science goals and recommended initiatives in a short, richly illustrated, non-technical booklet.\n",
+  url       = "https://www.nap.edu/catalog/9839/astronomy-and-astrophysics-in-the-new-millennium",
+  year      = 2001,
+  publisher = "The National Academies Press",
+  address   = "Washington, DC"
+}
+
+@BOOK{NAP10079,
+  author    = "{National Research Council}",
+  title     = "Connecting Quarks with the Cosmos: Eleven Science Questions for the New Century",
+  isbn      = "978-0-309-07406-3",
+  doi       = "10.17226/10079",
+  abstract  = "Advances made by physicists in understanding matter, space, and time and by astronomers in understanding the universe as a whole have closely intertwined the question being asked about the universe at its two extremes\u2014the very large and the very small. This report identifies 11 key questions that have a good chance to be answered in the next decade.  It urges that a new research strategy be created that brings to bear the techniques of both astronomy and sub-atomic physics in a cross-disciplinary way to address these questions. The report presents seven recommendations to facilitate the necessary research and development coordination. These recommendations identify key priorities for future scientific projects critical for realizing these scientific opportunities.\n",
+  url       = "https://www.nap.edu/catalog/10079/connecting-quarks-with-the-cosmos-eleven-science-questions-for-the",
+  year      = 2003,
+  publisher = "The National Academies Press",
+  address   = "Washington, DC"
+}
+
+@BOOK{NAP12982,
+  author    = "{National Research Council}",
+  title     = "Panel Reports—New Worlds, New Horizons in Astronomy and Astrophysics",
+  isbn      = "978-0-309-15962-3",
+  doi       = "10.17226/12982",
+  abstract  = "Every 10 years the National Research Council releases a survey of astronomy and astrophysics outlining priorities for the coming decade. The most recent survey, titled New Worlds, New Horizons in Astronomy and Astrophysics, provides overall priorities and recommendations for the field as a whole based on a broad and comprehensive examination of scientific opportunities, infrastructure, and organization in a national and international context. \n\nPanel Reports--New Worlds, New Horizons in Astronomy and Astrophysics is a collection of reports, each of which addresses a key sub-area of the field, prepared by specialists in that subarea, and each of which played an important role in setting overall priorities for the field. The collection, published in a single volume, includes the reports of the following panels:\n\n    Cosmology and Fundamental Physics\n    Galaxies Across Cosmic Time\n    The Galactic Neighborhood\n    Stars and Stellar Evolution\n    Planetary Systems and Star Formation\n    Electromagnetic Observations from Space\n    Optical and Infrared Astronomy from the Ground\n    Particle Astrophysics and Gravitation\n    Radio, Millimeter, and Submillimeter Astronomy from the Ground\n\n\nThe Committee for a Decadal Survey of Astronomy and Astrophysics synthesized these reports in the preparation of its prioritized recommendations for the field as a whole. These reports provide additional depth and detail in each of their respective areas. Taken together, they form an essential companion volume to New Worlds, New Horizons: A Decadal Survey of Astronomy and Astrophysics. The book of panel reports will be useful to managers of programs of research in the field of astronomy and astrophysics, the Congressional committees with jurisdiction over the agencies supporting this research, the scientific community, and the public.",
+  url       = "https://www.nap.edu/catalog/12982/panel-reports-new-worlds-new-horizons-in-astronomy-and-astrophysics",
+  year      = 2011,
+  publisher = "The National Academies Press",
+  address   = "Washington, DC"
+}
+
+@BOOK{NAP10432,
+  author    = "{National Research Council}",
+  title     = "New Frontiers in the Solar System: An Integrated Exploration Strategy",
+  doi       = "10.17226/10432",
+  abstract  = "Solar system exploration is that grand human endeavor which reaches out through interplanetary space to discover the nature and origins of the system of planets in which we live and to learn whether life exists beyond Earth.  It is an international enterprise involving scientists, engineers, managers, politicians, and others, sometimes working together and sometimes in competition, to open new frontiers of knowledge.  It has a proud past, a productive present, and an auspicious future. This survey was requested by the National Aeronautics and Space Administration (NASA) to determine the contemporary nature of solar system exploration and why it remains a compelling activity today.  A broad survey of the state of knowledge was requested.  In addition NASA asked for the identifcation of the top-level scientific questions to guide its ongoing program and a prioritized list of the most promising avenues for flight investigations and supporting ground-based activities.  \n",
+  url       = "https://www.nap.edu/catalog/10432/new-frontiers-in-the-solar-system-an-integrated-exploration-strategy",
+  year      = 2003,
+  publisher = "The National Academies Press",
+  address   = "Washington, DC"
+}
+
+@Book{Few:2013,
+  author    = "Stephen~Few",
+  title     = "{Information Dashboard Design}",
+  publisher = {Analytics Press},
+  year      = 2013,
+  edition   = 2
+}
+
+@book{Beyer:2016:SRE:3006357,
+ author = {Beyer, Betsy and Jones, Chris and Petoff, Jennifer and Murphy, Niall Richard},
+ title = {Site Reliability Engineering: How Google Runs Production Systems},
+ year = {2016},
+ isbn = {149192912X, 9781491929124},
+ edition = {1st},
+ publisher = {O'Reilly Media, Inc.},
+}
+
+@Book{1982mmme.book.....B,
+   author = {{Brooks}, F.~P.},
+    title = "{The Mythical Man-Month: Essays on Software Engineering}",
+booktitle = {Reading: Addison-Wesley, 1982},
+     year = 1982,
+   adsurl = {https://ui.adsabs.harvard.edu/abs/1982mmme.book.....B},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+

--- a/project_templates/technote_rst/{{cookiecutter.repo_name}}/lsstbib/lsst-dm.bib
+++ b/project_templates/technote_rst/{{cookiecutter.repo_name}}/lsstbib/lsst-dm.bib
@@ -2536,8 +2536,60 @@ booktitle = {Ground-based and Airborne Telescopes VI},
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+@INBOOK{2019ASPC..523..521B,
+       author = {{Bosch}, James and {AlSayyad}, Yusra and {Armstrong}, Robert and
+         {Bellm}, Eric and {Chiang}, Hsin-Fang and {Eggl}, Siegfried and
+         {Findeisen}, Krzysztof and {Fisher-Levine}, Merlin and
+         {Guy}, Leanne P. and {Guyonnet}, Augustin and
+         {Ivezi{\'c}}, {\v{Z}}eljko and {Jenness}, Tim and
+         {Kov{\'a}cs}, G{\'a}bor and {Krughoff}, K. Simon and
+         {Lupton}, Robert H. and {Lust}, Nate B. and {MacArthur}, Lauren A. and
+         {Meyers}, Joshua and {Moolekamp}, Fred and {Morrison}, Christopher B. and
+         {Morton}, Timothy D. and {O'Mullane}, William and {Parejko}, John K. and
+         {Plazas}, Andr{\'e}s A. and {Price}, Paul A. and {Rawls}, Meredith L. and
+         {Reed}, Sophie L. and {Schellart}, Pim and {Slater}, Colin T. and
+         {Sullivan}, Ian and {Swinbank}, John D. and {Taranu}, Dan and
+         {Waters}, Christopher Z. and {Wood-Vasey}, W.~M.},
+        title = "{An Overview of the LSST Image Processing Pipelines}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+    booktitle = {Astronomical Data Analysis Software and Systems XXVII},
+         year = "2019",
+       editor = {{Teuben}, Peter J. and {Pound}, Marc W. and {Thomas}, Brian A. and
+         {Warner}, Elizabeth M.},
+       volume = {523},
+       series = {Astronomical Society of the Pacific Conference Series},
+        pages = {521},
+     abstract = "{The Large Synoptic Survey Telescope (LSST) is an ambitious astronomical
+        survey with a similarly ambitious Data Management component.
+        Data Management for LSST includes processing on both nightly and
+        yearly cadences to generate transient alerts, deep catalogs of
+        the static sky, and forced photometry light-curves for billions
+        of objects at hundreds of epochs, spanning at least a decade.
+        The algorithms running in these pipelines are individually
+        sophisticated and interact in subtle ways. This paper provides
+        an overview of those pipelines, focusing more on those
+        interactions than the details of any individual algorithm. <P />}",
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2019ASPC..523..521B},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
 @Misc{DevGuide,
   author =       {{LSST Data Management}},
 	title =        "{LSST DM Developer Guide}",
 	url =          {https://developer.lsst.io/}
+}
+
+@inproceedings{10.1117/12.2561604,
+author = {Gabriele Comoretto and Leanne P. Guy and William O'Mullane and Keith Bechtol and Jeffrey L. Carlin and Jonathan Sick and Brian Van Klaveren and Austin Roberts},
+title = {{Documentation automation for the verification and validation of Rubin Observatory software}},
+volume = {11450},
+booktitle = {Modeling, Systems Engineering, and Project Management for Astronomy IX},
+editor = {George Z. Angeli and Philippe Dierickx},
+organization = {International Society for Optics and Photonics},
+publisher = {SPIE},
+pages = {68 -- 78},
+keywords = {verification and validation, documentation automation, test documentation, test management, LSST, LSST Data Management},
+year = {2020},
+doi = {10.1117/12.2561604},
+URL = {https://doi.org/10.1117/12.2561604}
 }

--- a/project_templates/technote_rst/{{cookiecutter.repo_name}}/lsstbib/lsst.bib
+++ b/project_templates/technote_rst/{{cookiecutter.repo_name}}/lsstbib/lsst.bib
@@ -1,3 +1,18 @@
+@DocuShare{RDO-013,
+  author = {Robert Blum and the Rubin Operations Team},
+  title = "{Vera C. Rubin Observatory
+Data Policy}",
+  year = {2020},
+  month =        sep,
+  handle = {RDO-013}
+}
+@DocuShare{Agreement-51,
+  author = {LSST},
+  title = "{Memorandum of Agreement regarding collaboration in the scientific exploitation of data acquired with LSST by specified Principal Investigators and scientists at IN2P3}",
+  year = {2015},
+  month =        mar,
+  handle = {Agreement-51}
+}
 
 @DocuShare{Document-1386,
   author =       {Jacek Becla},
@@ -6,6 +21,8 @@
   month =        mar,
   handle =       {Document-1386},
 }
+
+
 
 @DocuShare{Document-5356,
   author =       {Tim Axelrod and Robyn Allsman and Jeff Kantor and Jon Myers and
@@ -64,7 +81,7 @@
 
 @DocuShare{Document-9224,
   author =       {George Angeli and Robert McKercher},
-  title =        {Change Controlled Document Cover Page and Style Guide},
+  title =        "{Change Controlled Document Cover Page and Style Guide}",
   year =         2013,
   month =        oct,
   handle =       {Document-9224},
@@ -74,23 +91,69 @@
   author =       {Ray Plante and Robyn Allsman and Tim Axelrood and Jacek Becla
                   and Cristina Beldica and Greg Daues and Jeff Kantor and Jonathan Myers
                   and Russell Owen and Steve Pietrowicz},
-  title =        {Results from Data Challenge 1},
+  title =        "{Results from Data Challenge 1}",
   year =         2010,
   month =        jul,
   handle =       {Document-9541},
 }
 
+
+@DocuShare{Document-10548,
+  author = {William S. Smith and Steven M.  Kahn and Donald W Sweeney and J. Anthony Tyson and Sidney C Wolff  },
+   title = "{Fastlane Proposal for Construction of the Large Synoptic Survey Telescope}",
+    year = 2011,
+   month = feb,
+  handle = {Document-10548},
+}
+
+@DocuShare{Document-10549,
+  author =       {Sidney C. Wolff and Steven M. Kahn and Victor L. Krabbendam
+                  and Donald W. Sweeney and J. Anthony Tyson},
+  title =        "{Proposal to the National Science Foundation}",
+  year =         2011,
+  month =        feb,
+  handle =       {Document-10549},
+}
+
 @DocuShare{Document-10762,
   author =       {Richard Shaw and Michael Strauss},
-  title =        {LSST Data Challenge Handbook Version 1.1},
+  title =        "{LSST Data Challenge Handbook Version 1.1}",
   year =         2011,
   month =        aug,
   handle =       {Document-10762},
 }
 
+@DocuShare{Document-10963,
+  author =       {Zhaoming Ma and others},
+  title =        {{Science White Paper for LSST Deep-Drilling Field Observations: Using LSST Deep Drilling Fields to Improve Weak Lensing Measurements}},
+  year =         2011,
+  handle = {Document-10963},
+}
+
+@DocuShare{Document-11013,
+  author =       {Becker, A. and others},
+  title =        {{Science White Paper for LSST Deep-Drilling Field Observations Opportunities for Solar System Science}},
+  year =         2011,
+  handle = {Document-11013},
+}
+
+@DocuShare{Document-11019,
+  author =       {Arlin Crotts},
+  title =        {{Standard Candle Relations and Photo-diversity of Type Ia Supernovae}},
+  year =         2011,
+  handle = {Document-11019},
+}
+
+@DocuShare{Document-11622,
+  author =       {William Smith and Victor Perez Vera},
+  title =        {Supplementary and Clarifying Agreement between the Universidad de Chile and AURA covering the use of the LSST on Cerro Pachon},
+  year =         2011,
+  handle =       {Document-11622},
+}
+
 @DocuShare{Document-11624,
   author =       {{LSST Science Council}},
-  title =        {Optimization of LSST Deployment Parameters},
+  title =        "{Optimization of LSST Deployment Parameters}",
   year =         2011,
   month =        jul,
   handle =       {Document-11624},
@@ -106,7 +169,7 @@
 
 @DocuShare{Document-11701,
   author =       {Jacek Becla and Kian-Tat Lim and Daniel Wang},
-  title =        {Evaluation of Solid State Disks},
+  title =        "{Evaluation of Solid State Disks}",
   year =         2011,
   month =        jul,
   handle =       {Document-11701},
@@ -114,10 +177,18 @@
 
 @DocuShare{Document-11920,
   author =       {George Angeli and Robert McKercher},
-  title =        {Document Cover Page and Style Guide},
+  title =        "{Document Cover Page and Style Guide}",
   year =         2013,
   month =        oct,
   handle =       {Document-11920},
+}
+
+@DocuShare{Document-13380,
+  author =       {Sidney Wolff and Steven Kahn},
+  title =        "{Data Rights and Data Management Policy}",
+  year =         2013,
+  month =        aug,
+  handle =       {Document-13380},
 }
 
 @DocuShare{Document-13760,
@@ -138,7 +209,7 @@
 
 @DocuShare{Document-15077,
   author =        {Sidney Wolff},
-  title =         {LSST Project Overview},
+  title =         "{LSST Project Overview}",
   year =          2013,
   month=          sep,
   handle =        {Document-15077},
@@ -155,7 +226,7 @@
 @DocuShare{Document-15125,
   author =       {Peter Yoachim and Lynne Jones and {\v
                   Z}. {Ivezi{\'c}} and Tim Axelrod},
-  title =        {Photometric Self Calibration Design and Prototype},
+  title =        "{Photometric Self Calibration Design and Prototype}",
   year =         2013,
   month =        oct,
   handle =       {Document-15125},
@@ -163,7 +234,7 @@
 
 @DocuShare{Document-15286,
   author =       {Richard A. Shaw},
-  title =        {LSST Data Challenge Handbook: Summer 2012 Data Release},
+  title =        "{LSST Data Challenge Handbook: Summer 2012 Data Release}",
   year =         2012,
   month =        aug,
   handle =       {Document-15286},
@@ -171,7 +242,7 @@
 
 @DocuShare{Document-15298,
   author =       {J. Bosch and P. Gee and R. Owen and M. Juri\'c},
-  title =        {LSST DM S13 Report: Shapre Measurement Plans and Prototypes},
+  title =        "{LSST DM S13 Report: Shapre Measurement Plans and Prototypes}",
   year =         2013,
   month =        oct,
   handle =       {Document-15298},
@@ -179,7 +250,7 @@
 
 @DocuShare{Document-15299,
   author =       {Richard A. Shaw},
-  title =        {LSST Data Challenge Handbook: Winter 2013 Early Data Release},
+  title =        "{LSST Data Challenge Handbook: Winter 2013 Early Data Release}",
   year =         2013,
   month =        jan,
   handle =       {Document-15299},
@@ -187,7 +258,7 @@
 
 @DocuShare{Document-16168,
   author =       {{LSST Systems Engineering}},
-  title =        {{LSST Key System Parameters Summary}},
+  title =        "{{LSST Key System Parameters Summary}}",
   year =         2014,
   month =        jan,
   handle =       {Document-16168},
@@ -195,7 +266,7 @@
 
 @DocuShare{Document-26217,
   author =       {Jeff Kantor},
-  title =        {Data Challenge 3b Performance Test 1.1},
+  title =        "{Data Challenge 3b Performance Test 1.1}",
   year =         2010,
   month =        aug,
   handle =       {Document-26217},
@@ -203,23 +274,95 @@
 
 @DocuShare{Document-26273,
   author =       {Brian Selvy},
-  title =        {Risk \& Opportunity Management Report May 2017},
+  title =        "{Risk \& Opportunity Management Report May 2017}",
   year =         2017,
   month =        jul,
   handle =       {Document-26273},
 }
 
+@DocuShare{Document-26952,
+  author =       {{Science Working Group of the LSST} and Michael A. Strauss},
+  title =        "{Towards a Design Reference Mission for the Large Synoptic Survey Telescope}",
+  year =         2004,
+  month =        jun,
+  handle =       {Document-26952},
+}
+
 @DocuShare{Document-26276,
   author =       {Jacek Becla and K-T Lim and Daniel Wang},
-  title =        {Scalable Partitioning},
+  title =        "{Scalable Partitioning}",
   year =         2013,
   month =        feb,
   handle =       {Document-26276},
 }
 
+@DocuShare{Document-27758,
+  author =       {{\v Z}. {Ivezi{\'c}} and {LSST Project Science Team}},
+  title =        "{On the choice of LSST flux units}",
+  year =         2018,
+  month =        feb,
+  handle =       {Document-27758},
+}
+
+@DocuShare{Document-28449,
+  author =       {F. Delgado},
+  title =        "{Project Response to Telescope \& Site Software Review Report 2018-02}",
+  year =         2018,
+  month =        may,
+  handle =       {Document-28449},
+}
+
+@DocuShare{Document-28547,
+  author =       {J. Kantor},
+  title =        "{LSST Network Bandwidth Tests between Chile and the United States }",
+  year =         2018,
+  month =        jun,
+  handle =       {Document-28547},
+}
+
+@DocuShare{Document-28973,
+  author =       {R. Gill},
+  title =        "{LSST MEETINGS CODE OF CONDUCT}",
+  year =         2018,
+  month =        jul,
+  handle =       {Document-28973},
+}
+
+@DocuShare{Document-24920,
+  author =       {R. Gill},
+  title =        "{LSST COMMUNICATIONS CODE OF CONDUCT}",
+  year =         2018,
+  month =        jul,
+  handle =       {Document-24920}
+}
+
+@DocuShare{Document-31100,
+  author =       {J. Ross Thomson},
+  title =        "{LSST Benchmarkin of Qserv and BigQuery}",
+  year =         2019,
+  month =        jan,
+  handle =       {Document-31100}
+}
+
+@DocuShare{Document-32503,
+  author =       {Kian-Tat Lim and Review Committee},
+  title =        "{Identity Management Review Report}",
+  year =         2019,
+  month =        apr,
+  handle =       {Document-32503}
+}
+
+@DocuShare{Document-35896,
+  author =       {Federica Bianco and  SCs coordinator and  TVS SC},
+  title =        "{MEMO on the impact of delays in pixel-level data access}",
+  year =         2020,
+  month =        may,
+  handle =       {Document-35896}
+}
+
 @DocuShare{LCA-227,
   author =       {Martin Nordby and Nadine Kurita and Frank O'Neill and Darren Marsh},
-  title =        {LSST Camera Quality Implementation Plan},
+  title =        "{LSST Camera Quality Implementation Plan}",
   year =         2014,
   month =        sep,
   handle =       {LCA-227},
@@ -227,23 +370,24 @@
 
 @DocuShare{LDM-17,
   author =       {Tim Axelrod and others},
-  title =        {LSST Data Challenge 3a Final Report},
+  title =        "{LSST Data Challenge 3a Final Report}",
   year =         2009,
   month =        aug,
   handle =       {LDM-17},
 }
 
 @DocuShare{LDM-129,
-  author =       {Mike Freemon and Jeff Kantor},
-  title =        {Data Management Infrastructure Design},
-  year =         2013,
-  month =        oct,
+  author =       {Don Petravick and Margaret Johnson and Michelle Butler},
+  title =        "{LSST Data Facility Logical Information Technology and
+                   Communications Design}",
+  year =         2018,
+  month =        jul,
   handle =       {LDM-129},
 }
 
 @DocuShare{LDM-130,
   author =       {Unknown},
-  title =        {LSST Science User Interface and Tools Requirements},
+  title =        "{LSST Science User Interface and Tools Requirements}",
   institution =  {IPAC},
   year =         2017,
   month =        sep,
@@ -261,7 +405,7 @@
 
 @DocuShare{LDM-133,
   author =       {Mario Juri\'c and Kian-Tat Lim and Jeff Kantor},
-  title =        {Data Management UML Domain Model},
+  title =        "{Data Management UML Domain Model}",
   year =         2013,
   month =        oct,
   handle =       {LDM-133},
@@ -269,7 +413,7 @@
 
 @DocuShare{LDM-134,
   author =       {Mario Juri\'c and Robyn Allsman and Jeff Kantor},
-  title =        {Data Management Applications UML Use Case Model},
+  title =        "{Data Management Applications UML Use Case Model}",
   year =         2013,
   month =        oct,
   handle =       {LDM-134},
@@ -277,16 +421,17 @@
 
 @DocuShare{LDM-135,
   author =       {Jacek Becla and Daniel Wang and Serge Monkewitz and
-                  K-T Lim and Douglas Smith and Bill Chickering},
-  title =        {Database Design},
-  year =         2013,
-  month =        oct,
+                  K-T Lim and Douglas Smith and Bill Chickering and
+                  Michael Kelsey and Fritz Mueller},
+  title =        "{Data Management Database Design}",
+  year =         2017,
+  month =        jul,
   handle =       {LDM-135},
 }
 
 @DocuShare{LDM-138,
   author =       {Jeff Kantor and Tim Axelrod and Kian-Tat Lim},
-  title =        {Data Management Compute Sizing Model},
+  title =        "{Data Management Compute Sizing Model}",
   year =         2013,
   month =        oct,
   handle =       {LDM-138},
@@ -304,7 +449,7 @@
 @DocuShare{LDM-140,
   author =       {Kian-Tat Lim and Chris Smith and Tim Axelrod and
                   Gregory Dubois-Felsmann and Mike Freemon},
-  title =        {Data Management Compute Sizing Explanation},
+  title =        "{Data Management Compute Sizing Explanation}",
   year =         2013,
   month =        oct,
   handle =       {LDM-140},
@@ -312,7 +457,7 @@
 
 @DocuShare{LDM-141,
   author =       {Jacek Becla and K.-T. Lim},
-  title =        {Data Management Storage Sizing and I/O Model},
+  title =        "{Data Management Storage Sizing and I/O Model}",
   year =         2013,
   month =        oct,
   handle =       {LDM-141},
@@ -320,7 +465,7 @@
 
 @DocuShare{LDM-142,
   author =       {Jeff Kantor},
-  title =        {Network Sizing Model},
+  title =        "{Network Sizing Model}",
   year =         2017,
   month =        jan,
   handle =       {LDM-142},
@@ -328,7 +473,7 @@
 
 @DocuShare{LDM-143,
   author =       {Mike Freemon and Steve Pietrowicz},
-  title =        {Site Specific Infrastructure Estimation Explanation},
+  title =        "{Site Specific Infrastructure Estimation Explanation}",
   year =         2013,
   month =        oct,
   handle =       {LDM-143},
@@ -336,7 +481,7 @@
 
 @DocuShare{LDM-144,
   author =       {Mike Freemon and Steve Pietrowicz and Jason Alt},
-  title =        {Site Specific Infrastructure Estimation Model},
+  title =        "{Site Specific Infrastructure Estimation Model}",
   year =         2016,
   month =        jan,
   handle =       {LDM-144},
@@ -355,15 +500,15 @@
   author =       {K.-T. Lim and J. Bosch and G. Dubois-Felsmann and T. Jenness
                   and J. Kantor and W. O'Mullane and D. Petravick and
                   {The DM Leadership Team}},
-  title =        {Data Management System Design},
-  year =         2017,
+  title =        "{Data Management System Design}",
+  year =         2018,
   month =        jul,
   handle =       {LDM-148},
 }
 
 @DocuShare{LDM-151,
   author =       {John D. Swinbank and others},
-  title =        {Data Management Science Pipelines Design},
+  title =        "{Data Management Science Pipelines Design}",
   year =         2017,
   month =        may,
   handle =       {LDM-151},
@@ -372,7 +517,7 @@
 @DocuShare{LDM-152,
   author =       {Kian-Tat Lim and Gregory Dubois-Felsmann and M. Johnson
                   and M. Juri\'c and D. Petravick},
-  title =        {Data Management Middleware Design},
+  title =        "{Data Management Middleware Design}",
   year =         2017,
   month =        jul,
   handle =       {LDM-152},
@@ -380,14 +525,14 @@
 
 @DocuShare{LDM-153,
   author =      {J. Becla},
-  title =       {LSST Database Baseline Schema},
+  title =       "{LSST Database Baseline Schema}",
   year =        2013,
   handle =      {LDM-153},
 }
 
 @DocuShare{LDM-156,
   author =       {Jonathan Myers and Lynne Jones and Tim Axelrod},
-  title =        {Moving Object Pipeline System Design},
+  title =        "{Moving Object Pipeline System Design}",
   year =         2013,
   month =        oct,
   handle =       {LDM-156},
@@ -421,23 +566,23 @@
                   Ron Lambert and Kian-Tat Lim and Bruce Mather and Serge Monkewitz and
                   Knut Olsen and Steve Pietrowicz and Ray Plante and Dick Shaw and
                   Douglas Smith and Schuyler Van Dyk and Daniel Wang},
-  title =        {Report on Late Winter2013 Production: Image Differencing},
+  title =        "{Report on Late Winter2013 Production: Image Differencing}",
   year =         2013,
   month =        apr,
   handle =       {LDM-227},
 }
 
 @DocuShare{LDM-230,
-  author =       {D. Petravick and M. Gelman},
-  title =        {Concept of Operations for the LSST Data Facility Services},
-  year =         2017,
+  author =       {D. Petravick and M. Butler and M. Gelman},
+  title =        "{Concept of Operations for the LSST Data Facility Services}",
+  year =         2018,
   month =        jul,
   handle =       {LDM-230},
 }
 
 @DocuShare{LDM-240,
   author =       {Jeff Kantor and Mario Juri\'c and Kian-Tat Lim},
-  title =        {Data Management Releases},
+  title =        "{Data Management Releases}",
   year =         2016,
   month =        feb,
   handle =       {LDM-240},
@@ -446,15 +591,23 @@
 @DocuShare{LDM-294,
   author =       {William O'Mullane and John Swinbank and Mario Juri\'c
                   and {DMLT}},
-  title =        {Data Management Organization and Management},
-  year =         2017,
-  month =        jul,
+  title =        "{Data Management Organization and Management}",
+  year =         2018,
+  month =        jun,
   handle =       {LDM-294},
+}
+
+@DocuShare{LDM-324,
+  author =       {Jeff Kantor},
+  title =        "{Data Management Information Security Plan}",
+  year =         2016,
+  month =        mar,
+  handle =       {LDM-324},
 }
 
 @DocuShare{LDM-463,
   author =       {Jacek Becla and Nate Pease},
-  title =        {Data Access Design},
+  title =        "{Data Access Design}",
   year =         2017,
   month =        apr,
   handle =       {LDM-463},
@@ -464,7 +617,7 @@
   author =       {Jacek Becla and Frossie Economou and Fritz Mueller and
                   Margaret Johnson and K. Simon Krughoff and K-T Lim and
                   John Swinbank and Xiuqin Wu},
-  title =        {LSST DM Project Management and Tools},
+  title =        "{LSST DM Project Management and Tools}",
   year =         2017,
   month =        feb,
   handle =       {LDM-472},
@@ -472,7 +625,7 @@
 
 @DocuShare{LDM-482,
   author =       {David Ciardi and Gregory Dubois-Felsmann},
-  title =        {Data Access Policy for the Data Management Prototype DAC},
+  title =        "{Data Access Policy for the Data Management Prototype DAC}",
   year =         2016,
   month =        aug,
   handle =       {LDM-482},
@@ -481,7 +634,7 @@
 @DocuShare{LDM-492,
   author =       {David R. Ciardi and Xiuqin Wu and Gregory
                   Dubois-Felsmann},
-  title =        {A Vision for the Science User Interface and Tools},
+  title =        "{A Vision for the Science User Interface and Tools}",
   institution =  {IPAC},
   year =         2016,
   month =        sep,
@@ -490,7 +643,7 @@
 
 @DocuShare{LDM-493,
   author =       {Jonathan Sick},
-  title =        {Data Management Documentation Architecture},
+  title =        "{Data Management Documentation Architecture}",
   year =         2016,
   month =        nov,
   handle =       {LDM-493},
@@ -498,24 +651,24 @@
 
 @DocuShare{LDM-502,
   author =       {David Nidever and Frossie Economou},
-  title =        {The Measurement and Verification of DM Key Performance Metrics},
+  title =        "{The Measurement and Verification of DM Key Performance Metrics}",
   year =         2016,
   month =        may,
   handle =       {LDM-502},
 }
 
 @DocuShare{LDM-503,
-  author =       {William O'Mullane and Mario Juri\'c and Frossie
+  author =       {William O'Mullane and John Swinbank and Mario Juri\'c and Frossie
                   Economou},
-  title =        {Data Management Test Plan},
-  year =         2017,
+  title =        "{Data Management Test Plan}",
+  year =         2018,
   month =        jun,
   handle =       {LDM-503},
 }
 
 @DocuShare{LDM-512,
   author =       {Tim Jenness and William O'Mullane},
-  title =        {Data Management Risk Assessment Process},
+  title =        "{Data Management Risk Assessment Process}",
   year =         2017,
   month =        apr,
   handle =       {LDM-512},
@@ -523,7 +676,7 @@
 
 @DocuShare{LDM-513,
   author =       {Jim Bosch},
-  title =        {Proposal for Deblender Outputs as Level 2 Data Products},
+  title =        "{Proposal for Deblender Outputs as Level 2 Data Products}",
   year =         2017,
   month =        apr,
   handle =       {LDM-513},
@@ -531,7 +684,7 @@
 
 @DocuShare{LDM-522,
   author =       {Frossie Economou and Michael Wood-Vasey},
-  title =        {DM Science Quality Data Assurance System Conceptual Design},
+  title =        "{DM Science Quality Data Assurance System Conceptual Design}",
   year =         2017,
   month =        may,
   handle =       {LDM-522},
@@ -539,7 +692,7 @@
 
 @DocuShare{LDM-523,
   author =       {C. T. Slater and R. L. Jones and E. Bellm and M. Juri\'c},
-  title =        {Impact of a Heterogeneous Focal Plane on LSST Image Differencing},
+  title =        "{Impact of a Heterogeneous Focal Plane on LSST Image Differencing}",
   year =         2017,
   month =        may,
   handle =       {LDM-523},
@@ -547,15 +700,15 @@
 
 @DocuShare{LDM-532,
   author =       {Unknown},
-  title =        {NCSA Enclave Test Specification},
+  title =        "{NCSA Enclave Test Specification}",
   year =         2017,
   month =        jun,
   handle =       {LDM-532},
 }
 
 @DocuShare{LDM-533,
-  author =       {Unknown},
-  title =        {Level 1 System Software Test Specification},
+  author =       {Eric C. Bellm},
+  title =        "{Level 1 System Software Test Specification}",
   year =         2017,
   month =        jun,
   handle =       {LDM-533},
@@ -563,7 +716,7 @@
 
 @DocuShare{LDM-534,
   author =       {John D. Swinbank},
-  title =        {Level 2 System Software Test Specification},
+  title =        "{Level 2 System Software Test Specification}",
   year =         2017,
   month =        jun,
   handle =       {LDM-534},
@@ -571,7 +724,7 @@
 
 @DocuShare{LDM-535,
   author =       {Unknown},
-  title =        {Data Backbone Test Specification},
+  title =        "{Data Backbone Test Specification}",
   year =         2017,
   month =        jun,
   handle =       {LDM-535},
@@ -579,7 +732,7 @@
 
 @DocuShare{LDM-536,
   author =       {Unknown},
-  title =        {Data Backbone Data Services Test Specification},
+  title =        "{Data Backbone Data Services Test Specification}",
   year =         2017,
   month =        jun,
   handle =       {LDM-536},
@@ -587,39 +740,39 @@
 
 @DocuShare{LDM-537,
   author =       {Unknown},
-  title =        {Data Backbone Infrastructure Test Specification},
+  title =        "{Data Backbone Infrastructure Test Specification}",
   year =         2017,
   month =        jun,
   handle =       {LDM-537},
 }
 
 @DocuShare{LDM-538,
-  author =       {Unknown},
-  title =        {Base Enclave Test Specification},
-  year =         2017,
+  author =       {Michelle Butler and Jim Parsons and Michelle Gower},
+  title =        "{Raw Image Archiving Service Test Specification}",
+  year =         2018,
   month =        jun,
   handle =       {LDM-538},
 }
 
 @DocuShare{LDM-539,
   author =       {Unknown},
-  title =        {Data Access Center Enclave Test Specification},
+  title =        "{Data Access Center Enclave Test Specification}",
   year =         2017,
   month =        jun,
   handle =       {LDM-539},
 }
 
 @DocuShare{LDM-540,
-  author =       {Unknown},
-  title =        {LSST Science Platform Test Specification},
-  year =         2017,
-  month =        jun,
+  author =       {Gregory Dubois-Felsmann},
+  title =        "{LSST Science Platform Test Specification}",
+  year =         2018,
+  month =        may,
   handle =       {LDM-540},
 }
 
 @DocuShare{LDM-541,
   author =       {Unknown},
-  title =        {Commissioning Cluster Enclave Test Specification},
+  title =        "{Commissioning Cluster Enclave Test Specification}",
   year =         2017,
   month =        jun,
   handle =       {LDM-541},
@@ -627,7 +780,7 @@
 
 @DocuShare{LDM-542,
   author =       {Gregory Dubois-Felsmann and Kian-Tat Lim and Xiuqin Wu and Frossie Economou and Fritz Mueller and Brian Van Klaveren and Kenny Lo},
-  title =        {LSST Science Platform Design},
+  title =        "{LSST Science Platform Design}",
   year =         2017,
   month =        jun,
   handle =       {LDM-542},
@@ -635,7 +788,7 @@
 
 @DocuShare{LDM-552,
   author =       {Fritz Mueller},
-  title =        {Qserv Software Test Specification},
+  title =        "{Qserv Software Test Specification}",
   year =         2017,
   month =        jun,
   handle =       {LDM-552},
@@ -643,48 +796,206 @@
 
 @DocuShare{LDM-553,
   author =       {William O'Mullane and John D. Swinbank and Mario Juri\'c and {DMLT}},
-  title =        {Evolution of the Data Management Plan and Organization},
+  title =        "{Evolution of the Data Management Plan and Organization}",
   year =         2017,
   month =        jun,
   handle =       {LDM-553},
 }
 
 @DocuShare{LDM-554,
-  author =       {David Ciardi and Gregory Dubois-Felsmann},
-  title =        {Science Platform Requirements},
-  year =         2017,
+  author =       {Gregory Dubois-Felsmann and David Ciardi and Fritz Mueller
+                  and Frossie Economou},
+  title =        "{Science Platform Requirements}",
+  year =         2018,
   month =        jun,
   handle =       {LDM-554},
 }
 
 @DocuShare{LDM-555,
   author =       {Jacek Becla},
-  title =        {Data Management Database Requirements},
+  title =        "{Data Management Database Requirements}",
   year =         2017,
   month =        jun,
   handle =       {LDM-555},
 }
 
 @DocuShare{LDM-556,
-  author =       {Gregory Dubois-Felsmann},
-  title =        {Data Management Middleware Requirements},
-  year =         2017,
-  month =        jun,
+  author =       {Gregory Dubois-Felsmann and Tim Jenness and Jim Bosch
+                  and Michelle Gower and Simon Krughoff and Russell Owen
+                  and Pim Schellart and Brian {van Klaveren}},
+  title =        "{Data Management Middleware Requirements}",
+  year =         2018,
+  month =        may,
   handle =       {LDM-556},
+}
+
+@DocuShare{LDM-562,
+  author =       {Jim Bosch},
+  title =        "{Data Management System Level 2 System Requirements}",
+  year =         2017,
+  month =        nov,
+  handle =       {LDM-562},
+}
+
+@DocuShare{LDM-563,
+  author =       {William O'Mullane and Tim Jenness},
+  title =        "{Butler Working Group Charge}",
+  year =         2017,
+  month =        aug,
+  handle =       {LDM-563},
+}
+
+@DocuShare{LDM-564,
+  author =       {William O'Mullane and Frossie Economou and Tim Jenness and Andrew Loftus},
+  title =        "{Data Management Software Releases for Verification/Integration}",
+  year =         2018,
+  month =        jun,
+  handle =       {LDM-564},
+}
+
+@DocuShare{LDM-572,
+  author =       {William O'Mullane and Donald Petravick},
+  title =        "{Chilean Data Access Center}",
+  year =         2017,
+  month =        nov,
+  handle =       {LDM-572},
+}
+
+@DocuShare{LDM-582,
+  author =       {Mario Juric and Robert Gruendl},
+  title =        "{Lossy Compression Working Group Charge}",
+  year =         2017,
+  month =        oct,
+  handle =       {LDM-582},
+}
+
+@DocuShare{LDM-592,
+  author =       {Tim Jenness and Jim Bosch and Michelle Gower and
+                  Simon Krughoff and Russell Owen and Pim Schellart and
+                  Brian {van Klaveren} and Dominique Boutigny},
+  title =        "{Data Access Use Cases}",
+  year =         2017,
+  month =        nov,
+  handle =       {LDM-592},
+}
+
+@DocuShare{LDM-612,
+  author =       {Eric Bellm and Robert Blum and Melissa Graham and Leanne Guy and {\v Z}eljko {Ivezi{\'c}} and William O’Mullane and Maria Patterson and John Swinbank and Beth Willman},
+  title =        "{Plans and Policies for LSST Alert Distribution}",
+  year =         2019,
+  month =        jan,
+  handle =       {LDM-612},
+}
+
+
+@DocuShare{LDM-622,
+  author =       {John Swinbank},
+  title =        "{Data Management QA Strategy Working Group Charge}",
+  year =         2018,
+  month =        apr,
+  handle =       {LDM-622},
+}
+
+@DocuShare{LDM-633,
+  author =       {Mikolaj Kowalik and Michelle Gower and Rob Kooper},
+  title =        "{Offline Batch Production Services Use Cases}",
+  year =         2019,
+  month =        mar,
+  handle =       {LDM-633},
+}
+
+@DocuShare{LDM-635,
+  author =       {Michelle Gower and Michelle Butler and Kian-Tat Lim},
+  title =        "{Data Management Data Backbone Services Requirements}",
+  year =         2018,
+  month =        jun,
+  handle =       {LDM-635},
+}
+
+@DocuShare{LDM-636,
+  author =       {Mikolaj Kowalik and Michelle Gower and Rob Kooper},
+  title =        "{Batch Production Service Requirements}",
+  year =         2019,
+  month =        mar,
+  handle =       {LDM-636},
+}
+
+@DocuShare{LDM-639,
+  author =      {L. Guy},
+  title =       "{DM Acceptance Test Specification}",
+  year =        2018,
+  month =       jun,
+  handle =      {LDM-639},
+}
+
+@DocuShare{LDM-643,
+  author =      {M.~Johnson and R.A.~Gruendl},
+  title =       "{Proposed DM OPS Rehearsals}",
+  year =        2019,
+  month =       mar,
+  handle =      {LDM-643},
+}
+
+@DocuShare{LDM-672,
+   author = {G. Comoretto and L. Guy},
+    title = {LSST Software Release Management Policy},
+     year = 2019,
+    month = jul,
+   handle = {LDM-672},
+      url = {http://LDM-672.lsst.io } }
+
+@DocuShare{LDM-682,
+  author =       {Eric Bellm and Robert Blum and Melissa Graham and Leanne Guy and {\v Z}eljko {Ivezi{\'c}} and William O’Mullane and John Swinbank},
+  title =        "{Call for Letters of Intent for Community Alert Brokers}",
+  year =         2019,
+  month =        feb,
+  handle =       {LDM-682},
+}
+
+@DocuShare{LDM-692,
+   author = {Gabriele Comoretto},
+    title = {DM Verification Control Document},
+     year = 2019,
+    month = jun,
+   handle = {LDM-692},
+      url = {http://lm-692.lsst.io } }
+
+@DocuShare{LDM-702,
+  author =       {William O'Mullane},
+  title =        "{Image display working group charge}",
+  year =         2019,
+  month =        jun,
+  handle =       {LDM-702},
+}
+
+@DocuShare{LDM-723,
+  author =       {Eric Bellm and Robert Blum and Melissa Graham and Leanne Guy and {\v Z}eljko {Ivezi{\'c}} and William O’Mullane and John Swinbank},
+  title =        "{Call for Proposals for Community Alert Brokers}",
+  year =         2019,
+  month =        dec,
+  handle =       {LDM-723},
 }
 
 @DocuShare{LPM-17,
   author =       {{\v Z}. {Ivezi{\'c}} and {The LSST Science
                   Collaboration}},
   title =        "{LSST Science Requirements Document}",
-  year =         2011,
-  month =        jul,
+  year =         2018,
+  month =        jan,
   handle =       {LPM-17},
+}
+
+@DocuShare{LPM-18,
+  author =       {Chuck Gessner and Victor Krabbendam },
+  title =        "{Safety Policy}",
+  year =         2014,
+  month =        nov,
+  handle =       {LPM-18},
 }
 
 @DocuShare{LPM-19,
   author =       {George Angeli and Robert McKercher},
-  title =        {Change Control Process},
+  title =        "{Change Control Process}",
   year =         2015,
   month =        dec,
   handle =       {LPM-19},
@@ -692,7 +1003,7 @@
 
 @DocuShare{LPM-20,
   author =       {Victor Krabbendam and Brian Selvy},
-  title =        {Risk \& Opportunity Management Plan},
+  title =        "{Risk \& Opportunity Management Plan}",
   year =         2015,
   month =        aug,
   handle =       {LPM-20},
@@ -700,7 +1011,7 @@
 
 @DocuShare{LPM-43,
   author =       {Robert McKercher},
-  title =        {WBS Structure},
+  title =        "{WBS Structure}",
   year =         2016,
   month =        jul,
   handle =       {LPM-43},
@@ -708,7 +1019,7 @@
 
 @DocuShare{LPM-44,
   author =       {Robert McKercher},
-  title =        {WBS Dictionary},
+  title =        "{WBS Dictionary}",
   year =         2016,
   month =        jul,
   handle =       {LPM-44},
@@ -716,7 +1027,7 @@
 
 @DocuShare{LPM-51,
   author =       {Robert McKercher},
-  title =        {Document Management Plan},
+  title =        "{Document Management Plan}",
   year =         2013,
   month =        aug,
   handle =       {LPM-51},
@@ -724,7 +1035,7 @@
 
 @DocuShare{LPM-55,
   author =       {Donald Sweeney and Robert McKercher},
-  title =        {Project Quality Assurance Plan},
+  title =        "{Project Quality Assurance Plan}",
   year =         2013,
   month =        aug,
   handle =       {LPM-55},
@@ -732,7 +1043,7 @@
 
 @DocuShare{LPM-72,
   author =       {Victor Krabbendam},
-  title =        {Scope Options},
+  title =        "{Scope Options}",
   year =         2015,
   month =        oct,
   handle =       {LPM-72},
@@ -740,7 +1051,7 @@
 
 @DocuShare{LPM-73,
   author =       {Sidney Wolff},
-  title =        {Operations Plan},
+  title =        "{Operations Plan}",
   year =         2013,
   month =        oct,
   handle =       {LPM-73},
@@ -748,7 +1059,7 @@
 
 @DocuShare{LPM-81,
   author =       {Jeff Kantor and Victor Krabbendam},
-  title =        {Cost Estimating Plan},
+  title =        "{Cost Estimating Plan}",
   year =         2015,
   month =        aug,
   handle =       {LPM-81},
@@ -756,7 +1067,7 @@
 
 @DocuShare{LPM-98,
   author =       {Kevin E. Long},
-  title =        {LSST Project Controls System Description},
+  title =        "{LSST Project Controls System Description}",
   year =         2016,
   month =        dec,
   handle =       {LPM-98},
@@ -764,7 +1075,7 @@
 
 @DocuShare{LPM-121,
   author =       {Donald L. Petravick and Alexander Withers},
-  title =        {LSST Master Information Security Policy},
+  title =        "{LSST Master Information Security Policy}",
   year =         2016,
   month =        sep,
   handle =       {LPM-121},
@@ -772,15 +1083,23 @@
 
 @DocuShare{LPM-122,
   author =       {Donald Petravick},
-  title =        {LSST Information Classification Policy},
+  title =        "{LSST Information Classification Policy}",
   year =         2015,
   month =        aug,
   handle =       {LPM-122},
 }
 
+@DocuShare{LPM-123,
+  author =       {Donald Petravick},
+  title =        "{ LSST General Acceptable Use Policy  }",
+  year =         2017,
+  month =        oct,
+  handle =       {LPM-123},
+}
+
 @DocuShare{LPM-162,
   author =       {{Project Science Team}},
-  title =        {Project Publication Policy},
+  title =        "{Project Publication Policy}",
   year =         2015,
   month =        aug,
   handle =       {LPM-162},
@@ -794,9 +1113,33 @@
   handle =       {LPM-191},
 }
 
+@DocuShare{LPM-221,
+  author =       {William O'Mullane and Beth Willman},
+  title =        "{Charge for LSST Data Access Policy Working Group}",
+  year =         2017,
+  month =        nov,
+  handle =       {LPM-221},
+}
+
+@DocuShare{LPM-231,
+  author =       {G. P. Dubois-Felsmann and Z. Ivezic and M. Juric},
+  title =        "{LSST Data Product Categories}",
+  year =         2018,
+  month =        jan,
+  handle =       {LPM-231},
+}
+
+@DocuShare{LPM-251,
+  author =       {William O'Mullane and  Beth Willman and  Melissa Graham},
+  title =        "{Policy for Independent Data Access Centers}",
+  year =         2018,
+  month =        Jun,
+  handle =       {LPM-251},
+}
+
 @DocuShare{LSE-16,
   author =       {Robyn Allsman and Gregory Dubois-Felsmann and Jeff Kantor},
-  title =        {LSST Software Development Plan},
+  title =        "{LSST Software Development Plan}",
   year =         2009,
   month =        may,
   handle =       {LSE-16},
@@ -804,7 +1147,7 @@
 
 @DocuShare{LSE-17,
   author =       {Charles Claver and George Angeli and Brian Selvy},
-  title =        {Systems Engineering Management Plan},
+  title =        "{Systems Engineering Management Plan}",
   year =         2016,
   month =        jan,
   handle =       {LSE-17},
@@ -813,18 +1156,18 @@
 @DocuShare{LSE-29,
   author =       {Charles F. Claver and {The LSST Systems Engineering
                   Integrated Project Team}},
-  title =        {LSST System Requirements},
-  year =         2016,
-  month =        aug,
+  title =        "{LSST System Requirements (LSR)}",
+  year =         2017,
+  month =        sep,
   handle =       {LSE-29},
 }
 
 @DocuShare{LSE-30,
   author =       {Charles F. Claver and {The LSST Systems Engineering
                   Integrated Project Team}},
-  title =        {LSST System Requirements},
-  year =         2016,
-  month =        aug,
+  title =        "{Observatory System Specifications (OSS)}",
+  year =         2018,
+  month =        jan,
   handle =       {LSE-30},
 }
 
@@ -836,12 +1179,28 @@
   handle =       {LSE-39},
 }
 
+@DocuShare{LSE-60,
+  author =       {Jacques Sebag and Victor Krabbendam},
+  title =        "{LSST Telescope and Site (TS) Requirements}",
+  year =         2018,
+  month =        may,
+  handle =       {LSE-60},
+}
+
 @DocuShare{LSE-61,
-  author =       {Gregory Dubois-Felsmann},
-  title =        {LSST Data Management Subsystem Requirements},
-  year =         2016,
-  month =        feb,
+  author =       {Gregory Dubois-Felsmann and Tim Jenness},
+  title =        "{LSST Data Management Subsystem Requirements}",
+  year =         2018,
+  month =        jul,
   handle =       {LSE-61},
+}
+
+@DocuShare{LSE-62,
+  author =       {German Schumacher and Francisco Delgado},
+  title =        "{LSST Observatory Control System Requirements}",
+  year =         2019,
+  month =        oct,
+  handle =       {LSE-62},
 }
 
 @DocuShare{LSE-63,
@@ -856,7 +1215,7 @@
 
 @DocuShare{LSE-68,
   author =       {Gregory Dubois-Felsmann},
-  title =        {Camera Data Acquisition Interface},
+  title =        "{Camera Data Acquisition Interface}",
   year =         2015,
   month =        jun,
   handle =       {LSE-68},
@@ -864,7 +1223,7 @@
 
 @DocuShare{LSE-69,
   author =       {Gregory Dubois-Felsmann},
-  title =        {Interface between the Camera and Data Management},
+  title =        "{Interface between the Camera and Data Management}",
   year =         2014,
   month =        oct,
   handle =       {LSE-69},
@@ -879,7 +1238,7 @@
 }
 
 @DocuShare{LSE-72,
-  author =       {Gregory Dubious-Felsmann and German Schumacher and
+  author =       {Gregory Dubois-Felsmann and German Schumacher and
                   Brian Selvy},
   title =        "{OCS Command Dictionary for Data Management}",
   year =         2014,
@@ -888,7 +1247,7 @@
 }
 
 @DocuShare{LSE-75,
-  author =       {Gregory Dubious-Felsmann},
+  author =       {Gregory Dubois-Felsmann},
   title =        "{Control System Interfaces between the Telescope and Data Management}",
   year =         2011,
   month =        aug,
@@ -896,7 +1255,7 @@
 }
 
 @DocuShare{LSE-76,
-  author =       {Gregory Dubious-Felsmann},
+  author =       {Gregory Dubois-Felsmann},
   title =        "{Infrastructure Interfaces between Summit Facility and Data Management}",
   year =         2011,
   month =        aug,
@@ -904,7 +1263,7 @@
 }
 
 @DocuShare{LSE-77,
-  author =       {Gregory Dubious-Felsmann},
+  author =       {Gregory Dubois-Felsmann},
   title =        "{Infrastructure Interfaces between Base Facility and Data Management}",
   year =         2013,
   month =        oct,
@@ -914,7 +1273,7 @@
 @DocuShare{LSE-78,
 	author =       {Ron Lambert and Jeff Kantor and Mike Huffer and Chip Cox
                   and Paul Wefel and Matt Kollross and Sandra Jaque},
-	title =        { LSST Observatory Network Design},
+	title =        "{ LSST Observatory Network Design}",
 	year =         2017,
 	month =        apr,
 	handle =       {LSE-78},
@@ -922,15 +1281,24 @@
 
 @DocuShare{LSE-79,
   author =       {Chuck Claver and {The LSST Commissioning Planning Team}},
-  title =        {System AI\&T and Commissioning Plan},
+  title =        "{System AI\&T and Commissioning Plan}",
   year =         2017,
   month =        jan,
   handle =       {LSE-79},
 }
 
+@DocuShare{LEP-031,
+  author =       {The LSST EPO Team},
+  title =        "{LSST EPO Design}",
+  year =         2018,
+  month =        jul,
+  handle =       {LEP-031},
+}
+
+
 @DocuShare{LSE-81,
   author =       {Gregory Dubois-Felsmann},
-  title =        {LSST Science and Project Sizing Inputs},
+  title =        "{LSST Science and Project Sizing Inputs}",
   year =         2013,
   month =        oct,
   handle =       {LSE-81},
@@ -938,11 +1306,20 @@
 
 @DocuShare{LSE-82,
   author =       {Gregory Dubois-Felsmann and Kian-Tat Lim},
-  title =        {Science and Project Sizing Inputs Explanation},
+  title =        "{Science and Project Sizing Inputs Explanation}",
   year =         2013,
   month =        oct,
   handle =       {LSE-82},
 }
+
+@DocuShare{LSE-89,
+  author =       {Ben Emmons and Amanda Bauer},
+  title =        "{Education and Public Outreach Requirements}",
+  year =         2018,
+  month =        jan,
+  handle =       {LSE-89}
+}
+
 
 @DocuShare{LSE-130,
   author =       {Gregory Dubois-Felsmann},
@@ -969,6 +1346,14 @@
   handle =       {LSE-140},
 }
 
+@DocuShare{LSE-150,
+  author =       {Tiago Ribeiro and William O’Mullane and Tim Axelrod and Dave Mills},
+  title =        "{Control Software Architecture}",
+  year =         2019,
+  month =        aug,
+  handle =       {LSE-150},
+}
+
 @DocuShare{LSE-159,
   author =       {George Angeli},
   title =        "{Reviews Definitions, Guidelines, and Procedures}",
@@ -979,7 +1364,7 @@
 
 @DocuShare{LSE-163,
   author =       {Mario Juri\'c and others},
-  title =        {LSST Data Products Definition Document},
+  title =        "{LSST Data Products Definition Document}",
   year =         2017,
   month =        apr,
   handle =       {LSE-163},
@@ -987,34 +1372,115 @@
 
 @DocuShare{LSE-180,
   author =       {Lynne Jones},
-  title =        {Level 2 Photometric Calibration for the LSST Survey},
+  title =        "{Level 2 Photometric Calibration for the LSST Survey}",
   year =         2013,
   month =        nov,
   handle =       {LSE-180},
 }
 
 @DocuShare{LSE-209,
-	author =	     {Paul Lotz},
-	title =	 	     {Software Component to OCS Interface},
-	year =		     2016,
-	month =		     oct,
-	handle =	     {LSE-209},
+  author =       {Paul Lotz},
+  title =        {Software Component to OCS Interface},
+  year =         2016,
+  month =        oct,
+  handle =       {LSE-209},
+}
+
+@DocuShare{LSE-239,
+  author =       {Donald Petravick and Josh Hoblitt and Kian-Tat Lim and Ron Lambert and Gregory Dubois-Felsmann and Tom Durbin and Jeff Barr},
+  title =        "{Base Facility Data Center Design Requirements}",
+  year =         2016,
+  month =        aug,
+  handle =       {LSE-239},
 }
 
 @DocuShare{LSE-279,
-	author =	     {Alex Withers},
-	title =	 	     "{Concept of Operations for Unified LSST Authentication and Authorization Services}",
-	year =		     2017,
-	month =		     jan,
-	handle =	     {LSE-279},
+  author =       {Alex Withers},
+  title =        "{Concept of Operations for Unified LSST Authentication and Authorization Services}",
+  year =         2017,
+  month =        jan,
+  handle =       {LSE-279},
+}
+
+@DocuShare{LSE-309,
+  author =       {Jeff Kantor},
+  title =        "{Summit to Base Information Technology and Communication (ITC) Design}",
+  year =         2017,
+  month =        nov,
+  handle =       {LSE-309},
 }
 
 @DocuShare{LSE-319,
   author =       {M. Juri\'c and D. Ciardi and G.P. Dubois-Felsmann},
-  title =        {LSST Science Platform Vision Document},
+  title =        "{LSST Science Platform Vision Document}",
   year =         2017,
   month =        jun,
   handle =       {LSE-319},
+}
+
+@DocuShare{LPM-261,
+  author =       {Beth Willman and Melissa Graham and William O'Mullane and Donald Petravick},
+  title =        "{Access Policy for LSST Data and Data Access Center}",
+  year =         2018,
+  month =        mar,
+  handle =       {LPM-261},
+  note =         {Superseded by LDO-13},
+}
+
+@DocuShare{LSE-349,
+  author =       {K. Simon Krughoff},
+  title =        "{Defining the Transformation Between Camera Engineering Coordinates and Camera Data Visualization Coordinates}",
+  year =         2019,
+  month =        mar,
+  handle =       {LSE-349},
+}
+
+@DocuShare{LSE-379,
+  author =       {Patrick Ingraham},
+  title =        "{Auxiliary Telescope Concept of Operations}",
+  year =         2018,
+  month =        may,
+  handle =       {LSE-379},
+}
+
+@DocuShare{LSE-390,
+  author =       {Kevin Reil and  Chuck Claver and  Vincent Riot and Victor Krabbendam},
+  title =        "{Commissioning Execution Plan}",
+  year =         2020,
+  month =        mar,
+  handle =       {LSE-390},
+}
+
+@DocuShare{LSE-400,
+  author = {K-T Lim},
+  title = "{Header Service Interface}",
+  year = 2019,
+  handle = {LSE-400},
+  url = {https://lse-400.lsst.io},
+}
+
+@DocuShare{LDO-13,
+  author =      {R. Blum and others},
+  title =       "{LSST Data Policy}",
+  year =        2019,
+  month =       nov,
+  handle =      {LDO-13},
+}
+
+@DocuShare{LDO-31,
+  author =      {R. Blum and others},
+  title =       "{LSST Operations Proposal }",
+  year =        2020,
+  month =       mar,
+  handle =      {LDO-31},
+}
+
+@DocuShare{LSO-011,
+  author = {William O’Mullane and  Phil Marshall and  Leanne Guy},
+  title = "{Release Scenarios for LSST Data}",
+  year = 2019,
+  handle = {LSO-011},
+  url = {https://lso-011.lsst.io},
 }
 
 @DocuShare{LTS-206,
@@ -1024,10 +1490,74 @@
   handle =       {LTS-206},
 }
 
+@DocuShare{LTS-210,
+  author =       {D. Mills},
+  title =        "{Engineering and Facility Database Design Document}",
+  year =         2015,
+  handle =       {LTS-210},
+}
+
+@DocuShare{LTS-487,
+  author =       {P. Ingraham},
+  title =        "{Auxiliary Telescope Spectrograph Statement of Work (SOW)}",
+  year =         2017,
+  handle =       {LTS-487},
+}
+
+@DocuShare{LTS-488,
+  author =       {P. Ingraham},
+  title =        "{Auxiliary Telescope Spectrograph Specifications Document}",
+  year =         2017,
+  handle =       {LTS-488},
+}
+
+@DocuShare{LTS-807,
+  author =       {A. Serio},
+  title =        "{LSST Operations Viszualization Enviroment (LOVE) Requirements }",
+  year =         2018,
+  handle =       {LTS-807},
+}
+
+@DocuShare{Publication-141,
+  author =       {Dhital, S. and others},
+  title =        {{Science White Paper for LSST Deep-Drilling Field Observations Mapping the Milky Way's Ultracool Dwarfs, Subdwarfs, and White Dwarfs}},
+  year =         2011,
+  handle = {Publication-141},
+}
+
+@DocuShare{Publication-142,
+  author =       {Ferguson, H.~C.},
+  title =        {{Science White Paper for LSST Deep-Drilling Field Observations: LSST Deep Drilling for Galaxies}},
+  year =         2011,
+  handle = {Publication-142},
+}
+
+@DocuShare{Publication-143,
+  author =       {Gawiser, E. and others},
+  title =        {{Science White Paper for LSST Deep-Drilling Field Observations: Ultra-deep $ugrizy$ Imaging to Reduce Main Survey Photo-z Systematics and to Probe Faint Galaxy Clustering, AGN, and Strong Lenses}},
+  year =         2011,
+  handle = {Publication-143},
+}
+
+@DocuShare{Publication-144,
+  author =       {Kessler, R. and others},
+  title =        {{Science White Paper for LSST Deep-Drilling Field Observations: Supernova Light Curves}},
+  year =         2011,
+  handle = {Publication-144},
+}
+
+@DocuShare{Publication-145,
+  author =       {Szkody, P. and others},
+  title =        {{Science White Paper for LSST Deep-Drilling Field Observations
+High Cadence Observations of the Magellanic Clouds and Select Galactic Cluster Fields}},
+  year =         2011,
+  handle = {Publication-145},
+}
+
 @DocuShare{Report-142,
   author =       {Tim Jenness and John Swinbank and Simon Krughoff and
                   Gregory Dubois-Felsmann and David Ciardi},
-  title =        {Hot-Wiring the Transient Universe IV},
+  title =        "{Hot-Wiring the Transient Universe IV}",
   year =         2015,
   month =        jun,
   handle =       {Report-142},
@@ -1037,10 +1567,18 @@
 
 @DocuShare{Report-241,
   author =       {{LSST Project Science Team}},
-  title =        {Camera Mixed Focal Plane Option},
+  title =        "{Camera Mixed Focal Plane Option}",
   year =         2015,
   month =        nov,
   handle =       {Report-241},
+}
+
+@DocuShare{Report-561,
+  author =       {{Review Committee}},
+  title =        "{Telescope \& Site (T\&S) Software Review Report}",
+  year =         2018,
+  month =        mar,
+  handle =       {Report-561},
 }
 
 @DocuShare{DMTN-007,
@@ -1070,11 +1608,20 @@
      url = {https://dmtn-015.lsst.io},
 }
 
+@DocuShare{DMTN-018,
+  author = {Andy Salnikov},
+   title = "{Re-visiting L1 Database Design (Draft)}",
+    year = 2016,
+  handle = {DMTN-018},
+     url = {https://dmtn-018.lsst.io/}
+}
+
+
 @DocuShare{DMTN-020,
   author =       {Jacek Becla and Frossie Economou and Margaret Gelman and
                   Jeff Kantor and Simon Krughoff and Kevin Long and Fritz
                   Mueller and John Swinbank and Xiuqin Wu},
-  title =        {Project Management Guide},
+  title =        "{Project Management Guide}",
   year =         2016,
   month =        nov,
   handle =       {DMTN-020},
@@ -1088,6 +1635,33 @@
   handle = {DMTN-021},
     note = {LSST Data Management Technical Note},
      url = {https://dmtn-021.lsst.io},
+}
+
+@DocuShare{DMTN-025,
+  author = {Mikolaj Kowalik and Hsin-Fang Chiang and Greg Daues and Rob Kooper},
+   title = "{A survey of workflow management systems}",
+    year = 2016,
+  handle = {DMTN-025},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-025.lsst.io},
+}
+
+@DocuShare{DMTN-028,
+  author = {Maria T. Patterson},
+  title = "{Benchmarking a distribution system for LSST alerts}",
+    year = 2018,
+  handle = {DMTN-028},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-028.lsst.io},
+}
+
+@DocuShare{DMTN-031,
+  author = {Christopher B. Morrison},
+  title = "{Pessimistic Pattern Matching for LSST}",
+    year = 2018,
+  handle = {DMTN-031},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-031.lsst.io},
 }
 
 @DocuShare{DMTN-035,
@@ -1145,6 +1719,470 @@
      url = {https://dmtn-048.lsst.io},
 }
 
+@DocuShare{DMTN-049,
+  author = {M. L. Graham},
+   title = "{LSST DRP (Level 2) Catalog Photometric Redshifts}",
+    year = 2018,
+  handle = {DMTN-049},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-049.lsst.io},
+}
+
+@DocuShare{DMTN-056,
+   author = {Pim Schellart and  Jim Bosch},
+    title = {Butler Redesign Strawman},
+     year = 2018,
+    month = jan,
+   handle = {DMTN-056},
+      url = {http://DMTN-056.lsst.io}
+}
+
+@DocuShare{DMTN-057,
+  author = {Krzysztof Findeisen},
+   title = "{Integrating Verification Metrics into the LSST DM Stack}",
+    year = 2017,
+   month = oct,
+  handle = {DMTN-057},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-057.lsst.io},
+}
+
+@DocuShare{DMTN-059,
+  author = {Michelle Gower},
+   title = "{Batch Processing Facade Prototype 0.1}",
+    year = 2017,
+   month = sep,
+  handle = {DMTN-059},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-059.lsst.io},
+}
+
+@DocuShare{DMTN-064,
+  author = {J. Meyers},
+   title = "{Hyper Suprime-Cam donut analysis}",
+    year = 2018,
+   month = jan,
+  handle = {DMTN-064},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-064.lsst.io},
+}
+
+@DocuShare{DMTN-065,
+  author = {M. Graham and M. Juri\'{c} and K.-T. Lim and E. Bellm},
+   title = "{Data Management and LSST Special Programs}",
+    year = 2018,
+  handle = {DMTN-065},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-065.lsst.io},
+}
+
+
+
+@DocuShare{DMTN-069,
+  author = {A. C. Becker and K. Simon Krughoff and A. Connolly},
+   title = "{Report on Winter 2014 Production: Image Differencing}",
+    year = 2014,
+   month = may,
+  handle = {DMTN-069},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-069.lsst.io},
+}
+
+@DocuShare{DMTN-070,
+  author = {A. C. Becker and K. Simon Krughoff and A. Connolly},
+   title = "{Report on Summer 2014 Production: Analysis of DCR}",
+    year = 2014,
+   month = oct,
+  handle = {DMTN-070},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-070.lsst.io},
+}
+
+@DocuShare{DMTN-072,
+  author = {William O'Mullane and John Swinbank},
+   title = "{Cloud technical assesment}",
+    year = 2018,
+   month = jan,
+  handle = {DMTN-072},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-072.lsst.io},
+}
+
+@DocuShare{DMTN-074,
+  author = { John Swinbank },
+   title = "{DM QA Status \& Plans}",
+    year = 2018,
+   month = jun,
+  handle = {DMTN-074},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-074.lsst.io},
+}
+
+@DocuShare{DMTN-077,
+  author = { K. Suberlak and C. Slater and \v{Z}. Ivezi\'c},
+   title = "{LSST Fall 2017 Crowded Fields Testing}",
+    year = 2018,
+   month = apr,
+  handle = {DMTN-077},
+    note = {LSST Data Management Technical Note},
+     url = {https:/wdmtn-077.lsst.io},
+}
+
+@DocuShare{DMTN-078,
+  author = {William O'Mullane and John Swinbank and Margaret Gelemann and Xiuqin Wu and Fritz Mueller},
+   title = "{Potential proofs of concept for Google Cloud}",
+    year = 2018,
+   month = apr,
+  handle = {DMTN-078},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-078.lsst.io},
+}
+
+@DocuShare{DMTN-080,
+  author = {AlSayyad, Y.},
+   title = "{Coaddition Artifact Rejection and \texttt{CompareWarp}}",
+    year = 2018,
+   month = jul,
+  handle = {DMTN-080},
+    note = {LSST Data Management Technical Note, draft version},
+     url = {https://dmtn-080.lsst.io},
+}
+
+@DocuShare{DMTN-081,
+  author = {Maria T. Patterson},
+   title = "{Deploying an alert stream mini-broker prototype}",
+    year = 2018,
+   month = jun,
+  handle = {DMTN-081},
+    note = {LSST Data Management Technical Note, draft version},
+     url = {https://dmtn-081.lsst.io},
+}
+
+@DocuShare{DMTN-085,
+  author = {Bellm,~E.C. and Chiang,~H.-F. and Fausti,~A. and Krughoff,~K.S.  and MacArthur,~L.A.M and Morton,~T.D. and Swinbank,~J.D. and Roby,~T.},
+   title = "{QA Strategy Working Group Report}",
+    year = 2018,
+   month = jul,
+  handle = {DMTN-085},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-085.lsst.io},
+}
+
+@DocuShare{DMTN-086,
+  author = {C. Slater},
+   title = "{Next-to-the-Database Processing Use Cases}",
+    year = 2018,
+   month = jul,
+  handle = {DMTN-086},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-086.lsst.io},
+}
+
+@DocuShare{DMTN-087,
+  author = {Juric, M. and Jones, L.},
+   title = "{Proposed Modifications to Solar System Processing and Data Products}",
+    year = 2018,
+   month = jun,
+  handle = {DMTN-087},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-087.lsst.io},
+}
+
+@DocuShare{DMTN-088,
+  author = {Hsin-Fang Chiang Margaret W. G. Johnson},
+   title = "{As-is HSC Reprocessing}",
+    year = 2018,
+   month = jul,
+  handle = {DMTN-088},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-088.lsst.io},
+}
+
+@DocuShare{DMTN-091,
+  author = {Michael Wood-Vasey and Eric Bellm and Jim Bosch and Jeff Carlin and Zeljko Ivezic and Lauren MacArthur and Colin Slater},
+   title = "{Test Datasets for Scientific Performance Monitoring}",
+    year = 2019,
+   month = nov,
+  handle = {DMTN-091},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-091.lsst.io},
+}
+
+@DocuShare{DMTN-093,
+  author = {Maria Patterson and Eric Bellm and John Swinbank},
+   title = "{Design of the LSST Alert Distribution System}",
+    year = 2018,
+   month = oct,
+  handle = {DMTN-093},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-093.lsst.io},
+}
+
+@DocuShare{DMTN-094,
+  author = {Brian Van Klaveren},
+   title = "{LSP Authentication Design}",
+    year = 2019,
+   month = apr,
+  handle = {DMTN-094},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-094.lsst.io},
+}
+
+@DocuShare{DMTN-096,
+  author = {William O'Mullane and John Swinbank and Leanne Guy and Amanda Bauer},
+   title = "{Implementation and impacts of DM scope options}",
+    year = 2018,
+   month = nov,
+  handle = {DMTN-096},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-096.lsst.io},
+}
+
+@DocuShare{DMTN-098,
+  author = {Krzysztof Findeisen},
+   title = "{Metrics Measurement Framework Design}",
+    year = 2018,
+   month = dec,
+  handle = {DMTN-098},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-098.lsst.io},
+}
+
+@DocuShare{DMTN-102,
+  author = {M.~L.~Graham and E.~C.~Bellm and L.~P.~Guy and C.~T.~Slater G.~P.~Dubois-Felsmann and the DM System Science Team},
+   title = "{LSST Alerts: Key Numbers}",
+    year = 2019,
+   month = feb,
+  handle = {DMTN-102},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-102.lsst.io},
+}
+
+@DocuShare{DMTN-104,
+   author = { Gabriele Comoretto },
+    title = {Data Management Detailed Product Tree},
+     year = 2020,
+    month = apr,
+   handle = {DMTN-104},
+      url = {http://DMTN-104.lsst.io } }
+
+@DocuShare{DMTN-106,
+   author = { Gabriele Comoretto },
+    title = {DM Release Process},
+     year = 2019,
+    month = jun,
+   handle = {DMTN-106},
+      url = {http://DMTN-106.lsst.io } }
+
+@DocuShare{DMTN-107,
+  author = {M.~L.~Graham and E.~C.~Bellm and C.~T.~Slater  and the DM System Science Team},
+   title = "{Options for Alert Production in  LSST Operations Year 1}",
+    year = 2019,
+   month = mar,
+  handle = {DMTN-107},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-107.lsst.io},
+}
+
+@DocuShare{DMTN-109,
+   author = {Siegfried Eggl},
+    title = "{LSST discovery estimates for Solar System Objects}",
+     year = 2019,
+    month = jul,
+   handle = {DMTN-109},
+      url = {http://dmtn-109.lsst.io}
+}
+
+@DocuShare{DMTN-110,
+   author = {Gabriele Comoretto},
+    title = "{Conda Environment Proposal for Science Pipelines}",
+     year = 2019,
+    month = jun,
+   handle = {DMTN-110},
+      url = {http://dmtn-110.lsst.io}
+}
+
+@DocuShare{DMTN-111,
+   author = {Kian-Tat Lim },
+    title = { DM Usage in Observatory Operations},
+     year = 2019,
+    month = apr,
+   handle = {DMTN-111},
+      url = {http://dmtn-111.lsst.io}
+}
+
+@DocuShare{DMTN-113,
+   author = {Andy Salnikov},
+    title = {Performance of RDBMS-based PPDB implementation},
+     year = 2019,
+    month = mar,
+   handle = {DMTN-113},
+      url = {http://dmtn-113.lsst.io}
+}
+
+@DocuShare{DMTN-114,
+   author = {Kian-Tat Lim and Leanne Guy and Hsin-Fang Chiang},
+    title = {LSST + Amazon Web Services Proof of Concept},
+     year = 2019,
+    month = apr,
+   handle = {DMTN-114},
+      url = {http://dmtn-114.lsst.io}
+}
+
+@DocuShare{DMTN-119,
+   author = {William O'Mullane and Robert Gruendl and Robert Blum},
+    title = {Report on Operations Rehersal \#1},
+     year = 2019,
+    month = 05,
+   handle = {DMTN-119},
+      url = {http://dmtn-119.lsst.io}
+}
+
+@DocuShare{DMTN-121,
+   author = {Ian Sullivan},
+    title = "{Impact of variable seeing on DCR coadd generation}",
+     year = 2019,
+    month = jun,
+   handle = {DMTN-121},
+      url = {http://dmtn-121.lsst.io}
+}
+
+@DocuShare{DMTN-122,
+   author = { Michelle Gower and Kian-Tat Lim },
+    title = {Data Backbone Design},
+     year = 2019,
+    month = 07,
+   handle = {DMTN-122},
+      url = {http://DMTN-122.lsst.io } }
+
+@DocuShare{DMTN-123,
+   author = { Michelle Gower and Kian-Tat Lim },
+    title = {Batch Production Services Design},
+     year = 2019,
+    month = 08,
+   handle = {DMTN-123},
+      url = {http://DMTN-123.lsst.io } }
+
+@DocuShare{DMTN-125,
+   author = {Kian-Tat Lim},
+    title = "{Google Cloud Engagement Results}",
+     year = 2019,
+    month = jul,
+   handle = {DMTN-125},
+      url = {http://dmtn-125.lsst.io}
+}
+@DocuShare{DMTN-136,
+   author = {      Gregory Dubois-Felsmann },
+    title = {LSST Science Platform Portal Aspect Design and Maintenance Manual},
+     year = 2019,
+    month = nov,
+   handle = {DMTN-136},
+      url = {http://DMTN-136.lsst.io } }
+
+@DocuShare{DMTN-135,
+   author = { Michelle Butler and  Kian Tat Lim and  William O'Mullane },
+    title = {DM sizing model and purchase plan for the remainder of construction.},
+     year = 2019,
+    month = nov,
+   handle = {DMTN-135},
+      url = {http://DMTN-135.lsst.io } }
+
+@DocuShare{DMTN-137,
+   author = { Hsin-Fang Chiang and Dino Bektesevic and the AWS-PoC team },
+    title = {AWS Proof of Concept Project Report},
+     year = 2020,
+    month = jan,
+   handle = {DMTN-137},
+      url = {http://DMTN-137.lsst.io } }
+
+@DocuShare{DMTN-140,
+  author = {G. Comoretto and L. P. Guy and others},
+   title = "{Documentation Automation for the Verification and Validation of Rubin Observatory Software}",
+    year = 2020,
+    month = dec,
+  handle = {DMTN-140},
+     url = {https://dmtn-140.lsst.io/} }
+
+@DocuShare{DMTN-150,
+   author = { Kian-Tat Lim },
+    title = {LSST + Google Cloud Proof of Concept},
+     year = 2020,
+    month = may,
+   handle = {DMTN-150},
+      url = {http://DMTN-150.lsst.io } }
+
+@DocuShare{DMTN-157,
+   author = {Hsin-Fang Chiang and K-T Lim},
+    title = "{Report of Google Cloud Proof of Concept}",
+     year = 2020,
+   handle = {DMTN-157},
+     note = {LSST Data Management Technical Note},
+      url = {https://dmtn-157.lsst.io},
+ }
+
+@DocuShare{DMTN-163,
+ author = {Russ Allbery},
+  title = "{Encryption of Rubin Observatory data}",
+   year = 2020,
+ handle = {DMTN-163},
+   note = {LSST Data Management Technical Note},
+    url = {https://dmtn-163.lsst.io},
+}
+
+@DocuShare{DMTN-165,
+ author = {Eric Bellm and Spencer Nelson},
+  title = "{A Hybrid Notification and Alert Retrieval Service}",
+   year = 2020,
+ handle = {DMTN-165},
+   note = {LSST Data Management Technical Note},
+    url = {https://dmtn-165.lsst.io},
+}
+
+@DocuShare{DMTN-169,
+ author = {Russ Allbery},
+  title = "{A model for Butler registry access control document}",
+   year = 2020,
+ handle = {DMTN-169},
+   note = {LSST Data Management Technical Note},
+    url = {https://dmtn-169.lsst.io},
+}
+
+@DocuShare{DMTN-176,
+   author = {Tim Jenness},
+    title = "{A client/server Butler}",
+     year = 2021,
+   handle = {DMTN-176},
+     note = {LSST Data Management Technical Note},
+      url = {https://dmtn-176.lsst.io},
+ }
+
+@DocuShare{DMTN-177,
+  author = {Tim Jenness},
+   title = "{Limiting Registry Access During Workflow Execution}",
+    year = 2021,
+  handle = {DMTN-177},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-177.lsst.io},
+}
+
+@DocuShare{DMTN-178,
+   author = { Gabriele Comoretto },
+    title = {Docsteady Usecases for Rubin Observatory Construction},
+     year = 2021,
+    month = jan,
+   handle = {DMTN-178},
+      url = {http://DMTN-178.lsst.io } }
+}
+
+@DocuShare{DMTN-182,
+  author = {Russ Allbery},
+   title = "{Possible authorization approaches for Butler}",
+    year = 2021,
+  handle = {DMTN-182},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-182.lsst.io},
+}
+
 @DocuShare{DMTR-11,
   author = {Frossie Economou and John Swinbank and Jim Bosch
             and Simon Krughoff},
@@ -1194,6 +2232,13 @@
   handle = {DMTR-16},
 }
 
+@DocuShare{DMTR-17,
+  author = {Vaikunth~Thukral},
+   title = "{Qserv Fall 17 Large Scale Tests/KPMs}",
+    year = 2018,
+   month = jun,
+  handle = {DMTR-17},
+}
 @DocuShare{DMTR-21,
   author = {Jacek Becla and K-T Lim and Daniel Wang},
    title = "{Early (pre-2013) Large-Scale Qserv Tests}",
@@ -1210,6 +2255,282 @@
   handle = {DMTR-22},
 }
 
+@DocuShare{DMTR-31,
+  author = {H.-F. Chiang and G. Daues and S. Thrush and {The NCSA Team}},
+   title = "{S17B HSC PDR1 Reprocessing Report}",
+    year = 2017,
+   month = aug,
+  handle = {DMTR-31},
+}
+
+@DocuShare{DMTR-41,
+  author = {S. Krughoff and  J. Wood-Vasey},
+   title = "{Characterization Metric Report: Science Pipelines Version 14.0}",
+    year = 2017,
+   month = oct,
+  handle = {DMTR-41},
+}
+
+@DocuShare{DMTR-51,
+  author = {Bosch, J. and Chiang, H.-F. and Gower, M. and Kowalik, M. and Morton, T. and Swinbank, J.D.},
+   title = {LDM-503-02 (HSC Reprocessing) Test Report},
+    year = 2017,
+   month = dec,
+  handle = {DMTR-51},
+}
+
+@DocuShare{DMTR-52,
+  author = {Gregory P. Dubois-Felsmann},
+   title = {LDM-503-01 (WISE Data Loaded in PDAC) Test Report },
+    year = 2018,
+   month = may,
+  handle = {DMTR-52},
+}
+
+@DocuShare{DMTR-53,
+  author = {Bellm, E.C. and Swinbank, J.D.},
+   title = {LDM-503-03 (Alert Generation) Test Report},
+    year = 2018,
+   month = jan,
+  handle = {DMTR-53},
+}
+
+@DocuShare{DMTR-61,
+  author = {Butler, M. and Parsons, J.},
+   title = {LDM-503-04 and LDM-503-04b (Raw Image Archiving Service) Test Report},
+    year = 2018,
+   month = jun,
+  handle = {DMTR-61},
+}
+
+@DocuShare{DMTR-71,
+  author = {Fritz Mueller},
+   title = "{LVV-P46 (2018 qserv large scale testing) Test Plan and Report}",
+    year = 2019,
+   month = jul,
+  handle = {DMTR-71},
+}
+
+@DocuShare{DMTR-82,
+  author = {Vinicius Arcanjo and Albert Astudillo and Jeronimo Bezerra and Luis Corral and Julio Ibarra and Sandra Jaque and Jeff Kantor and Matt Kollross and Ron Lambert},
+   title = "{Network Bandwidth Tests between Chile and the United States}",
+    year = 2018,
+   month = jun,
+  handle = {DMTR-82},
+}
+
+@DocuShare{DMTR-91,
+  author = {Bellm, E.C.},
+   title = {LDM-503-05 (Alert Distribution Validation) Test Report},
+    year = 2018,
+   month = jul,
+  handle = {DMTR-91},
+}
+
+@DocuShare{DMTR-111,
+  author = {Swinbank, J.D.},
+   title = "{LDM-503-09a (Science pipelines fall 2018 release) Test Plan and Report}",
+    year = 2018,
+   month = nov,
+  handle = {DMTR-111},
+}
+
+@DocuShare{DMTR-112,
+  author = {Swinbank, J.D.},
+   title = "{LDM-503-07 (Camera data processing) Test Plan and Report}",
+    year = 2018,
+   month = nov,
+  handle = {DMTR-112},
+}
+@DocuShare{DMTR-102,
+   author = {Michelle Butler},
+    title = {LDM-503-8b (Small Scale CCOB Data Access) Test Plan and Report},
+     year = 2019,
+    month = jul,
+   handle = {DMTR-102},
+      url = {http://dmtr-102.lsst.io}
+}
+
+@DocuShare{DMTR-121,
+   author = {Michelle Butler},
+    title = {LDM-503-8 (Spectrograph Data Acquisition) Test Plan and Report},
+     year = 2019,
+    month = jul,
+   handle = {DMTR-121},
+      url = {http://dmtr-121.lsst.io }
+}
+
+@DocuShare{DMTR-141,
+   author = {G. Comoretto on behalf of Science Pipelines Team},
+    title = {Characterization Metric Report: Science Pipelines Version 18.0.0},
+     year = 2019,
+    month = jul,
+   handle = {DMTR-141},
+      url = {http://dmtr-141.lsst.io }
+}
+
+@DocuShare{DMTR-151,
+  author = {Jeff Kantor},
+   title = "{LVV-P47 (Summit - base network integration) Test Plan and Report}",
+    year = 2019,
+   month = feb,
+  handle = {DMTR-151},
+}
+
+@DocuShare{DMTR-161,
+   author = {Dubois-Felsmann, G.},
+    title = {LDM-503-10a: LSP with Authentication and TAP Test Plan and Report},
+     year = 2020,
+    month = jan,
+   handle = {DMTR-161},
+}
+
+@DocuShare{DMTR-171,
+   author = {Butler, M.},
+    title = {LDM-503-6: ComCam Interface Verification Readiness Test Plan and Report},
+     year = 2020,
+    month = aug,
+   handle = {DMTR-171},
+}
+
+@DocuShare{DMTR-181,
+   author = {Butler, M.},
+    title = {LDM-503-10: DAQ Validation Test Plan and Report},
+     year = 2020,
+    month = aug,
+   handle = {DMTR-181},
+}
+
+@DocuShare{DMTR-182,
+   author = {Butler, M.},
+    title = {LDM-503-10b: Large Scale CCOB Data Access Test Plan and Report},
+     year = 2019,
+    month = oct,
+   handle = {DMTR-182},
+     note = {Draft version},
+      url = {http://dmtr-182.lsst.io }
+}
+
+@DocuShare{DMTR-191,
+   author = {J. Carlin and  K. S. Krughoff and  G. Comoretto},
+    title = {Characterization Metric Report: Science Pipelines Version 19.0.0},
+     year = 2019,
+    month = dec,
+   handle = {DMTR-191},
+      url = {http://dmtr-191.lsst.io }
+}
+
+@DocuShare{DMTR-192,
+   author = {Swinbank, J.},
+    title = {LDM-503-11b: Science Pipelines Fall 2019 Release Test Plan and Report},
+     year = 2019,
+    month = nov,
+   handle = {DMTR-191},
+     note = {Draft version},
+      url = {http://dmtr-191.lsst.io }
+}
+
+@DocuShare{DMTR-201,
+  author = {Fritz Mueller},
+   title = "{LVV-P65 Fall 2019 Pipelines Release Acceptance Test Campaign Test Plan and Report}",
+    year = 2020,
+   month = mar,
+  handle = {DMTR-201},
+}
+
+@DocuShare{DMTR-211,
+  author = {Gregory Dubois-Felsmann},
+   title = "{DM-SUIT-8: Portal Integrated with Workspace Test Plan and Report}",
+    year = 2020,
+   month = may,
+  handle = {DMTR-211},
+}
+
+@DocuShare{DMTR-231,
+   author = {Gruendl, R.},
+    title = {LDM-503-11a: ComCam OPS Readiness Test Plan and Report},
+     year = 2020,
+    month = nov,
+   handle = {DMTR-231},
+}
+
+@DocuShare{DMTR-251,
+   author = {Jeff Carlin},
+    title = {Characterization Metric Report: Science Pipelines Version 20.0.0},
+     year = 2020,
+    month = jun,
+   handle = {DMTR-251},
+      url = {http://dmtr-251.lsst.io }
+}
+
+@DocuShare{DMTR-261,
+   author = {Carlin, J.},
+    title = {Science Pipelines Release 20.0.0 Acceptance Test Campaign Test Plan and Report},
+     year = 2020,
+    month = aug,
+   handle = {DMTR-261},
+}
+
+@DocuShare{DMTR-271,
+   author = { Robert Gruendl },
+    title = {LDM-GEN3: Gen 3 Butler Acceptance Testing Test Plan and Report},
+     year = 2021,
+    month = 05,
+   handle = {DMTR-271},
+      url = {http://DMTR-271.lsst.io } }
+
+@DocuShare{DMTR-301,
+ author = { Gregory Dubois-Felsmann },
+  title = {milestone-dp01},
+   year = 2021,
+  month = Mar,
+ handle = {DMTR-301},
+    url = {https://dmtr-301.lsst.io } }
+
+ @DocuShare{DMTR-302,
+    author = { Yusra AlSayyad },
+     title = {LDM-503-13a},
+      year = 2021,
+     month = Apr,
+    handle = {DMTR-302},
+       url = {https://dmtr-302.lsst.io } }
+
+@DocuShare{SQR-006,
+  author = {Jonathan Sick},
+   title = {The LSST the Docs Platform for Continuous Documentation Delivery},
+    year = 2017,
+   month = jul,
+  handle = {SQR-006},
+     url = {https://sqr-006.lsst.io},
+}
+
+@DocuShare{SQR-009,
+  author = {Angelo Fausti},
+   title = {The SQuaSH metrics dashboard},
+    year = 2017,
+   month = dec,
+  handle = {SQR-009},
+     url = {https://sqr-009.lsst.io},
+}
+
+@DocuShare{SQR-016,
+  author = { Frossie Economou },
+   title = "{Stack release playbook}",
+    year = 2018,
+   month = dec,
+  handle = {SQR-016},
+     url = {https://sqr-016.lsst.io},
+}
+
+@DocuShare{SQR-017,
+  author = {John Parejko and Jonathan Sick},
+   title = "{Validation Metrics Framework}",
+    year = 2017,
+   month = feb,
+  handle = {SQR-017},
+     url = {https://sqr-017.lsst.io},
+}
+
 @DocuShare{SQR-018,
   author = {Frossie Economou},
    title = "{Investigations into JupyterLab as a basis for the LSST Science Platform}",
@@ -1218,3 +2539,437 @@
   handle = {SQR-018},
      url = {https://sqr-018.lsst.io},
 }
+
+@DocuShare{SQR-019,
+  author = {Jonathan Sick and Angelo Fausti},
+   title = "{LSST Verification Framework API Demonstration}",
+    year = 2018,
+   month = apr,
+  handle = {SQR-019},
+     url = {https://sqr-019.lsst.io},
+}
+
+@DocuShare{PSTN-003,
+   author = {William O'Mullane and  Fritz Mueller },
+    title = {Discussion of Object vs. Source table queries and data distribution},
+     year = 2019,
+    month = jun,
+   handle = {PSTN-003},
+      url = {http://PSTN-003.lsst.io } }
+
+@DocuShare{PSTN-005,
+   author = {Jeff Barr},
+    title = {Overview of the LSST Telescope},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-005},
+      url = {http://PSTN-005.lsst.io } }
+
+
+@DocuShare{PSTN-006,
+   author = {Sandrine Thomas},
+    title = {Performance of the LSST Telescope},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-006},
+      url = {http://PSTN-006.lsst.io } }
+
+
+@DocuShare{PSTN-007,
+   author = {Lynne Jones},
+    title = {The LSST Scheduler Overview and Performance},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-007},
+      url = {http://PSTN-007.lsst.io } }
+
+
+@DocuShare{PSTN-008,
+   author = {Bo Xin},
+    title = {Performance of the LSST Active Optics System},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-008},
+      url = {http://PSTN-008.lsst.io } }
+
+
+@DocuShare{PSTN-009,
+   author = {Tiago Ribeiro},
+    title = {LSST Observing System Software Architecture},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-009},
+      url = {http://PSTN-009.lsst.io } }
+
+
+@DocuShare{PSTN-010,
+   author = {Justin Wolfe},
+    title = {LSST Camera Optics},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-010},
+      url = {http://PSTN-010.lsst.io } }
+
+
+@DocuShare{PSTN-011,
+   author = {Chris Stubbs},
+    title = {LSST Camera Rafts},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-011},
+      url = {http://PSTN-011.lsst.io } }
+
+
+@DocuShare{PSTN-012,
+   author = {Steve Ritz},
+    title = {LSST Camera Cryostat},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-012},
+      url = {http://PSTN-012.lsst.io } }
+
+
+@DocuShare{PSTN-013,
+   author = {Ralph Schindler},
+    title = {LSST Camera Refrigeration},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-013},
+      url = {http://PSTN-013.lsst.io } }
+
+
+@DocuShare{PSTN-014,
+   author = {Steve Ritz},
+    title = {LSST Camera Body and Mechanisms},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-014},
+      url = {http://PSTN-014.lsst.io } }
+
+
+@DocuShare{PSTN-015,
+   author = {Mark Huffer and Tony Johnson},
+    title = {LSST Camera Control System and DAQ},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-015},
+      url = {http://PSTN-015.lsst.io } }
+
+
+@DocuShare{PSTN-016,
+   author = {Tim Bond and Aaron Rodman},
+    title = {LSST Camera Integration and Tests},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-016},
+      url = {http://PSTN-016.lsst.io } }
+
+
+@DocuShare{PSTN-017,
+   author = {William O'Mullane and  Leanne Guy},
+    title = {Overview of LSST Data Management},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-017},
+      url = {http://PSTN-017.lsst.io } }
+
+
+@DocuShare{PSTN-018,
+   author = {Michelle Butler},
+    title = {LSST Data Facility},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-018},
+      url = {http://PSTN-018.lsst.io } }
+
+
+@DocuShare{PSTN-019,
+   author = {Tim Jenness},
+    title = {LSST Data Management Software System},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-019},
+      url = {http://PSTN-019.lsst.io } }
+
+
+@DocuShare{PSTN-020,
+   author = {Jim Bosch},
+    title = {LSST Data Release Processing},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-020},
+      url = {http://PSTN-020.lsst.io } }
+
+
+@DocuShare{PSTN-021,
+   author = {Eric Bellm},
+    title = {LSST Prompt Data Products},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-021},
+      url = {http://PSTN-021.lsst.io } }
+
+
+@DocuShare{PSTN-022,
+   author = {Frossie Economou and  Gregory Dubois-Felsmann},
+    title = {LSST Science Platform},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-022},
+      url = {http://PSTN-022.lsst.io } }
+
+
+@DocuShare{PSTN-023,
+   author = {Simon Krughoff},
+    title = {LSST Data Management Quality Assurance and Reliability Engineering},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-023},
+      url = {http://PSTN-023.lsst.io } }
+
+
+@DocuShare{PSTN-024,
+   author = {},
+    title = {LSST Data Management System Verification and Validation},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-024},
+      url = {http://PSTN-024.lsst.io } }
+
+
+@DocuShare{PSTN-025,
+   author = {Mario Juric},
+    title = {LSST Moving Object Processing},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-025},
+      url = {http://PSTN-025.lsst.io } }
+
+
+@DocuShare{PSTN-026,
+   author = {Robert Lupton},
+    title = {LSST Calibration Strategy and Pipelines},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-026},
+      url = {http://PSTN-026.lsst.io } }
+
+
+@DocuShare{PSTN-027,
+   author = {Patrick Ingraham},
+    title = {Performance of the LSST Calibration Systems},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-027},
+      url = {http://PSTN-027.lsst.io } }
+
+
+@DocuShare{PSTN-028,
+   author = {Patrick Ingraham},
+    title = {Atmospheric Properties with the LSST Auxiliary Telescope},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-028},
+      url = {http://PSTN-028.lsst.io } }
+
+
+@DocuShare{PSTN-029,
+   author = {Amanda Bauer},
+    title = {Overview of LSST Education and Public Outreach},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-029},
+      url = {http://PSTN-029.lsst.io } }
+
+
+@DocuShare{PSTN-030,
+   author = {Ardis Herrold},
+    title = {LSST Formal Education Program},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-030},
+      url = {http://PSTN-030.lsst.io } }
+
+
+@DocuShare{PSTN-031,
+   author = {Amanda Bauer},
+    title = {LSST EPO: The User Feedback},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-031},
+      url = {http://PSTN-031.lsst.io } }
+
+
+@DocuShare{PSTN-004,
+   author = {Chuck Claver},
+    title = {LSST Observatory System Operations Readiness Report},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-004},
+      url = {http://PSTN-004.lsst.io } }
+
+
+@DocuShare{PSTN-032,
+   author = {Bo Xin},
+    title = {Performance of Delivered LSST System},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-032},
+      url = {http://PSTN-032.lsst.io } }
+
+
+@DocuShare{PSTN-033,
+   author = {Chuck Claver},
+    title = {Active Optics Performance with LSST Commissiong Camera},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-033},
+      url = {http://PSTN-033.lsst.io } }
+
+
+@DocuShare{PSTN-034,
+   author = {Chuck Claver},
+    title = {LSST Active Optics Performance with the LSST Science Camera},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-034},
+      url = {http://PSTN-034.lsst.io } }
+
+
+@DocuShare{PSTN-035,
+   author = {Brian Stalder},
+    title = {Integration, Test and Commissioning Results from LSST Commissiong Camera},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-035},
+      url = {http://PSTN-035.lsst.io } }
+
+
+@DocuShare{PSTN-036,
+   author = {Kevin Reil},
+    title = {LSST Camera Instrumental Signature Characterization, Calibration and Removal},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-036},
+      url = {http://PSTN-036.lsst.io } }
+
+
+@DocuShare{PSTN-037,
+   author = {Patrick Hascal},
+    title = {Installation and Performance of the LSST Camera Refrigeration System},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-037},
+      url = {http://PSTN-037.lsst.io } }
+
+
+@DocuShare{PSTN-038,
+   author = {Andy Connolly},
+    title = {Science Validation of LSST Alert Processing},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-038},
+      url = {http://PSTN-038.lsst.io } }
+
+
+@DocuShare{PSTN-039,
+   author = {Keith Bechtol},
+    title = {Science Validation of LSST Data Release Processing},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-039},
+      url = {http://PSTN-039.lsst.io } }
+
+
+@DocuShare{PSTN-040,
+   author = {Michael Reuter},
+    title = {Tracking of LSST System Performance with Continuous Integration Methods},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-040},
+      url = {http://PSTN-040.lsst.io } }
+
+
+@DocuShare{PSTN-041,
+   author = {Chuck Claver},
+    title = {The LSST Science Platform as a Commissioning Tool},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-041},
+      url = {http://PSTN-041.lsst.io } }
+
+
+@DocuShare{PSTN-042,
+   author = {Chuck Claver},
+    title = {Commissioning Science Data Quality Analysis Tools, Methods and Procedures},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-042},
+      url = {http://PSTN-042.lsst.io } }
+
+
+@DocuShare{PSTN-043,
+   author = {Lynne Jones},
+    title = {Performance Verification of the LSST Survey Scheduler},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-043},
+      url = {http://PSTN-043.lsst.io } }
+
+@DocuShare{PSTN-046,
+   author = {Steve Ritz},
+    title = {LSST Camera Design and Delivered Performance},
+     year = 2020,
+    month = dec,
+   handle = {PSTN-046},
+      url = {http://PSTN-046.lsst.io } }
+
+
+@DocuShare{ITTN-006,
+   author = {Cristian Silva and Iain Goodenow and William O'Mullane},
+    title = {Rubin Observatory IT mangegement plan},
+     year = 2020,
+    month = may,
+   handle = {ITTN-006},
+      url = {http://ITTN-006.lsst.io } }
+
+@DocuShare{ITTN-002,
+   author = {Joshua Hoblitt},
+    title = {LSST On-Prem Deployment Platform},
+     year = 2019,
+    month = sep,
+   handle = {ITTN-002},
+      url = {http://ITTN-002.lsst.io } }
+
+@DocuShare{LSE-160,
+  author =       {Brian Selvy},
+  title =        "{Verification and Validation Process}",
+  year =         2013,
+  month =        sep,
+  handle =       {LSE-160},
+}
+
+@DocuShare{document-14789,
+  author =       {Jeff Kantor},
+  title =        "{LSST Long-Haul Networks (LHN) End-to-end Test Plan}",
+  year =         2014,
+  month =        sep,
+  handle =       {document-14789},
+}
+
+@DocuShare{RTN-001,
+   author = {William O'Mullane},
+    title = {Data Preview 0: Definition and planning.},
+     year = 2020,
+    month = Jun,
+   handle = {RTN-001},
+      url = {http://RTN-001.lsst.io } }
+
+
+@DocuShare{RTN-013,
+       author = { William O'Mullane and Richard Dubois },
+        title = {Near term workflow for pre-operations with PanDA},
+         year = 2020,
+        month = dec,
+       handle = {RTN-013},
+          url = {http://RTN-013.lsst.io } }

--- a/project_templates/technote_rst/{{cookiecutter.repo_name}}/lsstbib/refs.bib
+++ b/project_templates/technote_rst/{{cookiecutter.repo_name}}/lsstbib/refs.bib
@@ -1,5 +1,4 @@
-% General reference not found in ADS
-% Do not put books in this file
+% General reference not found in ADS % Do not put books in this file
 %
 
 @ARTICLE{1991.Spyak.OpticalEngineering,
@@ -1996,6 +1995,29 @@ adsnote = {Provided by the SAO/NASA Astrophysics Data System}
   url = {http://xrootd.org/presentations/xpaper3_cut_journal.pdf},
 }
 
+@ARTICLE{Thain:2005:Condor,
+  author = "Douglas Thain and Todd Tannenbaum and Miron Livny",
+  url = {https://research.cs.wisc.edu/htcondor/doc/condor-practice.pdf},
+  title = "Distributed computing in practice: the Condor experience.",
+  journal = "Concurrency - Practice and Experience",
+  volume = 17,
+  number = "2-4",
+  year = 2005,
+  pages = "323-356",
+}
+
+@ARTICLE{Deelman:2015:Pegasus,
+  author = {Ewa Deelman and Karan Vahi and Gideon Juve and Mats Rynge and Scott Callaghan and Philip J Maechling and Rajiv Mayani and Weiwei Chen and Ferreira da Silva, Rafael and Miron Livny and Kent Wenger},
+  url = {http://pegasus.isi.edu/publications/2014/2014-fgcs-deelman.pdf},
+  title = {Pegasus: a Workflow Management System for Science Automation},
+  journal = {Future Generation Computer Systems},
+  volume = 46,
+  pages = {17-35},
+  year = 2015,
+  note = {Funding Acknowledgements: NSF ACI SDCI 0722019, NSF ACI SI2-SSI 1148515 and NSF OCI-1053575},
+  doi = {10.1016/j.future.2014.10.008}
+}
+
 @INPROCEEDINGS{VanderPlas:6382200,
   author = {J. VanderPlas and A. J. Connolly and {\v Z}. {Ivezi{\'c}} and A. Gray},
   booktitle = {2012 Conference on Intelligent Data Understanding},
@@ -2122,3 +2144,132 @@ adsnote = {Provided by the SAO/NASA Astrophysics Data System}
   address = {New York, NY, USA},
   keywords = {benchmarks, mapreduce, parallel database},
 }
+
+@article{Hohenkerk1985,
+	abstract = {The bending of a light ray as it passes through the atmosphere is cal- culated by numerical evaluation of the refraction integral, expressed in a form that avoids numerical difficulties at a zenith angle of 90 ◦ . A polytropic model atmosphere is used, and the parameters of the model are varied in order to determine the effect on the computed refraction value. Good agreement is obtained with other evaluations of refraction for zenith angles up to 75 ◦ . Beyond that it becomes sen- sitive to the values of the parameters used, particularly the pressure, temperature, temperature lapse rate, and wavelength of the light ray. Good agreement is obtained with other evaluations provided the same parameter values are used.},
+	author = {Hohenkerk, C.Y. and Sinclair, A.T.},
+  journal = {NAO Technical Note},
+	volume = {63},
+	title = {The computation of angular atmospheric refraction at large zenith angles},
+	year = {1985},
+  url = {http://astro.ukho.gov.uk/data/tn/naotn63.pdf},
+}
+
+@article{soton271449,
+  volume = {27},
+  number = {6},
+  month = {June},
+  author = {Luc Moreau and Ben Clifford and Juliana Freire and Joe Futrelle and Yolanda Gil and Paul Groth and Natalia Kwasnikowska and Simon Miles and Paolo Missier and Jim Myers and Beth Plale and Yogesh Simmhan and Eric Stephan and Jan Van den Bussche},
+  title = {The Open Provenance Model core specification (v1.1)},
+  journal = {Future Generation Computer Systems},
+  pages = {743--756},
+  year = {2011},
+  keywords = {provenance, representation, inter-operability},
+  url = {https://eprints.soton.ac.uk/271449/},
+  abstract = {The Open Provenance Model is a model of provenance that is designed to meet the following requirements: (1) To allow provenance information to be exchanged between systems, by means of a compatibility layer based on a shared provenance model. (2) To allow developers to build and share tools that operate on such a provenance model. (3) To define provenance in a precise, technology-agnostic manner. (4) To support a digital representation of provenance for any 'thing', whether produced by computer systems or not. (5) To allow multiple levels of description to coexist. (6) To define a core set of rules that identify the valid inferences that can be made on provenance representation. This document contains the specification of the Open Provenance Model (v1.1) resulting from a community-effort to achieve inter-operability in the Provenance Challenge series.}
+}
+
+@article{JSSv059i10,
+   author = {Hadley Wickham},
+   title = {Tidy Data},
+   journal = {Journal of Statistical Software, Articles},
+   volume = {59},
+   number = {10},
+   year = {2014},
+   keywords = {},
+   abstract = {A huge amount of effort is spent cleaning data to get it ready for analysis, but there has been little research on how to make data cleaning as easy and effective as possible. This paper tackles a small, but important, component of data cleaning: data tidying. Tidy datasets are easy to manipulate, model and visualize, and have a specific structure: each variable is a column, each observation is a row, and each type of observational unit is a table. This framework makes it easy to tidy messy datasets because only a small set of tools are needed to deal with a wide range of un-tidy datasets. This structure also makes it easier to develop tidy tools for data analysis, tools that both input and output tidy datasets. The advantages of a consistent data structure and matching tools are demonstrated with a case study free from mundane data manipulation chores.},
+   issn = {1548-7660},
+   pages = {1--23},
+   doi = {10.18637/jss.v059.i10},
+   url = {https://www.jstatsoft.org/v059/i10}
+}
+
+@article{doi:10.1002/2013JD020914,
+   author = {Ziemke, J. R. and Olsen, M. A. and Witte, J. C. and Douglass, A. R. and Strahan, S. E. and Wargan, K. and Liu, X. and Schoeberl, M. R. and Yang, K. and Kaplan, T. B. and Pawson, S. and Duncan, B. N. and Newman, P. A. and Bhartia, P. K. and Heney, M. K.},
+   title = {Assessment and applications of NASA ozone data products derived from Aura OMI/MLS satellite measurements in context of the GMI chemical transport model},
+   journal = {Journal of Geophysical Research: Atmospheres},
+   volume = {119},
+   number = {9},
+   pages = {5671--5699},
+   keywords = {ozone},
+   doi = {10.1002/2013JD020914},
+   url = {https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1002/2013JD020914},
+   eprint = {https://agupubs.onlinelibrary.wiley.com/doi/pdf/10.1002/2013JD020914},
+   abstract = {AbstractMeasurements from the Ozone Monitoring Instrument (OMI) and Microwave Limb Sounder (MLS), both on board the Aura spacecraft, have been used to produce daily global maps of column and profile ozone since August 2004. Here we compare and evaluate three strategies to obtain daily maps of tropospheric and stratospheric ozone from OMI and MLS measurements: trajectory mapping, direct profile retrieval, and data assimilation. Evaluation is based on an assessment that includes validation using ozonesondes and comparisons with the Global Modeling Initiative (GMI) chemical transport model. We investigate applications of the three ozone data products from near-decadal and interannual time scales to day-to-day case studies. Interannual changes in zonal mean tropospheric ozone from all of the products in any latitude range are of the order 1–2 Dobson units while changes (increases) over the 8 year Aura record investigated vary by 2–4 Dobson units. It is demonstrated that all of the ozone products can measure and monitor exceptional tropospheric ozone events including major forest fire and pollution transport events. Stratospheric ozone during the Aura record has several anomalous interannual events including split stratospheric warmings in the Northern Hemisphere extratropics that are well captured using the data assimilation ozone profile product. Data assimilation with continuous daily global coverage and vertical ozone profile information is the best of the three strategies at generating a global tropospheric and stratospheric ozone product for science applications.}
+}
+
+@article{doi:10.1175/JCLI-D-16-0609.1,
+  author = {Randles, C. A. and da Silva, A. M. and Buchard, V. and Colarco, P. R. and Darmenov, A. and Govindaraju, R. and Smirnov, A. and Holben, B. and Ferrare, R. and Hair, J. and Shinozuka, Y. and Flynn, C. J.},
+   title = {The MERRA-2 Aerosol Reanalysis, 1980 Onward. Part I: System Description and Data Assimilation Evaluation},
+ journal = {Journal of Climate},
+  volume = {30},
+  number = {17},
+   pages = {6823--6850},
+    year = {2017},
+     doi = {10.1175/JCLI-D-16-0609.1},
+     URL = {https://doi.org/10.1175/JCLI-D-16-0609.1},
+  eprint = {https://doi.org/10.1175/JCLI-D-16-0609.1}
+}
+
+
+
+
+@INPROCEEDINGS{bbcp,
+    author = {Andrew Hanushevsky and Artem Trunov and Les Cottrell},
+    title = {Peer-to-Peer Computing for Secure High Performance Data Copying},
+    booktitle = {In Proc. of the 2001 Int. Conf. on Computing in High Energy and Nuclear Physics (CHEP 2001), Beijng},
+    year = {2001},
+    url  = {http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.132.2288&rep=rep1}
+}
+
+@article{abell2009lsst,
+  title={LSST Science Book, Version 2.0},
+  author={Abell, P.~A. and Allison, J. and Anderson, S.~F. and Andrew, J.~R. and Angel, J.~R.~P. and Armus, L. and Arnett, D. and Asztalos, S.~J. and Axelrod, T.~S. and Bailey, S and others},
+  archivePrefix = "arXiv",
+  eprint = {0912.0201},
+  year={2009}
+}
+
+@ARTICLE{nist800-60,
+  author =       {Kevin Stine and  Rich Kissel and William C. Barker and Jim Fahlsing and  Jessica Gulick},
+  title =        {Volume I: Guide for Mapping Types of Information and Information Systems to Security Categories },
+  journal =      {INFORMATION SECURITY},
+  publisher =    {National Institute of Standards and Technology Special Publications},
+  year =         {2008},
+  month =        {aug},
+  volume =       {31},
+  handle =       {NIST.800-60},
+  URL=           {https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-60v1r1.pdf}
+}
+
+@ARTICLE{osn,
+author = {N{\'u}\~{n}ez-Corrales, Santiago and Cragin, Melissa and White (Wonders), Alainna and Norman, Michael and Kickpatrick, Christine and Mchenry, Kenton and Ahalt, Stanley and Shanley, Lea and Goodhue, John and Simmel, Derek and Szalay, Alex},
+year = {2018},
+month = {11},
+pages = {},
+title = {Open Storage Network: national data storage cyberinfrastructure for the 21st},
+doi = {10.13140/RG.2.2.31543.78249}
+}
+
+@MISC{NIST.SP.800-171,
+publisher  = {National Institute of Standards and Technology },
+author = {RON ROSS and PATRICK VISCUSO and GARY GUISSANIE and KELLEY DEMPSEY and MARK RIDDLE},
+title = {Special Publication 800-171, Protecting Controlled Unclassified Information in Nonfederal Systems and Organizations},
+month  = {feb},
+year = {2020},
+handle = {NIST.SP.800-171},
+url = {https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171r2.pdf}
+
+}
+
+@MISC{FIPS200,
+publisher = {National Institute of Standards and Technology Federal Information Processing Standards},
+author = {Computer Security Division},
+title = {Publication 200, Minimum Security Requirements for Federal Information and Information Systems},
+month  = {mar},
+year = {2006},
+handle = {NIST.FIPS.200},
+url = {https://doi.org/10.6028/NIST.FIPS.200}
+}
+
+

--- a/project_templates/technote_rst/{{cookiecutter.repo_name}}/lsstbib/refs_ads.bib
+++ b/project_templates/technote_rst/{{cookiecutter.repo_name}}/lsstbib/refs_ads.bib
@@ -14,6 +14,19 @@
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+@ARTICLE{1967ApOpt...6...51O,
+   author = {{Owens}, J.~C.},
+    title = "{Optical refractive index of air: dependence on pressure, temperature, and composition}",
+  journal = {\ao},
+     year = 1967,
+    month = jan,
+   volume = 6,
+    pages = {51},
+      doi = {10.1364/AO.6.000051},
+   adsurl = {http://adsabs.harvard.edu/abs/1967ApOpt...6...51O},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
 @INPROCEEDINGS{1978moas.coll..197L,
   author =       {{Lindegren}, L.},
   title =        "{Photoelectric astrometry - A comparison of methods
@@ -42,6 +55,20 @@
                   {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1982A\%26A...114..278B&db_key=AST},
   adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
                   System}
+}
+
+@ARTICLE{1982PASP...94..715F,
+   author = {{Filippenko}, A.~V.},
+    title = "{The importance of atmospheric differential refraction in spectrophotometry}",
+  journal = {\pasp},
+ keywords = {Atmospheric Refraction, Instrument Errors, Spectrophotometry, Telescopes, Ambient Temperature, Atmospheric Pressure, Error Analysis, Optimization, Pressure Effects, Temperature Effects},
+     year = 1982,
+    month = aug,
+   volume = 94,
+    pages = {715-721},
+      doi = {10.1086/131052},
+   adsurl = {http://adsabs.harvard.edu/abs/1982PASP...94..715F},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @ARTICLE{1983A&A...120..197S,
@@ -178,6 +205,20 @@
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+@ARTICLE{1991PASP..103.1033K,
+   author = {{Krisciunas}, K. and {Schaefer}, B.~E.},
+    title = "{A model of the brightness of moonlight}",
+  journal = {\pasp},
+ keywords = {Astronomical Models, Atmospheric Scattering, Lunar Luminescence, Sky Brightness, Charge Coupled Devices, Reflected Waves, Scattering Functions},
+     year = 1991,
+    month = sep,
+   volume = 103,
+    pages = {1033-1039},
+      doi = {10.1086/132921},
+   adsurl = {http://adsabs.harvard.edu/abs/1991PASP..103.1033K},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
 @ARTICLE{1994A&A...287..338N,
   author =       {{Nordstroem}, B. and {Latham}, D.~W. and {Morse},
                   J.~A. and ƒ {Milone}, A.~A.~E. and {Kurucz},
@@ -255,9 +296,6 @@
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-
-% Rickman:2001
-
 @ARTICLE{1995A&A...304...61L,
   author =       {{Lindegren}, L.},
   title =        "{Estimating the external accuracy of HIPPARCOS
@@ -273,8 +311,6 @@
                   {http://cdsads.u-strasbg.fr/abs/1995A\%26A...304...61L},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
-
-% Soffel:et:al:2003
 
 @INPROCEEDINGS{1995ASPC...77..429R,
   author =       {{Rose}, J. and {Akella}, R. and {Binegar}, S. and
@@ -296,8 +332,6 @@
                   System}
 }
 
-% Klioner:Soffel:2000
-
 @ARTICLE{1996A&A...305..146G,
   author =       {{Gunn}, A.~G. and {Hall}, J.~C. and {Lockwood},
                   G.~W. and {Doyle}, J.~G.  },
@@ -315,6 +349,21 @@
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+@ARTICLE{1996AJ....112.2872T,
+   author = {{Tomaney}, A.~B. and {Crotts}, A.~P.~S.},
+    title = "{Expanding the Realm of Microlensing Surveys with Difference Image Photometry}",
+  journal = {\aj},
+   eprint = {astro-ph/9610066},
+ keywords = {GRAVITATIONAL LENSING, SURVEYS},
+     year = 1996,
+    month = dec,
+   volume = 112,
+    pages = {2872},
+      doi = {10.1086/118228},
+   adsurl = {http://adsabs.harvard.edu/abs/1996AJ....112.2872T},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
 @ARTICLE{1996PASP..108..851S,
    author = {{Stetson}, P.~B.},
     title = "{On the Automatic Determination of Light-Curve Parameters for Cepheid Variables}",
@@ -326,6 +375,20 @@
     pages = {851},
       doi = {10.1086/133808},
    adsurl = {http://adsabs.harvard.edu/abs/1996PASP..108..851S},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{1996PASP..108.1051S,
+   author = {{Stone}, R.~C.},
+    title = "{An Accurate Method for Computing Atmospheric Refraction}",
+  journal = {\pasp},
+ keywords = {ATMOSPHERIC EFFECTS, METHODS: NUMERICAL},
+     year = 1996,
+    month = nov,
+   volume = 108,
+    pages = {1051-1058},
+      doi = {10.1086/133831},
+   adsurl = {http://adsabs.harvard.edu/abs/1996PASP..108.1051S},
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
@@ -344,8 +407,6 @@
                   System}
 }
 
-% Klioner:2004
-
 @ARTICLE{1997A&A...327.1253M,
   author =       {{Moreno}, F. and {Molina}, A. and {Ortiz}, J.~L.},
   title =        "{The 1993 south equatorial belt revival and other
@@ -360,8 +421,6 @@
   adsurl =       {http://adsabs.harvard.edu/abs/1997A\%26A...327.1253M},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
-
-% Klioner:2003
 
 @INPROCEEDINGS{1997ESASP.402..767D,
   author =       {{de Felice}, F. and {Lattanzi}, M.~G. and
@@ -381,9 +440,6 @@
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-
-% Klioner:Peip:2003
-
 @PROCEEDINGS{1997ESASP1200.....P,
   title =        "{The HIPPARCOS and TYCHO catalogues. Astrometric and
                   photometric star catalogues derived from the ESA
@@ -399,9 +455,6 @@
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-
-% deFelice:2004
-
 @ARTICLE{1997SSRv...81..201V,
   author =       {{van Leeuwen}, F.},
   title =        "{The HIPPARCOS Mission}",
@@ -416,9 +469,6 @@
                   System}
 }
 
-
-% defelice1
-
 @INPROCEEDINGS{1997hipp.conf..467E,
   author =       {{Eyer}, L. and {Grenon}, M.},
   title =        "{Photometric {V}ariability in the {HR} {D}iagram}",
@@ -430,8 +480,6 @@
   adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
                   System}
 }
-
-% vecchia2
 
 @INPROCEEDINGS{1997hipp.conf..621G,
   author =       {{Gomez}, A.~E. and {Grenier}, S. and {Udry}, S. and
@@ -447,8 +495,6 @@
   adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
                   System}
 }
-
-% bini1
 
 @ARTICLE{1998A&A...332.1133D,
   author =       {{de Felice}, F. and {Lattanzi}, M.~G. and
@@ -466,8 +512,6 @@
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-% defelice2
-
 @ARTICLE{1998A&A...340..309M,
   author =       {{Makarov}, V.~V.},
   title =        "{Absolute measurements of trigonometric parallaxes
@@ -482,8 +526,6 @@
                   System}
 }
 
-% Lattanzi-2005:a
-
 @ARTICLE{1998A&AS..130...65L,
   author =       {{Lejeune}, T. and {Cuisinier}, F. and {Buser}, R.},
   title =        "{A standard stellar library for evolutionary
@@ -496,6 +538,20 @@
   pages =        {65-75},
   adsurl =
                   {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1998A\%26AS..130...65L&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+@ARTICLE{1998ARA&A..36...99K,
+  author =       {{Kovalevsky}, J.},
+  title =        "{First Results from HIPPARCOS}",
+  journal =      {\araa},
+  year =         1998,
+  volume =       36,
+  pages =        {99-130},
+  doi =          {10.1146/annurev.astro.36.1.99},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1998ARA\%26A..36...99K&db_key=AST},
   adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
                   System}
 }
@@ -515,22 +571,6 @@
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-@ARTICLE{1998ARA&A..36...99K,
-  author =       {{Kovalevsky}, J.},
-  title =        "{First Results from HIPPARCOS}",
-  journal =      {\araa},
-  year =         1998,
-  volume =       36,
-  pages =        {99-130},
-  doi =          {10.1146/annurev.astro.36.1.99},
-  adsurl =
-                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1998ARA\%26A..36...99K&db_key=AST},
-  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
-                  System}
-}
-
-% Sozzetti-2001:a
-
 @ARTICLE{1998MNRAS.298..387D,
   author =       {{Dehnen}, W. and {Binney}, J.~J.},
   title =        "{Local stellar kinematics from HIPPARCOS data}",
@@ -548,8 +588,6 @@
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-% paper:gaiascience
-
 @ARTICLE{1998PASP..110..863P,
   author =       {{Pickles}, A.~J.},
   title =        "{A Stellar Spectral Flux Library: 1150-25000 {\AA}}",
@@ -564,7 +602,20 @@
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-% Lattanzi-2000:a
+@INPROCEEDINGS{1998SPIE.3355...36C,
+   author = {{Cuby}, J.~G. and {Bottini}, D. and {Picat}, J.~P.},
+    title = "{Handling atmospheric dispersion and differential refraction effects in large-field multiobject spectroscopic observations}",
+booktitle = {Optical Astronomical Instrumentation},
+     year = 1998,
+   series = {\procspie},
+   volume = 3355,
+   editor = {{D'Odorico}, S.},
+    month = jul,
+    pages = {36-47},
+      doi = {10.1117/12.316769},
+   adsurl = {http://adsabs.harvard.edu/abs/1998SPIE.3355...36C},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
 
 @ARTICLE{1999A&AS..137..521M,
   author =       {{Munari}, U. and {Tomasella}, L.},
@@ -582,7 +633,25 @@
                   System}
 }
 
-% kov1
+@ARTICLE{1999ApJ...521..602A,
+   author = {{Alcock}, C. and {Allsman}, R.~A. and {Alves}, D. and {Axelrod}, T.~S. and
+	{Becker}, A.~C. and {Bennett}, D.~P. and {Cook}, K.~H. and {Drake}, A.~J. and
+	{Freeman}, K.~C. and {Griest}, K. and {Lehner}, M.~J. and {Marshall}, S.~L. and
+	{Minniti}, D. and {Peterson}, B.~A. and {Pratt}, M.~R. and {Quinn}, P.~J. and
+	{Stubbs}, C.~W. and {Sutherland}, W. and {Tomaney}, A. and {Vandehei}, T. and
+	{Welch}, D.~L. and {MACHO Collaboration}},
+    title = "{Difference Image Analysis of Galactic Microlensing. I. Data Analysis}",
+  journal = {\apj},
+   eprint = {astro-ph/9903215},
+ keywords = {ATMOSPHERIC EFFECTS, GALAXY: STELLAR CONTENT, COSMOLOGY: GRAVITATIONAL LENSING, TECHNIQUES: IMAGE PROCESSING, Atmospheric Effects, Galaxy: Stellar Content, Cosmology: Gravitational Lensing, Techniques: Image Processing},
+     year = 1999,
+    month = aug,
+   volume = 521,
+    pages = {602-612},
+      doi = {10.1086/307567},
+   adsurl = {http://adsabs.harvard.edu/abs/1999ApJ...521..602A},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
 
 @ARTICLE{1999BaltA...8...57O,
   author =       {{O'Mullane}, W. and {Lindegren}, L.},
@@ -597,7 +666,6 @@
                   System}
 }
 
-% Pourbaix-2002:b
 
 @ARTICLE{1999MNRAS.310..645W,
   author =       {{Wilkinson}, M.~I. and {Evans}, N.~W.},
@@ -614,9 +682,6 @@
                   System}
 }
 
-
-% Smolcic-2004:a
-
 @ARTICLE{2000A&A...354..522M,
   author =       {{Mignard}, F.},
   title =        "{Local galactic kinematics from Hipparcos proper
@@ -632,8 +697,6 @@
   adsurl =       {http://adsabs.harvard.edu/abs/2000A\%26A...354..522M},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
-
-% Bretagnon1988
 
 @ARTICLE{2000A&A...355L..27H,
   author =       {{H{\o}g}, E. and {Fabricius}, C. and {Makarov},
@@ -652,7 +715,6 @@
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-% Bretagnon1982
 
 @ARTICLE{2000A&AS..143...33B,
   author =       {{Bonnarel}, F. and {Fernique}, P. and
@@ -674,7 +736,20 @@
 }
 
 
-% Simon1983
+@ARTICLE{2000AJ....119.2472A,
+   author = {{Auer}, L.~H. and {Standish}, E.~M.},
+    title = "{Astronomical Refraction: Computational Method for All Zenith Angles}",
+  journal = {\aj},
+ keywords = {METHODS: NUMERICAL},
+     year = 2000,
+    month = may,
+   volume = 119,
+    pages = {2472-2474},
+      doi = {10.1086/301325},
+   adsurl = {http://adsabs.harvard.edu/abs/2000AJ....119.2472A},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
 
 @INPROCEEDINGS{2000ASPC..203...71E,
   author =       {{Eyer}, L. and {Cuypers}, J.},
@@ -692,7 +767,6 @@
                   System}
 }
 
-% astro:besanconmodel
 
 @INPROCEEDINGS{2000ASPC..216..419O,
   author =       {{O'Mullane}, W. and {Hazell}, A. and {Bennett},
@@ -709,7 +783,6 @@
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-% astro:extinctionmodel
 
 @INPROCEEDINGS{2000ASSL..252..201G,
   author =       {{Groom}, D.~E. and {Eberhard}, P.~H. and {Holland},
@@ -727,6 +800,7 @@
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+
 @ARTICLE{2000ApJ...536..571B,
    author = {{Ben{\'{\i}}tez}, N.},
     title = "{Bayesian Photometric Redshift Estimation}",
@@ -741,6 +815,7 @@
    adsurl = {http://adsabs.harvard.edu/abs/2000ApJ...536..571B},
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
+
 
 @ARTICLE{2000MNRAS.317..211L,
   author =       {{Lattanzi}, M.~G. and {Spagna}, A. and {Sozzetti},
@@ -759,7 +834,6 @@
                   System}
 }
 
-% gomez1997
 
 @ARTICLE{2000MNRAS.319..657H,
   author =       {{Helmi}, A. and {de Zeeuw}, P.~T.},
@@ -777,7 +851,7 @@
                   System}
 }
 
-% cu6:skew_technique
+
 
 @ARTICLE{2000PhRvD..62b4019K,
   author =       {{Klioner}, S.~A. and {Soffel}, M.~H.},
@@ -795,8 +869,6 @@
   adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
                   System}
 }
-
-% koval98
 
 @INPROCEEDINGS{2000SPIE.4013..453G,
   author =       {{Gilmore}, G.~F. and {de Boer}, K.~S. and {Favata},
@@ -819,8 +891,6 @@
                   System}
 }
 
-% paper:hipquality
-
 @ARTICLE{2001A&A...369..339P,
   author =       {{Perryman}, M.~A.~C. and {de Boer}, K.~S. and
                   {Gilmore}, G. and {H{\o}g}, E. and {Lattanzi},
@@ -841,8 +911,6 @@
                   System}
 }
 
-% paper:hipreproc
-
 @ARTICLE{2001A&A...373..336D,
   author =       {{de Felice}, F. and {Bucciarelli}, B. and
                   {Lattanzi}, M.~G. and {Vecchiato}, A.},
@@ -860,8 +928,6 @@
   adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
                   System}
 }
-
-% fvl97
 
 @ARTICLE{2001A&A...373L..21S,
   author =       {{Sozzetti}, A. and {Casertano}, S. and {Lattanzi},
@@ -881,7 +947,6 @@
                   System}
 }
 
-% paper:RBBdL06
 
 @INPROCEEDINGS{2001ASPC..225..201O,
   author =       {{O'Mullane}, W. and {Luri}, X.},
@@ -898,7 +963,6 @@
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-% helmi2000
 
 @ARTICLE{2001ApJ...556..181D,
   author =       {{Drimmel}, R. and {Spergel}, D.~N.},
@@ -917,8 +981,6 @@
                   System}
 }
 
-
-% pickles1998
 
 @ARTICLE{2001IAUTr..24B....R,
   author =       {{Rickman}, H.},
@@ -966,6 +1028,7 @@ keywords =       {Instrumentation: Detectors,
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+
 @INPROCEEDINGS{2001misk.conf..631K,
    author = {{Kunszt}, P.~Z. and {Szalay}, A.~S. and {Thakar}, A.~R.},
     title = "{The Hierarchical Triangular Mesh}",
@@ -991,7 +1054,6 @@ booktitle = {Mining the Sky},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-% wilkinson1999
 
 @ARTICLE{2002A&A...385..686P,
   author =       {{Pourbaix}, D.},
@@ -1011,7 +1073,22 @@ booktitle = {Mining the Sky},
                   System}
 }
 
-% wilkinson2004a
+
+@ARTICLE{2002AJ....123..583B,
+   author = {{Bernstein}, G.~M. and {Jarvis}, M.},
+    title = "{Shapes and Shears, Stars and Smears: Optimal Measurements for Weak Lensing}",
+  journal = {\aj},
+   eprint = {astro-ph/0107431},
+ keywords = {Cosmology: Gravitational Lensing, Methods: Data Analysis, Techniques: Image Processing},
+     year = 2002,
+    month = feb,
+   volume = 123,
+    pages = {583-618},
+      doi = {10.1086/338085},
+   adsurl = {http://adsabs.harvard.edu/abs/2002AJ....123..583B},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
 
 @INPROCEEDINGS{2002ASPC..259..160E,
   author =       {{Eyer}, L. and {Blake}, C.},
@@ -1029,7 +1106,6 @@ booktitle = {Mining the Sky},
                   System}
 }
 
-% wilkinson2004b
 
 @ARTICLE{2002AcA....52..241E,
   author =       {{Eyer}, L.},
@@ -1046,20 +1122,6 @@ booktitle = {Mining the Sky},
                   System}
 }
 
-@ARTICLE{2002AJ....123..583B,
-   author = {{Bernstein}, G.~M. and {Jarvis}, M.},
-    title = "{Shapes and Shears, Stars and Smears: Optimal Measurements for Weak Lensing}",
-  journal = {\aj},
-   eprint = {astro-ph/0107431},
- keywords = {Cosmology: Gravitational Lensing, Methods: Data Analysis, Techniques: Image Processing},
-     year = 2002,
-    month = feb,
-   volume = 123,
-    pages = {583-618},
-      doi = {10.1086/338085},
-   adsurl = {http://adsabs.harvard.edu/abs/2002AJ....123..583B},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
 
 @ARTICLE{2002Ap&SS.280...21B,
   author =       {{Bailer-Jones}, C.~A.~L.},
@@ -1075,7 +1137,6 @@ booktitle = {Mining the Sky},
                   System}
 }
 
-% paper:tdi
 
 @INPROCEEDINGS{2002EAS.....2..107M,
   author =       {{Mignard}, F.},
@@ -1090,6 +1151,7 @@ booktitle = {Mining the Sky},
   adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
                   System}
 }
+
 
 @ARTICLE{2002Icar..158..106B,
   author =       {{Bus}, S.~J. and {Binzel}, R.~P.},
@@ -1107,7 +1169,6 @@ booktitle = {Mining the Sky},
                   System}
 }
 
-% defelice3
 
 @ARTICLE{2002Icar..158..146B,
   author =       {{Bus}, S.~J. and {Binzel}, R.~P.},
@@ -1125,7 +1186,6 @@ booktitle = {Mining the Sky},
                   System}
 }
 
-% busonero1
 
 @INPROCEEDINGS{2002SPIE.4836..333S,
   author =       {{Szalay}, A.~S. and {Gray}, J. and {VandenBerg}, J.},
@@ -1145,7 +1205,6 @@ booktitle = {Mining the Sky},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-% gai2
 
 @ARTICLE{2002cs........2013S,
   author =       {{Szalay}, A.~S. and {Gray}, J. and {Thakar},
@@ -1165,7 +1224,6 @@ booktitle = {Mining the Sky},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-% paper:jfc06QSO
 
 @ARTICLE{2003A&A...399..337V,
   author =       {{Vecchiato}, A. and {Lattanzi}, M.~G. and
@@ -1186,7 +1244,6 @@ booktitle = {Mining the Sky},
                   System}
 }
 
-% paper:gtr04QSO
 
 @ARTICLE{2003A&A...409..523R,
   author =       {{Robin}, A.~C. and {Reyl{\'e}}, C. and
@@ -1206,7 +1263,6 @@ booktitle = {Mining the Sky},
                   System}
 }
 
-% paper:le02QSO
 
 @ARTICLE{2003A&A...410.1063K,
   author =       {{Klioner}, S.~A. and {Peip}, M.},
@@ -1225,7 +1281,6 @@ booktitle = {Mining the Sky},
                   System}
 }
 
-% munari1999
 
 @ARTICLE{2003A&A...412..105M,
   author =       {{Moniez}, M.},
@@ -1244,7 +1299,6 @@ booktitle = {Mining the Sky},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-% paper:sozzrev
 
 @ARTICLE{2003AJ....125.1580K,
   author =       {{Klioner}, S.~A.},
@@ -1261,7 +1315,6 @@ booktitle = {Mining the Sky},
                   System}
 }
 
-% paper:c1bc1m
 
 @ARTICLE{2003AJ....126.2687S,
   author =       {{Soffel}, M. and {Klioner}, S.~A. and {Petit},
@@ -1290,7 +1343,6 @@ booktitle = {Mining the Sky},
                   System}
 }
 
-% brettetal2004
 
 @INPROCEEDINGS{2003ASPC..295..261M,
   author =       {{Miller}, III, W.~W. and {Sontag}, C. and {Rose},
@@ -1310,7 +1362,7 @@ booktitle = {Mining the Sky},
                   System}
 }
 
-% evansbelokurov2005
+
 
 @INPROCEEDINGS{2003ASPC..298..199B,
   author =       {{Bailer-Jones}, C.~A.~L.},
@@ -1328,7 +1380,6 @@ booktitle = {Mining the Sky},
                   System}
 }
 
-% eyergrenon1997
 
 @ARTICLE{2003CQGra..20.4695B,
   author =       {{Bini}, D. and {Crosta}, M.~T. and {de Felice}, F.},
@@ -1346,7 +1397,6 @@ booktitle = {Mining the Sky},
                   System}
 }
 
-% eyercuypers2000
 
 @ARTICLE{2003MNRAS.342..151V,
   author =       {{Vande Putte}, D. and {Smith}, R.~C. and {Hawkins},
@@ -1366,7 +1416,6 @@ booktitle = {Mining the Sky},
                   System}
 }
 
-% eyerblake2002
 
 @ARTICLE{2004A&A...419..385B,
   author =       {{Bailer-Jones}, C.~A.~L.},
@@ -1385,7 +1434,6 @@ booktitle = {Mining the Sky},
                   System}
 }
 
-% eyer2005
 
 @INPROCEEDINGS{2004ASPC..314..293Y,
   author =       {{Yasuda}, N. and {Mizumoto}, Y. and {Ohishi}, M. and
@@ -1408,7 +1456,6 @@ booktitle = {Mining the Sky},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-% eyerblake2005
 
 @INPROCEEDINGS{2004ASPC..314..376W,
   author =       {{Wieprecht}, E. and {Brumfit}, J. and {Bakker},
@@ -1433,7 +1480,6 @@ booktitle = {Mining the Sky},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-% eyermignard2005
 
 @INPROCEEDINGS{2004ASPC..314..585P,
   author =       {{Plante}, R. and {Greene}, G. and {Hanisch}, R. and
@@ -1454,8 +1500,6 @@ booktitle = {Mining the Sky},
 }
 
 
-% eyer2006a
-
 @ARTICLE{2004ApJ...607..580D,
   author =       {{de Felice}, F. and {Crosta}, M.~T. and {Vecchiato},
                   A. and {Lattanzi}, M.~G. and {Bucciarelli}, B.},
@@ -1475,7 +1519,6 @@ booktitle = {Mining the Sky},
                   System}
 }
 
-% eyer2006b
 
 @ARTICLE{2004ApJ...615L.141S,
   author =       {{Smol{\v c}i{\'c}}, V. and {Ivezi{\'c}}, {\v Z}. and
@@ -1500,7 +1543,6 @@ booktitle = {Mining the Sky},
                   System}
 }
 
-% protopapasetal2006
 
 @ARTICLE{2004ApJS..155..257R,
   author =       {{Richards}, G.~T. and {Nichol}, R.~C. and {Gray},
@@ -1527,7 +1569,6 @@ booktitle = {Mining the Sky},
                   System}
 }
 
-% moniez2003
 
 @ARTICLE{2004MNRAS.353..369B,
   author =       {{Brett}, D.~R. and {West}, R.~G. and {Wheatley},
@@ -1547,7 +1588,6 @@ booktitle = {Mining the Sky},
                   System}
 }
 
-% cu8:cbjparis
 
 @ARTICLE{2004PhR...400..209K,
   author =       {{Kopeikin}, S. and {Vlasov}, I.},
@@ -1567,7 +1607,6 @@ booktitle = {Mining the Sky},
                   System}
 }
 
-% cu8:cbjhfd
 
 @ARTICLE{2004PhRvD..69l4001K,
   author =       {{Klioner}, S.~A.},
@@ -1588,20 +1627,18 @@ booktitle = {Mining the Sky},
                   System}
 }
 
-% cu8:cbjvilnius
+%conf:gaiaeurospaceproject
 
 @INPROCEEDINGS{2004SPIE.5494..529B,
   author =       {{Baccaro}, S. and {Cecilia}, A. and {Di Sarcina},
                   I. and {Piegari}, A.~M.  },
   title =        "{Optical coating behavior under y irradiation for
                   space applications}",
-  booktitle =    {Society of Photo-Optical Instrumentation Engineers
-                  (SPIE) Conference Series},
+  booktitle =    {Optical Fabrication, Metrology, and Material Advancements for Telescopes},
   year =         2004,
-  series =       {Presented at the Society of Photo-Optical
-                  Instrumentation Engineers (SPIE) Conference},
+  series =       {\procspie},
   volume =       5494,
-  editor =       "{E.~Atad-Ettedgui \& P.~Dierickx}",
+  editor =       "{E.~Atad-Ettedgui and P.~Dierickx}",
   month =        sep,
   pages =        {529-535},
   doi =          {10.1117/12.553602},
@@ -1609,7 +1646,6 @@ booktitle = {Mining the Sky},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-% cu8:baselmethod
 
 @INPROCEEDINGS{2004SPIE.5495...23J,
   author =       {{Jessen}, N.~C. and {N{\o}rgaard-Nielsen}, H.~U. and
@@ -1617,13 +1653,11 @@ booktitle = {Mining the Sky},
                   J. and {Hastings}, P.},
   title =        "{The CFRP primary structure of the MIRI instrument
                   onboard the James Webb Space Telescope}",
-  booktitle =    {Society of Photo-Optical Instrumentation Engineers
-                  (SPIE) Conference Series},
+  booktitle =    {Astronomical Structures and Mechanisms Technology},
   year =         2004,
-  series =       {Presented at the Society of Photo-Optical
-                  Instrumentation Engineers (SPIE) Conference},
+  series =       {\procspie},
   volume =       5495,
-  editor =       "{J.~Antebi \& D.~Lemke}",
+  editor =       "{J.~Antebi and D.~Lemke}",
   month =        sep,
   pages =        {23-30},
   doi =          {10.1117/12.550023},
@@ -1631,7 +1665,6 @@ booktitle = {Mining the Sky},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-% mpclass:bus2002b
 
 @INPROCEEDINGS{2004SPIE.5497..461G,
   author =       {{Gardiol}, D. and {Loreggia}, D. and {Mannu}, S. and
@@ -1639,10 +1672,8 @@ booktitle = {Mining the Sky},
                   {Lattanzi}, M.~G.},
   title =        "{End-to-end optomechanical simulation for
                   high-precision global astrometry}",
-  booktitle =    {Modeling and Systems Engineering for Astronomy.
-                  Edited by Craig, Simon C.; Cullum, Martin J.
-                  Proceedings of the SPIE, Volume 5497, pp. 461-470
-                  (2004).},
+  booktitle =    {Modeling and Systems Engineering for Astronomy},
+  series =       {\procspie},
   year =         2004,
   editor =       {{Craig}, S.~C. and {Cullum}, M.~J.},
   month =        sep,
@@ -1654,7 +1685,20 @@ booktitle = {Mining the Sky},
                   System}
 }
 
-% mpclass:bus2002a
+@INPROCEEDINGS{2004SPIE.5497..290B,
+   author = {{Britton}, M.~C.},
+    title = "{Arroyo}",
+booktitle = {Modeling and Systems Engineering for Astronomy},
+     year = 2004,
+   series = {\procspie},
+   volume = 5497,
+   editor = {{Craig}, S.~C. and {Cullum}, M.~J.},
+    month = sep,
+    pages = {290-300},
+      doi = {10.1117/12.552316},
+   adsurl = {http://adsabs.harvard.edu/abs/2004SPIE.5497..290B},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
 
 @ARTICLE{2005A&A...438..745B,
   author =       {{Bastian}, U. and {Biermann}, M.},
@@ -1672,8 +1716,6 @@ booktitle = {Mining the Sky},
                   System}
 }
 
-% mpclass:Zellner
-
 @ARTICLE{2005A&A...439..791V,
   author =       {{van Leeuwen}, F. and {Fantino}, E.},
   title =        "{A new reduction of the raw Hipparcos data}",
@@ -1689,8 +1731,6 @@ booktitle = {Mining the Sky},
   adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
                   System}
 }
-
-% cu3:Bruen
 
 @ARTICLE{2005A&A...439..805V,
   author =       {{van Leeuwen}, F.},
@@ -1709,7 +1749,19 @@ booktitle = {Mining the Sky},
                   System}
 }
 
-% conf:gaiascience
+@INPROCEEDINGS{2005ASPC..338..134C,
+   author = {{Chambers}, K.~C.},
+    title = "{Astrometry with Pan-STARRS and PS1: Pushing the limits of atmospheric refraction, dispersion, and extinction corrections for wide field imaging.}",
+booktitle = {Astrometry in the Age of the Next Generation of Large Telescopes},
+     year = 2005,
+   series = {Astronomical Society of the Pacific Conference Series},
+   volume = 338,
+   editor = {{Seidelmann}, P.~K. and {Monet}, A.~K.~B.},
+    month = oct,
+    pages = {134},
+   adsurl = {http://adsabs.harvard.edu/abs/2005ASPC..338..134C},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
 
 @ARTICLE{2005ApJ...622..759G,
   author =       {{G{\'o}rski}, K.~M. and {Hivon}, E. and {Banday},
@@ -1729,8 +1781,6 @@ booktitle = {Mining the Sky},
   doi =          {10.1086/427976}
 }
 
-%conf:gaiaeurospaceproject
-
 @PROCEEDINGS{2005ESASP.576.....T,
   title =        "{The Three-Dimensional Universe with Gaia}",
   booktitle =    {The Three-Dimensional Universe with Gaia},
@@ -1743,8 +1793,6 @@ booktitle = {Mining the Sky},
   adsurl =       {http://adsabs.harvard.edu/abs/2005ESASP.576.....T},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
-
-% conf:inpopephem
 
 @INPROCEEDINGS{2005ESASP.576...29L,
   author =       {{Lindegren}, L.},
@@ -1760,8 +1808,6 @@ booktitle = {Mining the Sky},
   adsurl =       {http://adsabs.harvard.edu/abs/2005ESASP.576...29L},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
-
-% cu5:photometry-paris
 
 @INPROCEEDINGS{2005ESASP.576...67D,
   author =       {{de Bruijne}, J.~H.~J. and {Lammers}, U. and
@@ -2415,6 +2461,21 @@ booktitle = {Mining the Sky},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+@ARTICLE{2006astro.ph..9591A,
+   author = {{Albrecht}, A. and {Bernstein}, G. and {Cahn}, R. and {Freedman}, W.~L. and
+        {Hewitt}, J. and {Hu}, W. and {Huth}, J. and {Kamionkowski}, M. and
+        {Kolb}, E.~W. and {Knox}, L. and {Mather}, J.~C. and {Staggs}, S. and
+        {Suntzeff}, N.~B.},
+    title = "{Report of the Dark Energy Task Force}",
+  journal = {ArXiv Astrophysics e-prints},
+   eprint = {astro-ph/0609591},
+ keywords = {Astrophysics},
+     year = 2006,
+    month = sep,
+   adsurl = {http://adsabs.harvard.edu/abs/2006astro.ph..9591A},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
 @ARTICLE{2006astro.ph.11885O,
   author =       {{O'Mullane}, W. and {Lammers}, U. and
                   {Bailer-Jones}, C. and {Bastian}, U. and {Brown},
@@ -2627,36 +2688,6 @@ archivePrefix = "arXiv",
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-@ARTICLE{2008ApJ...679..301B,
-   author = {{Budav{\'a}ri}, T. and {Szalay}, A.~S.},
-    title = "{Probabilistic Cross-Identification of Astronomical Sources}",
-  journal = {\apj},
-archivePrefix = "arXiv",
-   eprint = {0707.1611},
- keywords = {astrometry, catalogs, galaxies: statistics, methods: statistical },
-     year = 2008,
-    month = may,
-   volume = 679,
-      eid = {301-309},
-    pages = {301-309},
-      doi = {10.1086/587156},
-   adsurl = {http://adsabs.harvard.edu/abs/2008ApJ...679..301B},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2008arXiv0805.2366I,
-   author = {{Ivezic}, Z. and others},
-    title = "{LSST: from Science Drivers to Reference Design and Anticipated Data Products}",
-  journal = {ArXiv e-prints},
-archivePrefix = "arXiv",
-   eprint = {0805.2366},
- keywords = {Astrophysics},
-     year = 2008,
-    month = may,
-   adsurl = {http://adsabs.harvard.edu/abs/2008arXiv0805.2366I},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
 @INPROCEEDINGS{2008AIPC.1082..331H,
   author =       {{Hogg}, D.~W. and {Lang}, D.},
   title =        "{Astronomical imaging: The theory of everything}",
@@ -2732,6 +2763,23 @@ archivePrefix = "arXiv",
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+@ARTICLE{2008ApJ...679..301B,
+   author = {{Budav{\'a}ri}, T. and {Szalay}, A.~S.},
+    title = "{Probabilistic Cross-Identification of Astronomical Sources}",
+  journal = {\apj},
+archivePrefix = "arXiv",
+   eprint = {0707.1611},
+ keywords = {astrometry, catalogs, galaxies: statistics, methods: statistical },
+     year = 2008,
+    month = may,
+   volume = 679,
+      eid = {301-309},
+    pages = {301-309},
+      doi = {10.1086/587156},
+   adsurl = {http://adsabs.harvard.edu/abs/2008ApJ...679..301B},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
 @ARTICLE{2008CSE....10....9T,
   author =       {{Thakar}, A.~R.},
   title =        "{The Sloan Digital Sky Survey: Drinking from the
@@ -2797,6 +2845,272 @@ archivePrefix = "arXiv",
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+@ARTICLE{2008arXiv0805.2366I,
+       author = {{Ivezi{\'c}}, {\v{Z}}eljko and {Kahn}, Steven M. and
+         {Tyson}, J. Anthony and {Abel}, Bob and {Acosta}, Emily and
+         {Allsman}, Robyn and {Alonso}, David and {AlSayyad}, Yusra and
+         {Anderson}, Scott F. and {Andrew}, John and {Angel}, James Roger P. and
+         {Angeli}, George Z. and {Ansari}, Reza and {Antilogus}, Pierre and
+         {Araujo}, Constanza and {Armstrong}, Robert and {Arndt}, Kirk T. and
+         {Astier}, Pierre and {Aubourg}, {\'E}ric and {Auza}, Nicole and
+         {Axelrod}, Tim S. and {Bard}, Deborah J. and {Barr}, Jeff D. and
+         {Barrau}, Aurelian and {Bartlett}, James G. and {Bauer}, Amanda E. and
+         {Bauman}, Brian J. and {Baumont}, Sylvain and {Bechtol}, Ellen and
+         {Bechtol}, Keith and {Becker}, Andrew C. and {Becla}, Jacek and
+         {Beldica}, Cristina and {Bellavia}, Steve and {Bianco}, Federica B. and
+         {Biswas}, Rahul and {Blanc}, Guillaume and {Blazek}, Jonathan and {Bland
+        ford}, Roger D. and {Bloom}, Josh S. and {Bogart}, Joanne and
+         {Bond}, Tim W. and {Booth}, Michael T. and {Borgland}, Anders W. and
+         {Borne}, Kirk and {Bosch}, James F. and {Boutigny}, Dominique and
+         {Brackett}, Craig A. and {Bradshaw}, Andrew and {Brand
+        t}, William Nielsen and {Brown}, Michael E. and {Bullock}, James S. and
+         {Burchat}, Patricia and {Burke}, David L. and {Cagnoli}, Gianpietro and
+         {Calabrese}, Daniel and {Callahan}, Shawn and {Callen}, Alice L. and
+         {Carlin}, Jeffrey L. and {Carlson}, Erin L. and {Chand
+        rasekharan}, Srinivasan and {Charles-Emerson}, Glenaver and
+         {Chesley}, Steve and {Cheu}, Elliott C. and {Chiang}, Hsin-Fang and
+         {Chiang}, James and {Chirino}, Carol and {Chow}, Derek and
+         {Ciardi}, David R. and {Claver}, Charles F. and {Cohen-Tanugi}, Johann and
+         {Cockrum}, Joseph J. and {Coles}, Rebecca and {Connolly}, Andrew J. and
+         {Cook}, Kem H. and {Cooray}, Asantha and {Covey}, Kevin R. and
+         {Cribbs}, Chris and {Cui}, Wei and {Cutri}, Roc and {Daly}, Philip N. and
+         {Daniel}, Scott F. and {Daruich}, Felipe and {Daubard}, Guillaume and
+         {Daues}, Greg and {Dawson}, William and {Delgado}, Francisco and
+         {Dellapenna}, Alfred and {de Peyster}, Robert and
+         {de Val-Borro}, Miguel and {Digel}, Seth W. and {Doherty}, Peter and
+         {Dubois}, Richard and {Dubois-Felsmann}, Gregory P. and
+         {Durech}, Josef and {Economou}, Frossie and {Eifler}, Tim and
+         {Eracleous}, Michael and {Emmons}, Benjamin L. and
+         {Fausti Neto}, Angelo and {Ferguson}, Henry and {Figueroa}, Enrique and
+         {Fisher-Levine}, Merlin and {Focke}, Warren and {Foss}, Michael D. and
+         {Frank}, James and {Freemon}, Michael D. and {Gangler}, Emmanuel and
+         {Gawiser}, Eric and {Geary}, John C. and {Gee}, Perry and
+         {Geha}, Marla and {Gessner}, Charles J.~B. and {Gibson}, Robert R. and
+         {Gilmore}, D. Kirk and {Glanzman}, Thomas and {Glick}, William and
+         {Goldina}, Tatiana and {Goldstein}, Daniel A. and {Goodenow}, Iain and
+         {Graham}, Melissa L. and {Gressler}, William J. and {Gris}, Philippe and
+         {Guy}, Leanne P. and {Guyonnet}, Augustin and {Haller}, Gunther and
+         {Harris}, Ron and {Hascall}, Patrick A. and {Haupt}, Justine and {Hernand
+        ez}, Fabio and {Herrmann}, Sven and {Hileman}, Edward and
+         {Hoblitt}, Joshua and {Hodgson}, John A. and {Hogan}, Craig and
+         {Howard}, James D. and {Huang}, Dajun and {Huffer}, Michael E. and
+         {Ingraham}, Patrick and {Innes}, Walter R. and {Jacoby}, Suzanne H. and
+         {Jain}, Bhuvnesh and {Jammes}, Fabrice and {Jee}, M. James and
+         {Jenness}, Tim and {Jernigan}, Garrett and {Jevremovi{\'c}}, Darko and
+         {Johns}, Kenneth and {Johnson}, Anthony S. and
+         {Johnson}, Margaret W.~G. and {Jones}, R. Lynne and
+         {Juramy-Gilles}, Claire and {Juri{\'c}}, Mario and {Kalirai}, Jason S. and
+         {Kallivayalil}, Nitya J. and {Kalmbach}, Bryce and
+         {Kantor}, Jeffrey P. and {Karst}, Pierre and {Kasliwal}, Mansi M. and
+         {Kelly}, Heather and {Kessler}, Richard and {Kinnison}, Veronica and
+         {Kirkby}, David and {Knox}, Lloyd and {Kotov}, Ivan V. and
+         {Krabbendam}, Victor L. and {Krughoff}, K. Simon and
+         {Kub{\'a}nek}, Petr and {Kuczewski}, John and {Kulkarni}, Shri and
+         {Ku}, John and {Kurita}, Nadine R. and {Lage}, Craig S. and
+         {Lambert}, Ron and {Lange}, Travis and {Langton}, J. Brian and
+         {Le Guillou}, Laurent and {Levine}, Deborah and {Liang}, Ming and
+         {Lim}, Kian-Tat and {Lintott}, Chris J. and {Long}, Kevin E. and
+         {Lopez}, Margaux and {Lotz}, Paul J. and {Lupton}, Robert H. and
+         {Lust}, Nate B. and {MacArthur}, Lauren A. and {Mahabal}, Ashish and {Mand
+        elbaum}, Rachel and {Markiewicz}, Thomas W. and {Marsh}, Darren S. and
+         {Marshall}, Philip J. and {Marshall}, Stuart and {May}, Morgan and
+         {McKercher}, Robert and {McQueen}, Michelle and {Meyers}, Joshua and
+         {Migliore}, Myriam and {Miller}, Michelle and {Mills}, David J. and
+         {Miraval}, Connor and {Moeyens}, Joachim and {Moolekamp}, Fred E. and
+         {Monet}, David G. and {Moniez}, Marc and {Monkewitz}, Serge and
+         {Montgomery}, Christopher and {Morrison}, Christopher B. and
+         {Mueller}, Fritz and {Muller}, Gary P. and
+         {Mu{\~n}oz Arancibia}, Freddy and {Neill}, Douglas R. and
+         {Newbry}, Scott P. and {Nief}, Jean-Yves and {Nomerotski}, Andrei and
+         {Nordby}, Martin and {O'Connor}, Paul and {Oliver}, John and
+         {Olivier}, Scot S. and {Olsen}, Knut and {O'Mullane}, William and
+         {Ortiz}, Sandra and {Osier}, Shawn and {Owen}, Russell E. and
+         {Pain}, Reynald and {Palecek}, Paul E. and {Parejko}, John K. and
+         {Parsons}, James B. and {Pease}, Nathan M. and {Peterson}, J. Matt and
+         {Peterson}, John R. and {Petravick}, Donald L. and
+         {Libby Petrick}, M.~E. and {Petry}, Cathy E. and
+         {Pierfederici}, Francesco and {Pietrowicz}, Stephen and {Pike}, Rob and
+         {Pinto}, Philip A. and {Plante}, Raymond and {Plate}, Stephen and
+         {Plutchak}, Joel P. and {Price}, Paul A. and {Prouza}, Michael and
+         {Radeka}, Veljko and {Rajagopal}, Jayadev and {Rasmussen}, Andrew P. and
+         {Regnault}, Nicolas and {Reil}, Kevin A. and {Reiss}, David J. and
+         {Reuter}, Michael A. and {Ridgway}, Stephen T. and {Riot}, Vincent J. and
+         {Ritz}, Steve and {Robinson}, Sean and {Roby}, William and
+         {Roodman}, Aaron and {Rosing}, Wayne and {Roucelle}, Cecille and
+         {Rumore}, Matthew R. and {Russo}, Stefano and {Saha}, Abhijit and
+         {Sassolas}, Benoit and {Schalk}, Terry L. and {Schellart}, Pim and
+         {Schindler}, Rafe H. and {Schmidt}, Samuel and {Schneider}, Donald P. and
+         {Schneider}, Michael D. and {Schoening}, William and
+         {Schumacher}, German and {Schwamb}, Megan E. and {Sebag}, Jacques and
+         {Selvy}, Brian and {Sembroski}, Glenn H. and {Seppala}, Lynn G. and
+         {Serio}, Andrew and {Serrano}, Eduardo and {Shaw}, Richard A. and
+         {Shipsey}, Ian and {Sick}, Jonathan and {Silvestri}, Nicole and
+         {Slater}, Colin T. and {Smith}, J. Allyn and {Smith}, R. Chris and
+         {Sobhani}, Shahram and {Soldahl}, Christine and
+         {Storrie-Lombardi}, Lisa and {Stover}, Edward and
+         {Strauss}, Michael A. and {Street}, Rachel A. and
+         {Stubbs}, Christopher W. and {Sullivan}, Ian S. and {Sweeney}, Donald and
+         {Swinbank}, John D. and {Szalay}, Alexander and {Takacs}, Peter and
+         {Tether}, Stephen A. and {Thaler}, Jon J. and {Thayer}, John Gregg and
+         {Thomas}, Sandrine and {Thornton}, Adam J. and {Thukral}, Vaikunth and
+         {Tice}, Jeffrey and {Trilling}, David E. and {Turri}, Max and
+         {Van Berg}, Richard and {Vanden Berk}, Daniel and {Vetter}, Kurt and
+         {Virieux}, Francoise and {Vucina}, Tomislav and {Wahl}, William and
+         {Walkowicz}, Lucianne and {Walsh}, Brian and {Walter}, Christopher W. and
+         {Wang}, Daniel L. and {Wang}, Shin-Yawn and {Warner}, Michael and
+         {Wiecha}, Oliver and {Willman}, Beth and {Winters}, Scott E. and
+         {Wittman}, David and {Wolff}, Sidney C. and {Wood-Vasey}, W. Michael and
+         {Wu}, Xiuqin and {Xin}, Bo and {Yoachim}, Peter and {Zhan}, Hu},
+        title = "{LSST: From Science Drivers to Reference Design and Anticipated Data Products}",
+      journal = {\apj},
+     keywords = {astrometry, cosmology: observations, Galaxy: general, methods: observational, stars: general, surveys, Astrophysics},
+         year = "2019",
+        month = "Mar",
+       volume = {873},
+       number = {2},
+          eid = {111},
+        pages = {111},
+          doi = {10.3847/1538-4357/ab042c},
+archivePrefix = {arXiv},
+       eprint = {0805.2366},
+ primaryClass = {astro-ph},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2019ApJ...873..111I},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2019ApJ...873..111I,
+       author = {{Ivezi{\'c}}, {\v{Z}}eljko and {Kahn}, Steven M. and
+         {Tyson}, J. Anthony and {Abel}, Bob and {Acosta}, Emily and
+         {Allsman}, Robyn and {Alonso}, David and {AlSayyad}, Yusra and
+         {Anderson}, Scott F. and {Andrew}, John and {Angel}, James Roger P. and
+         {Angeli}, George Z. and {Ansari}, Reza and {Antilogus}, Pierre and
+         {Araujo}, Constanza and {Armstrong}, Robert and {Arndt}, Kirk T. and
+         {Astier}, Pierre and {Aubourg}, {\'E}ric and {Auza}, Nicole and
+         {Axelrod}, Tim S. and {Bard}, Deborah J. and {Barr}, Jeff D. and
+         {Barrau}, Aurelian and {Bartlett}, James G. and {Bauer}, Amanda E. and
+         {Bauman}, Brian J. and {Baumont}, Sylvain and {Bechtol}, Ellen and
+         {Bechtol}, Keith and {Becker}, Andrew C. and {Becla}, Jacek and
+         {Beldica}, Cristina and {Bellavia}, Steve and {Bianco}, Federica B. and
+         {Biswas}, Rahul and {Blanc}, Guillaume and {Blazek}, Jonathan and {Bland
+        ford}, Roger D. and {Bloom}, Josh S. and {Bogart}, Joanne and
+         {Bond}, Tim W. and {Booth}, Michael T. and {Borgland}, Anders W. and
+         {Borne}, Kirk and {Bosch}, James F. and {Boutigny}, Dominique and
+         {Brackett}, Craig A. and {Bradshaw}, Andrew and {Brand
+        t}, William Nielsen and {Brown}, Michael E. and {Bullock}, James S. and
+         {Burchat}, Patricia and {Burke}, David L. and {Cagnoli}, Gianpietro and
+         {Calabrese}, Daniel and {Callahan}, Shawn and {Callen}, Alice L. and
+         {Carlin}, Jeffrey L. and {Carlson}, Erin L. and {Chand
+        rasekharan}, Srinivasan and {Charles-Emerson}, Glenaver and
+         {Chesley}, Steve and {Cheu}, Elliott C. and {Chiang}, Hsin-Fang and
+         {Chiang}, James and {Chirino}, Carol and {Chow}, Derek and
+         {Ciardi}, David R. and {Claver}, Charles F. and {Cohen-Tanugi}, Johann and
+         {Cockrum}, Joseph J. and {Coles}, Rebecca and {Connolly}, Andrew J. and
+         {Cook}, Kem H. and {Cooray}, Asantha and {Covey}, Kevin R. and
+         {Cribbs}, Chris and {Cui}, Wei and {Cutri}, Roc and {Daly}, Philip N. and
+         {Daniel}, Scott F. and {Daruich}, Felipe and {Daubard}, Guillaume and
+         {Daues}, Greg and {Dawson}, William and {Delgado}, Francisco and
+         {Dellapenna}, Alfred and {de Peyster}, Robert and
+         {de Val-Borro}, Miguel and {Digel}, Seth W. and {Doherty}, Peter and
+         {Dubois}, Richard and {Dubois-Felsmann}, Gregory P. and
+         {Durech}, Josef and {Economou}, Frossie and {Eifler}, Tim and
+         {Eracleous}, Michael and {Emmons}, Benjamin L. and
+         {Fausti Neto}, Angelo and {Ferguson}, Henry and {Figueroa}, Enrique and
+         {Fisher-Levine}, Merlin and {Focke}, Warren and {Foss}, Michael D. and
+         {Frank}, James and {Freemon}, Michael D. and {Gangler}, Emmanuel and
+         {Gawiser}, Eric and {Geary}, John C. and {Gee}, Perry and
+         {Geha}, Marla and {Gessner}, Charles J.~B. and {Gibson}, Robert R. and
+         {Gilmore}, D. Kirk and {Glanzman}, Thomas and {Glick}, William and
+         {Goldina}, Tatiana and {Goldstein}, Daniel A. and {Goodenow}, Iain and
+         {Graham}, Melissa L. and {Gressler}, William J. and {Gris}, Philippe and
+         {Guy}, Leanne P. and {Guyonnet}, Augustin and {Haller}, Gunther and
+         {Harris}, Ron and {Hascall}, Patrick A. and {Haupt}, Justine and {Hernand
+        ez}, Fabio and {Herrmann}, Sven and {Hileman}, Edward and
+         {Hoblitt}, Joshua and {Hodgson}, John A. and {Hogan}, Craig and
+         {Howard}, James D. and {Huang}, Dajun and {Huffer}, Michael E. and
+         {Ingraham}, Patrick and {Innes}, Walter R. and {Jacoby}, Suzanne H. and
+         {Jain}, Bhuvnesh and {Jammes}, Fabrice and {Jee}, M. James and
+         {Jenness}, Tim and {Jernigan}, Garrett and {Jevremovi{\'c}}, Darko and
+         {Johns}, Kenneth and {Johnson}, Anthony S. and
+         {Johnson}, Margaret W.~G. and {Jones}, R. Lynne and
+         {Juramy-Gilles}, Claire and {Juri{\'c}}, Mario and {Kalirai}, Jason S. and
+         {Kallivayalil}, Nitya J. and {Kalmbach}, Bryce and
+         {Kantor}, Jeffrey P. and {Karst}, Pierre and {Kasliwal}, Mansi M. and
+         {Kelly}, Heather and {Kessler}, Richard and {Kinnison}, Veronica and
+         {Kirkby}, David and {Knox}, Lloyd and {Kotov}, Ivan V. and
+         {Krabbendam}, Victor L. and {Krughoff}, K. Simon and
+         {Kub{\'a}nek}, Petr and {Kuczewski}, John and {Kulkarni}, Shri and
+         {Ku}, John and {Kurita}, Nadine R. and {Lage}, Craig S. and
+         {Lambert}, Ron and {Lange}, Travis and {Langton}, J. Brian and
+         {Le Guillou}, Laurent and {Levine}, Deborah and {Liang}, Ming and
+         {Lim}, Kian-Tat and {Lintott}, Chris J. and {Long}, Kevin E. and
+         {Lopez}, Margaux and {Lotz}, Paul J. and {Lupton}, Robert H. and
+         {Lust}, Nate B. and {MacArthur}, Lauren A. and {Mahabal}, Ashish and {Mand
+        elbaum}, Rachel and {Markiewicz}, Thomas W. and {Marsh}, Darren S. and
+         {Marshall}, Philip J. and {Marshall}, Stuart and {May}, Morgan and
+         {McKercher}, Robert and {McQueen}, Michelle and {Meyers}, Joshua and
+         {Migliore}, Myriam and {Miller}, Michelle and {Mills}, David J. and
+         {Miraval}, Connor and {Moeyens}, Joachim and {Moolekamp}, Fred E. and
+         {Monet}, David G. and {Moniez}, Marc and {Monkewitz}, Serge and
+         {Montgomery}, Christopher and {Morrison}, Christopher B. and
+         {Mueller}, Fritz and {Muller}, Gary P. and
+         {Mu{\~n}oz Arancibia}, Freddy and {Neill}, Douglas R. and
+         {Newbry}, Scott P. and {Nief}, Jean-Yves and {Nomerotski}, Andrei and
+         {Nordby}, Martin and {O'Connor}, Paul and {Oliver}, John and
+         {Olivier}, Scot S. and {Olsen}, Knut and {O'Mullane}, William and
+         {Ortiz}, Sandra and {Osier}, Shawn and {Owen}, Russell E. and
+         {Pain}, Reynald and {Palecek}, Paul E. and {Parejko}, John K. and
+         {Parsons}, James B. and {Pease}, Nathan M. and {Peterson}, J. Matt and
+         {Peterson}, John R. and {Petravick}, Donald L. and
+         {Libby Petrick}, M.~E. and {Petry}, Cathy E. and
+         {Pierfederici}, Francesco and {Pietrowicz}, Stephen and {Pike}, Rob and
+         {Pinto}, Philip A. and {Plante}, Raymond and {Plate}, Stephen and
+         {Plutchak}, Joel P. and {Price}, Paul A. and {Prouza}, Michael and
+         {Radeka}, Veljko and {Rajagopal}, Jayadev and {Rasmussen}, Andrew P. and
+         {Regnault}, Nicolas and {Reil}, Kevin A. and {Reiss}, David J. and
+         {Reuter}, Michael A. and {Ridgway}, Stephen T. and {Riot}, Vincent J. and
+         {Ritz}, Steve and {Robinson}, Sean and {Roby}, William and
+         {Roodman}, Aaron and {Rosing}, Wayne and {Roucelle}, Cecille and
+         {Rumore}, Matthew R. and {Russo}, Stefano and {Saha}, Abhijit and
+         {Sassolas}, Benoit and {Schalk}, Terry L. and {Schellart}, Pim and
+         {Schindler}, Rafe H. and {Schmidt}, Samuel and {Schneider}, Donald P. and
+         {Schneider}, Michael D. and {Schoening}, William and
+         {Schumacher}, German and {Schwamb}, Megan E. and {Sebag}, Jacques and
+         {Selvy}, Brian and {Sembroski}, Glenn H. and {Seppala}, Lynn G. and
+         {Serio}, Andrew and {Serrano}, Eduardo and {Shaw}, Richard A. and
+         {Shipsey}, Ian and {Sick}, Jonathan and {Silvestri}, Nicole and
+         {Slater}, Colin T. and {Smith}, J. Allyn and {Smith}, R. Chris and
+         {Sobhani}, Shahram and {Soldahl}, Christine and
+         {Storrie-Lombardi}, Lisa and {Stover}, Edward and
+         {Strauss}, Michael A. and {Street}, Rachel A. and
+         {Stubbs}, Christopher W. and {Sullivan}, Ian S. and {Sweeney}, Donald and
+         {Swinbank}, John D. and {Szalay}, Alexander and {Takacs}, Peter and
+         {Tether}, Stephen A. and {Thaler}, Jon J. and {Thayer}, John Gregg and
+         {Thomas}, Sandrine and {Thornton}, Adam J. and {Thukral}, Vaikunth and
+         {Tice}, Jeffrey and {Trilling}, David E. and {Turri}, Max and
+         {Van Berg}, Richard and {Vanden Berk}, Daniel and {Vetter}, Kurt and
+         {Virieux}, Francoise and {Vucina}, Tomislav and {Wahl}, William and
+         {Walkowicz}, Lucianne and {Walsh}, Brian and {Walter}, Christopher W. and
+         {Wang}, Daniel L. and {Wang}, Shin-Yawn and {Warner}, Michael and
+         {Wiecha}, Oliver and {Willman}, Beth and {Winters}, Scott E. and
+         {Wittman}, David and {Wolff}, Sidney C. and {Wood-Vasey}, W. Michael and
+         {Wu}, Xiuqin and {Xin}, Bo and {Yoachim}, Peter and {Zhan}, Hu},
+        title = "{LSST: From Science Drivers to Reference Design and Anticipated Data Products}",
+      journal = {\apj},
+     keywords = {astrometry, cosmology: observations, Galaxy: general, methods: observational, stars: general, surveys, Astrophysics},
+         year = "2019",
+        month = "Mar",
+       volume = {873},
+       number = {2},
+          eid = {111},
+        pages = {111},
+          doi = {10.3847/1538-4357/ab042c},
+archivePrefix = {arXiv},
+       eprint = {0805.2366},
+ primaryClass = {astro-ph},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2019ApJ...873..111I},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
 @ARTICLE{2009A&A...496..577Z,
    author = {{Zechmeister}, M. and {K{\"u}rster}, M.},
     title = "{The generalised Lomb-Scargle periodogram. A new formalism for the floating-mean and Keplerian periodograms}",
@@ -2811,20 +3125,6 @@ archivePrefix = "arXiv",
     pages = {577-584},
       doi = {10.1051/0004-6361:200811296},
    adsurl = {http://adsabs.harvard.edu/abs/2009A\%26A...496..577Z},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2009arXiv0912.0201L,
-   author = {{LSST Science Collaboration}},
-    title = "{LSST Science Book, Version 2.0}",
-  journal = {ArXiv e-prints},
-archivePrefix = "arXiv",
-   eprint = {0912.0201},
- primaryClass = "astro-ph.IM",
- keywords = {Astrophysics - Instrumentation and Methods for Astrophysics, Astrophysics - Cosmology and Extragalactic Astrophysics, Astrophysics - Earth and Planetary Astrophysics, Astrophysics - Galaxy Astrophysics, Astrophysics - Solar and Stellar Astrophysics},
-     year = 2009,
-    month = dec,
-   adsurl = {http://adsabs.harvard.edu/abs/2009arXiv0912.0201L},
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
@@ -3001,6 +3301,20 @@ archivePrefix = "arXiv",
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+@ARTICLE{2009arXiv0912.0201L,
+   author = {{LSST Science Collaboration}},
+    title = "{LSST Science Book, Version 2.0}",
+  journal = {ArXiv e-prints},
+archivePrefix = "arXiv",
+   eprint = {0912.0201},
+ primaryClass = "astro-ph.IM",
+ keywords = {Astrophysics - Instrumentation and Methods for Astrophysics, Astrophysics - Cosmology and Extragalactic Astrophysics, Astrophysics - Earth and Planetary Astrophysics, Astrophysics - Galaxy Astrophysics, Astrophysics - Solar and Stellar Astrophysics},
+     year = 2009,
+    month = dec,
+   adsurl = {http://adsabs.harvard.edu/abs/2009arXiv0912.0201L},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
 @ARTICLE{2010A&A...516A..77B,
   author =       {{Bombrun}, A. and {Lindegren}, L. and {Holl}, B. and
                   {Jordan}, S.  },
@@ -3035,29 +3349,6 @@ archivePrefix = "arXiv",
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-@ARTICLE{2010A&A...523A..48J,
-  author =       {{Jordi}, C. and {Gebran}, M. and {Carrasco},
-                  J.~M. and {de Bruijne}, J.  and {Voss}, H. and
-                  {Fabricius}, C. and {Knude}, J. and {Vallenari},
-                  A. and {Kohley}, R. and {Mora}, A.},
-  title =        "{Gaia broad band photometry}",
-  journal =      {\aap},
-  archivePrefix ="arXiv",
-  eprint =       {1008.0815},
-  primaryClass = "astro-ph.IM",
-  keywords =     {instrumentation: photometers, techniques:
-                  photometric, Galaxy: general, dust, extinction,
-                  stars: evolution},
-  year =         2010,
-  month =        nov,
-  volume =       523,
-  eid =          {A48},
-  pages =        {A48},
-  doi =          {10.1051/0004-6361/201015441},
-  adsurl =       {http://adsabs.harvard.edu/abs/2010A\%26A...523A..48J},
-  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
-}
-
 @ARTICLE{2010A&A...523A..31H,
    author = {{Hildebrandt}, H. and {Arnouts}, S. and {Capak}, P. and {Moustakas}, L.~A. and
 	{Wolf}, C. and {Abdalla}, F.~B. and {Assef}, R.~J. and {Banerji}, M. and
@@ -3079,6 +3370,29 @@ archivePrefix = "arXiv",
       doi = {10.1051/0004-6361/201014885},
    adsurl = {http://adsabs.harvard.edu/abs/2010A\%26A...523A..31H},
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2010A&A...523A..48J,
+  author =       {{Jordi}, C. and {Gebran}, M. and {Carrasco},
+                  J.~M. and {de Bruijne}, J.  and {Voss}, H. and
+                  {Fabricius}, C. and {Knude}, J. and {Vallenari},
+                  A. and {Kohley}, R. and {Mora}, A.},
+  title =        "{Gaia broad band photometry}",
+  journal =      {\aap},
+  archivePrefix ="arXiv",
+  eprint =       {1008.0815},
+  primaryClass = "astro-ph.IM",
+  keywords =     {instrumentation: photometers, techniques:
+                  photometric, Galaxy: general, dust, extinction,
+                  stars: evolution},
+  year =         2010,
+  month =        nov,
+  volume =       523,
+  eid =          {A48},
+  pages =        {A48},
+  doi =          {10.1051/0004-6361/201015441},
+  adsurl =       {http://adsabs.harvard.edu/abs/2010A\%26A...523A..48J},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @INPROCEEDINGS{2010AAS...21641512W,
@@ -3157,6 +3471,17 @@ archivePrefix = "arXiv",
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+@ARTICLE{2010ISSIR...9..279L,
+  author =       {{Lindegren}, L.},
+  title =        "{High-accuracy positioning: astrometry}",
+  journal =      {ISSI Scientific Reports Series},
+  year =         2010,
+  volume =       9,
+  pages =        {279-291},
+  adsurl =       {http://adsabs.harvard.edu/abs/2010ISSIR...9..279L},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
 @ARTICLE{2010Icar..209..542M,
    author = {{Muinonen}, K. and {Belskaya}, I.~N. and {Cellino}, A. and {Delb{\`o}}, M. and
     {Levasseur-Regourd}, A.-C. and {Penttil{\"a}}, A. and {Tedesco}, E.~F.
@@ -3170,17 +3495,6 @@ archivePrefix = "arXiv",
       doi = {10.1016/j.icarus.2010.04.003},
    adsurl = {http://adsabs.harvard.edu/abs/2010Icar..209..542M},
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2010ISSIR...9..279L,
-  author =       {{Lindegren}, L.},
-  title =        "{High-accuracy positioning: astrometry}",
-  journal =      {ISSI Scientific Reports Series},
-  year =         2010,
-  volume =       9,
-  pages =        {279-291},
-  adsurl =       {http://adsabs.harvard.edu/abs/2010ISSIR...9..279L},
-  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @ARTICLE{2010MNRAS.403...96B,
@@ -3311,6 +3625,41 @@ ral},
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+@INPROCEEDINGS{2011ASPC..442..351O,
+  author =       {{O'Mullane}, W. and {Lammers}, U. and {Hernandez},
+                  J.},
+  title =        "{Gaia: Processing to Archive}",
+  booktitle =    {Astronomical Data Analysis Software and Systems XX},
+  year =         2011,
+  series =       {Astronomical Society of the Pacific Conference
+                  Series},
+  volume =       442,
+  editor =       "{I.~N.~Evans, A.~Accomazzi, D.~J.~Mink, \&
+                  A.~H.~Rots}",
+  month =        jul,
+  pages =        351,
+  adsurl =       {http://adsabs.harvard.edu/abs/2011ASPC..442..351O},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2011ASPC..442..443C,
+  author =       {{Connolly}, A.~J. and {Smith}, I. and {Krughoff},
+                  K.~S. and {Gibson}, R.},
+  title =        "{Using the Browser for Science: A Collaborative
+                  Toolkit for Astronomy}",
+  booktitle =    {Astronomical Data Analysis Software and Systems XX},
+  year =         2011,
+  series =       {Astronomical Society of the Pacific Conference
+                  Series},
+  volume =       442,
+  editor =       {{Evans}, I.~N. and {Accomazzi}, A. and {Mink},
+                  D.~J. and {Rots}, A.~H.  },
+  month =        jul,
+  pages =        443,
+  adsurl =       {http://adsabs.harvard.edu/abs/2011ASPC..442..443C},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
 @ARTICLE{2011ApJ...733...10R,
    author = {{Richards}, J.~W. and {Starr}, D.~L. and {Butler}, N.~R. and
         {Bloom}, J.~S. and {Brewer}, J.~M. and {Crellin-Quick}, A. and
@@ -3348,41 +3697,6 @@ archivePrefix = "arXiv",
       doi = {10.1088/0004-637X/734/1/36},
    adsurl = {http://cdsads.u-strasbg.fr/abs/2011ApJ...734...36A},
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@INPROCEEDINGS{2011ASPC..442..351O,
-  author =       {{O'Mullane}, W. and {Lammers}, U. and {Hernandez},
-                  J.},
-  title =        "{Gaia: Processing to Archive}",
-  booktitle =    {Astronomical Data Analysis Software and Systems XX},
-  year =         2011,
-  series =       {Astronomical Society of the Pacific Conference
-                  Series},
-  volume =       442,
-  editor =       "{I.~N.~Evans, A.~Accomazzi, D.~J.~Mink, \&
-                  A.~H.~Rots}",
-  month =        jul,
-  pages =        351,
-  adsurl =       {http://adsabs.harvard.edu/abs/2011ASPC..442..351O},
-  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@INPROCEEDINGS{2011ASPC..442..443C,
-  author =       {{Connolly}, A.~J. and {Smith}, I. and {Krughoff},
-                  K.~S. and {Gibson}, R.},
-  title =        "{Using the Browser for Science: A Collaborative
-                  Toolkit for Astronomy}",
-  booktitle =    {Astronomical Data Analysis Software and Systems XX},
-  year =         2011,
-  series =       {Astronomical Society of the Pacific Conference
-                  Series},
-  volume =       442,
-  editor =       {{Evans}, I.~N. and {Accomazzi}, A. and {Mink},
-                  D.~J. and {Rots}, A.~H.  },
-  month =        jul,
-  pages =        443,
-  adsurl =       {http://adsabs.harvard.edu/abs/2011ASPC..442..443C},
-  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @INPROCEEDINGS{2011EAS....45..109L,
@@ -3770,6 +4084,22 @@ archivePrefix = "arXiv",
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+@ARTICLE{2012PASP..124.1113A,
+   author = {{Alejandro Plazas}, A. and {Bernstein}, G.},
+    title = "{Atmospheric Dispersion Effects in Weak Lensing Measurements}",
+  journal = {\pasp},
+archivePrefix = "arXiv",
+   eprint = {1204.1346},
+ primaryClass = "astro-ph.IM",
+     year = 2012,
+    month = oct,
+   volume = 124,
+    pages = {1113},
+      doi = {10.1086/668294},
+   adsurl = {http://adsabs.harvard.edu/abs/2012PASP..124.1113A},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
 @ARTICLE{2012PASP..124.1175B,
    author = {{Bloom}, J.~S. and {Richards}, J.~W. and {Nugent}, P.~E. and
 	{Quimby}, R.~M. and {Kasliwal}, M.~M. and {Starr}, D.~L. and
@@ -3956,16 +4286,17 @@ archivePrefix = "arXiv",
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-@MISC{2013ascl.soft04011C,
-   author = {{Carrasco Kind}, M. and {Brunner}, R.},
-    title = "{TPZ: Trees for Photo-Z}",
- keywords = {Software},
-howpublished = {Astrophysics Source Code Library},
+@ARTICLE{2013arXiv1304.3455G,
+   author = {{Gould}, A.},
+    title = "{LSST's DC Bias Against Planets and Galactic-Plane Science}",
+  journal = {ArXiv e-prints},
+archivePrefix = "arXiv",
+   eprint = {1304.3455},
+ primaryClass = "astro-ph.GA",
+ keywords = {Astrophysics - Galaxy Astrophysics, Astrophysics - Earth and Planetary Astrophysics, Astrophysics - Solar and Stellar Astrophysics},
      year = 2013,
     month = apr,
-archivePrefix = "ascl",
-   eprint = {1304.011},
-   adsurl = {http://adsabs.harvard.edu/abs/2013ascl.soft04011C},
+   adsurl = {http://adsabs.harvard.edu/abs/2013arXiv1304.3455G},
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
@@ -4167,6 +4498,19 @@ archivePrefix = "arXiv",
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+@MISC{2013ascl.soft04011C,
+   author = {{Carrasco Kind}, M. and {Brunner}, R.},
+    title = "{TPZ: Trees for Photo-Z}",
+ keywords = {Software},
+howpublished = {Astrophysics Source Code Library},
+     year = 2013,
+    month = apr,
+archivePrefix = "ascl",
+   eprint = {1304.011},
+   adsurl = {http://adsabs.harvard.edu/abs/2013ascl.soft04011C},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
 @ARTICLE{2014A&A...566A.119L,
   author =       {{Luri}, X. and {Palmer}, M. and {Arenou}, F. and
                   {Masana}, E. and {de Bruijne}, J. and {Antiche},
@@ -4237,6 +4581,35 @@ archivePrefix = "arXiv",
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+@ARTICLE{2014ApJ...794...23D,
+   author = {{Drout}, M.~R. and {Chornock}, R. and {Soderberg}, A.~M. and
+  {Sanders}, N.~E. and {McKinnon}, R. and {Rest}, A. and {Foley}, R.~J. and
+  {Milisavljevic}, D. and {Margutti}, R. and {Berger}, E. and
+  {Calkins}, M. and {Fong}, W. and {Gezari}, S. and {Huber}, M.~E. and
+  {Kankare}, E. and {Kirshner}, R.~P. and {Leibler}, C. and {Lunnan}, R. and
+  {Mattila}, S. and {Marion}, G.~H. and {Narayan}, G. and {Riess}, A.~G. and
+  {Roth}, K.~C. and {Scolnic}, D. and {Smartt}, S.~J. and {Tonry}, J.~L. and
+  {Burgett}, W.~S. and {Chambers}, K.~C. and {Hodapp}, K.~W. and
+  {Jedicke}, R. and {Kaiser}, N. and {Magnier}, E.~A. and {Metcalfe}, N. and
+  {Morgan}, J.~S. and {Price}, P.~A. and {Waters}, C.},
+    title = "{Rapidly Evolving and Luminous Transients from Pan-STARRS1}",
+  journal = {\apj},
+archivePrefix = "arXiv",
+   eprint = {1405.3668},
+ primaryClass = "astro-ph.HE",
+ keywords = {supernovae: general},
+     year = 2014,
+    month = oct,
+   volume = 794,
+      eid = {23},
+    pages = {23},
+      doi = {10.1088/0004-637X/794/1/23},
+   adsurl = {http://adsabs.harvard.edu/abs/2014ApJ...794...23D},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+
+
 @ARTICLE{2014ApJS..212...18B,
    author = {{Brown}, M.~J.~I. and {Moustakas}, J. and {Smith}, J.-D.~T. and
 	{da Cunha}, E. and {Jarrett}, T.~H. and {Imanishi}, M. and {Armus}, L. and
@@ -4268,17 +4641,6 @@ archivePrefix = "arXiv",
   doi =          {10.1051/eas/1567003},
   adsurl =       {http://adsabs.harvard.edu/abs/2014EAS....67...15P},
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@BOOK{2014sdmm.book.....I,
-   author = {{Ivezi{\'c}}, {\v Z}. and {Connolly}, A.~J. and {VanderPlas}, J.~T. and
-        {Gray}, A.},
-    title = "{Statistics, Data Mining, and Machine Learning in Astronomy}",
-booktitle = {Statistics, Data Mining, and Machine Learning in Astronomy},
-     year = 2014,
-publisher = {Princeton University Press},
-   adsurl = {http://adsabs.harvard.edu/abs/2014sdmm.book.....I},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @ARTICLE{2014MNRAS.439..264G,
@@ -4423,6 +4785,17 @@ archivePrefix = "arXiv",
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+@BOOK{2014sdmm.book.....I,
+   author = {{Ivezi{\'c}}, {\v Z}. and {Connolly}, A.~J. and {VanderPlas}, J.~T. and
+        {Gray}, A.},
+    title = "{Statistics, Data Mining, and Machine Learning in Astronomy}",
+booktitle = {Statistics, Data Mining, and Machine Learning in Astronomy},
+     year = 2014,
+publisher = {Princeton University Press},
+   adsurl = {http://adsabs.harvard.edu/abs/2014sdmm.book.....I},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
 @ARTICLE{2015A&A...574A.115M,
   author =       {{Michalik}, D. and {Lindegren}, L. and {Hobbs}, D.},
   title =        "{The Tycho-Gaia astrometric solution . How to get
@@ -4495,6 +4868,23 @@ archivePrefix = "arXiv",
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+@ARTICLE{2015ApJ...807..182M,
+   author = {{Meyers}, J.~E. and {Burchat}, P.~R.},
+    title = "{Impact of Atmospheric Chromatic Effects on Weak Lensing Measurements}",
+  journal = {\apj},
+archivePrefix = "arXiv",
+   eprint = {1409.6273},
+ keywords = {atmospheric effects, cosmology: observations, gravitational lensing: weak, techniques: image processing},
+     year = 2015,
+    month = jul,
+   volume = 807,
+      eid = {182},
+    pages = {182},
+      doi = {10.1088/0004-637X/807/2/182},
+   adsurl = {http://adsabs.harvard.edu/abs/2015ApJ...807..182M},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
 @ARTICLE{2015ApJ...812...18V,
    author = {{VanderPlas}, J.~T. and {Ivezi{\'c}}, {\v Z}.},
     title = "{Periodograms for Multiband Astronomical Time Series}",
@@ -4513,6 +4903,29 @@ archivePrefix = "arXiv",
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+@ARTICLE{2015ApJS..218...14P,
+   author = {{Peterson}, J.~R. and {Jernigan}, J.~G. and {Kahn}, S.~M. and
+	{Rasmussen}, A.~P. and {Peng}, E. and {Ahmad}, Z. and {Bankert}, J. and
+	{Chang}, C. and {Claver}, C. and {Gilmore}, D.~K. and {Grace}, E. and
+	{Hannel}, M. and {Hodge}, M. and {Lorenz}, S. and {Lupu}, A. and
+	{Meert}, A. and {Nagarajan}, S. and {Todd}, N. and {Winans}, A. and
+	{Young}, M.},
+    title = "{Simulation of Astronomical Images from Optical Survey Telescopes Using a Comprehensive Photon Monte Carlo Approach}",
+  journal = {\apjs},
+archivePrefix = "arXiv",
+   eprint = {1504.06570},
+ primaryClass = "astro-ph.IM",
+ keywords = {atmospheric effects, cosmology: observations, Galaxy: structure, instrumentation: detectors, surveys, telescopes},
+     year = 2015,
+    month = may,
+   volume = 218,
+      eid = {14},
+    pages = {14},
+      doi = {10.1088/0067-0049/218/1/14},
+   adsurl = {http://adsabs.harvard.edu/abs/2015ApJS..218...14P},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
 @ARTICLE{2015JInst..10C5010O,
    author = {{O'Connor}, P.},
     title = "{Crosstalk in multi-output CCDs for LSST}",
@@ -4527,6 +4940,22 @@ archivePrefix = "arXiv",
     pages = {C05010},
       doi = {10.1088/1748-0221/10/05/C05010},
    adsurl = {http://adsabs.harvard.edu/abs/2015JInst..10C5010O},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2015PASP..127...74M,
+   author = {{Mangum}, J.~G. and {Wallace}, P.},
+    title = "{Atmospheric Refractive Electromagnetic Wave Bending and Propagation Delay}",
+  journal = {\pasp},
+archivePrefix = "arXiv",
+   eprint = {1411.1617},
+ primaryClass = "astro-ph.IM",
+     year = 2015,
+    month = jan,
+   volume = 127,
+    pages = {74},
+      doi = {10.1086/679582},
+   adsurl = {http://adsabs.harvard.edu/abs/2015PASP..127...74M},
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
@@ -4644,6 +5073,39 @@ archivePrefix = "arXiv",
   adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+@INPROCEEDINGS{2016SPIE.9911E..25R,
+   author = {{Reuter}, M.~A. and {Cook}, K.~H. and {Delgado}, F. and {Petry}, C.~E. and
+	{Ridgway}, S.~T.},
+    title = "{Simulating the LSST OCS for conducting survey simulations using the LSST scheduler}",
+booktitle = {Modeling, Systems Engineering, and Project Management for Astronomy VI},
+     year = 2016,
+   series = {\procspie},
+   volume = 9911,
+    month = aug,
+      eid = {991125},
+    pages = {991125},
+      doi = {10.1117/12.2232680},
+   adsurl = {http://adsabs.harvard.edu/abs/2016SPIE.9911E..25R},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2016SPIE.9910E..13D,
+   author = {{Delgado}, F. and {Reuter}, M.~A.},
+    title = "{The LSST Scheduler from design to construction}",
+booktitle = {Observatory Operations: Strategies, Processes, and Systems VI},
+     year = 2016,
+   series = {\procspie},
+   volume = 9910,
+    month = jul,
+      eid = {991013},
+    pages = {991013},
+      doi = {10.1117/12.2233630},
+   adsurl = {http://adsabs.harvard.edu/abs/2016SPIE.9910E..13D},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+
+
 @TECHREPORT{2016acs..rept....1B,
    author = {{Borncamp}, D. and {Lim}, P.~L.},
     title = "{Satellite Detection in Advanced Camera for Surveys/Wide Field Channel Images}",
@@ -4653,20 +5115,6 @@ institution = {STScI},
      year = 2016,
     month = jan,
    adsurl = {http://adsabs.harvard.edu/abs/2016acs..rept....1B},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{2017arXiv170309824V,
-   author = {{VanderPlas}, J.~T.},
-    title = "{Understanding the Lomb-Scargle Periodogram}",
-  journal = {ArXiv e-prints},
-archivePrefix = "arXiv",
-   eprint = {1703.09824},
- primaryClass = "astro-ph.IM",
- keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
-     year = 2017,
-    month = mar,
-   adsurl = {http://adsabs.harvard.edu/abs/2017arXiv170309824V},
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
@@ -4685,4 +5133,1202 @@ archivePrefix = "arXiv",
       doi = {10.3847/1538-4357/aa6332},
    adsurl = {http://adsabs.harvard.edu/abs/2017ApJ...838....5L},
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2017arXiv170208449A,
+   author = {{Aihara}, H. and {Armstrong}, R. and {Bickerton}, S. and {Bosch}, J. and
+	{Coupon}, J. and {Furusawa}, H. and {Hayashi}, Y. and {Ikeda}, H. and
+	{Kamata}, Y. and {Karoji}, H. and {Kawanomoto}, S. and {Koike}, M. and
+	{Komiyama}, Y. and {Lupton}, R.~H. and {Mineo}, S. and {Miyatake}, H. and
+	{Miyazaki}, S. and {Morokuma}, T. and {Obuchi}, Y. and {Oishi}, Y. and
+	{Okura}, Y. and {Price}, P.~A. and {Takata}, T. and {Tanaka}, M.~M. and
+	{Tanaka}, M. and {Tanaka}, Y. and {Uchida}, T. and {Uraguchi}, F. and
+	{Utsumi}, Y. and {Wang}, S.-Y. and {Yamada}, Y. and {Yamanoi}, H. and
+	{Yasuda}, N. and {Arimoto}, N. and {Chiba}, M. and {Finet}, F. and
+	{Fujimori}, H. and {Fujimoto}, S. and {Furusawa}, J. and {Goto}, T. and
+	{Goulding}, A. and {Gunn}, J.~E. and {Harikane}, Y. and {Hattori}, T. and
+	{Hayashi}, M. and {Helminiak}, K.~G. and {Higuchi}, R. and {Hikage}, C. and
+	{Ho}, P.~T.~P. and {Hsieh}, B.-C. and {Huang}, K. and {Huang}, S. and
+	{Imanishi}, M. and {Iwata}, I. and {Jaelani}, A.~T. and {Jian}, H.-Y. and
+	{Kashikawa}, N. and {Katayama}, N. and {Kojima}, T. and {Konno}, A. and
+	{Koshida}, S. and {Kusakabe}, H. and {Leauthaud}, A. and {Lee}, C.-H. and
+	{Lin}, L. and {Lin}, Y.-T. and {Mandelbaum}, R. and {Matsuoka}, Y. and
+	{Medezinski}, E. and {Miyama}, S. and {Momose}, R. and {More}, A. and
+	{More}, S. and {Mukae}, S. and {Murata}, R. and {Murayama}, H. and
+	{Nagao}, T. and {Nakata}, F. and {Niikura}, H. and {Nishizawa}, A.~J. and
+	{Oguri}, M. and {Okabe}, N. and {Ono}, Y. and {Onodera}, M. and
+	{Onoue}, M. and {Ouchi}, M. and {Pyo}, T.-S. and {Shibuya}, T. and
+	{Shimasaku}, K. and {Simet}, M. and {Speagle}, J. and {Spergel}, D.~N. and
+	{Strauss}, M.~A. and {Sugahara}, Y. and {Sugiyama}, N. and {Suto}, Y. and
+	{Suzuki}, N. and {Tait}, P.~J. and {Takada}, M. and {Terai}, T. and
+	{Toba}, Y. and {Turner}, E.~L. and {Uchiyama}, H. and {Umetsu}, K. and
+	{Urata}, Y. and {Usuda}, T. and {Yeh}, S. and {Yuma}, S.},
+    title = "{First Data Release of the Hyper Suprime-Cam Subaru Strategic Program}",
+  journal = {ArXiv e-prints},
+archivePrefix = "arXiv",
+   eprint = {1702.08449},
+ primaryClass = "astro-ph.IM",
+ keywords = {Astrophysics - Instrumentation and Methods for Astrophysics, Astrophysics - Earth and Planetary Astrophysics, Astrophysics - Astrophysics of Galaxies, Astrophysics - High Energy Astrophysical Phenomena, Astrophysics - Solar and Stellar Astrophysics},
+     year = 2017,
+    month = feb,
+   adsurl = {http://adsabs.harvard.edu/abs/2017arXiv170208449A},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+@ARTICLE{2017arXiv170309824V,
+   author = {{VanderPlas}, J.~T.},
+    title = "{Understanding the Lomb-Scargle Periodogram}",
+  journal = {ArXiv e-prints},
+archivePrefix = "arXiv",
+   eprint = {1703.09824},
+ primaryClass = "astro-ph.IM",
+ keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+     year = 2017,
+    month = mar,
+   adsurl = {http://adsabs.harvard.edu/abs/2017arXiv170309824V},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2017arXiv170804058L,
+   author = {{LSST Science Collaboration} and {Marshall}, P. and {Anguita}, T. and
+	{Bianco}, F.~B. and {Bellm}, E.~C. and {Brandt}, N. and {Clarkson}, W. and
+	{Connolly}, A. and {Gawiser}, E. and {Ivezic}, Z. and {Jones}, L. and
+	{Lochner}, M. and {Lund}, M.~B. and {Mahabal}, A. and {Nidever}, D. and
+	{Olsen}, K. and {Ridgway}, S. and {Rhodes}, J. and {Shemmer}, O. and
+	{Trilling}, D. and {Vivas}, K. and {Walkowicz}, L. and {Willman}, B. and
+	{Yoachim}, P. and {Anderson}, S. and {Antilogus}, P. and {Angus}, R. and
+	{Arcavi}, I. and {Awan}, H. and {Biswas}, R. and {Bell}, K.~J. and
+	{Bennett}, D. and {Britt}, C. and {Buzasi}, D. and {Casetti-Dinescu}, D.~I. and
+	{Chomiuk}, L. and {Claver}, C. and {Cook}, K. and {Davenport}, J. and
+	{Debattista}, V. and {Digel}, S. and {Doctor}, Z. and {Firth}, R.~E. and
+	{Foley}, R. and {Fong}, W.-f. and {Galbany}, L. and {Giampapa}, M. and
+	{Gizis}, J.~E. and {Graham}, M.~L. and {Grillmair}, C. and {Gris}, P. and
+	{Haiman}, Z. and {Hartigan}, P. and {Hawley}, S. and {Hlozek}, R. and
+	{Jha}, S.~W. and {Johns-Krull}, C. and {Kanbur}, S. and {Kalogera}, V. and
+	{Kashyap}, V. and {Kasliwal}, V. and {Kessler}, R. and {Kim}, A. and
+	{Kurczynski}, P. and {Lahav}, O. and {Liu}, M.~C. and {Malz}, A. and
+	{Margutti}, R. and {Matheson}, T. and {McEwen}, J.~D. and {McGehee}, P. and
+	{Meibom}, S. and {Meyers}, J. and {Monet}, D. and {Neilsen}, E. and
+	{Newman}, J. and {O'Dowd}, M. and {Peiris}, H.~V. and {Penny}, M.~T. and
+	{Peters}, C. and {Poleski}, R. and {Ponder}, K. and {Richards}, G. and
+	{Rho}, J. and {Rubin}, D. and {Schmidt}, S. and {Schuhmann}, R.~L. and
+	{Shporer}, A. and {Slater}, C. and {Smith}, N. and {Soares-Santos}, M. and
+	{Stassun}, K. and {Strader}, J. and {Strauss}, M. and {Street}, R. and
+	{Stubbs}, C. and {Sullivan}, M. and {Szkody}, P. and {Trimble}, V. and
+	{Tyson}, T. and {de Val-Borro}, M. and {Valenti}, S. and {Wagoner}, R. and
+	{Wood-Vasey}, W.~M. and {Zauderer}, B.~A.},
+    title = "{Science-Driven Optimization of the LSST Observing Strategy}",
+  journal = {ArXiv e-prints},
+archivePrefix = "arXiv",
+   eprint = {1708.04058},
+ primaryClass = "astro-ph.IM",
+ keywords = {Astrophysics - Instrumentation and Methods for Astrophysics, Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Earth and Planetary Astrophysics, Astrophysics - Astrophysics of Galaxies, Astrophysics - Solar and Stellar Astrophysics},
+     year = 2017,
+    month = aug,
+   adsurl = {http://adsabs.harvard.edu/abs/2017arXiv170804058L},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2017PASP..129g4503B,
+   author = {{Bernstein}, G.~M. and {Armstrong}, R. and {Plazas}, A.~A. and
+	{Walker}, A.~R. and {Abbott}, T.~M.~C. and {Allam}, S. and {Bechtol}, K. and
+	{Benoit-L{\'e}vy}, A. and {Brooks}, D. and {Burke}, D.~L. and
+	{Carnero Rosell}, A. and {Carrasco Kind}, M. and {Carretero}, J. and
+	{Cunha}, C.~E. and {da Costa}, L.~N. and {DePoy}, D.~L. and
+	{Desai}, S. and {Diehl}, H.~T. and {Eifler}, T.~F. and {Fernandez}, E. and
+	{Fosalba}, P. and {Frieman}, J. and {Garc{\'{\i}}a-Bellido}, J. and
+	{Gerdes}, D.~W. and {Gruen}, D. and {Gruendl}, R.~A. and {Gschwend}, J. and
+	{Gutierrez}, G. and {Honscheid}, K. and {James}, D.~J. and {Kent}, S. and
+	{Krause}, E. and {Kuehn}, K. and {Kuropatkin}, N. and {Li}, T.~S. and
+	{Maia}, M.~A.~G. and {March}, M. and {Marshall}, J.~L. and {Menanteau}, F. and
+	{Miquel}, R. and {Ogando}, R.~L.~C. and {Reil}, K. and {Roodman}, A. and
+	{Rykoff}, E.~S. and {Sanchez}, E. and {Scarpine}, V. and {Schindler}, R. and
+	{Schubnell}, M. and {Sevilla-Noarbe}, I. and {Smith}, M. and
+	{Smith}, R.~C. and {Soares-Santos}, M. and {Sobreira}, F. and
+	{Suchyta}, E. and {Swanson}, M.~E.~C. and {Tarle}, G. and {DES Collaboration}
+	},
+    title = "{Astrometric Calibration and Performance of the Dark Energy Camera}",
+  journal = {\pasp},
+archivePrefix = "arXiv",
+   eprint = {1703.01679},
+ primaryClass = "astro-ph.IM",
+     year = 2017,
+    month = jul,
+   volume = 129,
+   number = 7,
+    pages = {074503},
+      doi = {10.1088/1538-3873/aa6c55},
+   adsurl = {http://adsabs.harvard.edu/abs/2017PASP..129g4503B},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2016A&C....15...33B,
+   author = {{Berry}, D.~S. and {Warren-Smith}, R.~F. and {Jenness}, T.},
+    title = "{AST: A library for modelling and manipulating coordinate systems}",
+  journal = {Astronomy and Computing},
+archivePrefix = "arXiv",
+   eprint = {1602.06681},
+ primaryClass = "astro-ph.IM",
+ keywords = {World Coordinate Systems, Data models, Starlink},
+     year = 2016,
+    month = apr,
+   volume = 15,
+    pages = {33-49},
+      doi = {10.1016/j.ascom.2016.02.003},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2005ASPC..347..491S,
+   author = {{Shupe}, D.~L. and {Moshir}, M. and {Li}, J. and {Makovoz}, D. and
+	{Narron}, R. and {Hook}, R.~N.},
+    title = "{The SIP Convention for Representing Distortion in FITS Image Headers}",
+booktitle = {Astronomical Data Analysis Software and Systems XIV},
+     year = 2005,
+   series = {Astronomical Society of the Pacific Conference Series},
+   volume = 347,
+   editor = {{Shopbell}, P. and {Britton}, M. and {Ebert}, R.},
+    month = dec,
+    pages = {491},
+   adsurl = {http://adsabs.harvard.edu/abs/2005ASPC..347..491S},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2002A&A...395.1061G,
+   author = {{Greisen}, E.~W. and {Calabretta}, M.~R.},
+    title = "{Representations of world coordinates in FITS}",
+  journal = {\aap},
+   eprint = {astro-ph/0207407},
+ keywords = {methods: data analysis, techniques: image processing, astronomical data bases: miscellaneous},
+     year = 2002,
+    month = dec,
+   volume = 395,
+    pages = {1061-1075},
+      doi = {10.1051/0004-6361:20021326},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2016SPIE.9910E..1AY,
+   author = {{Yoachim}, P. and {Coughlin}, M. and {Angeli}, G.~Z. and {Claver}, C.~F. and
+	{Connolly}, A.~J. and {Cook}, K. and {Daniel}, S. and {Ivezi{\'c}}, {\v Z}. and
+	{Jones}, R.~L. and {Petry}, C. and {Reuter}, M. and {Stubbs}, C. and
+	{Xin}, B.},
+    title = "{An optical to IR sky brightness model for the LSST}",
+booktitle = {Observatory Operations: Strategies, Processes, and Systems VI},
+     year = 2016,
+   series = {\procspie},
+   volume = 9910,
+    month = jul,
+      eid = {99101A},
+    pages = {99101A},
+      doi = {10.1117/12.2232947},
+   adsurl = {http://adsabs.harvard.edu/abs/2016SPIE.9910E..1AY},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2017arXiv170202968M,
+   author = {{Mohammadi}, M. and {Bazhirov}, T.},
+    title = "{Comparative benchmarking of cloud computing vendors with High Performance Linpack}",
+  journal = {ArXiv e-prints},
+archivePrefix = "arXiv",
+   eprint = {1702.02968},
+ primaryClass = "cs.PF",
+ keywords = {Computer Science - Performance, Computer Science - Distributed, Parallel, and Cluster Computing},
+     year = 2017,
+    month = feb,
+   adsurl = {http://adsabs.harvard.edu/abs/2017arXiv170202968M},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2004PASP..116..133L,
+   author = {{Lupton}, R. and {Blanton}, M.~R. and {Fekete}, G. and {Hogg}, D.~W. and
+	{O'Mullane}, W. and {Szalay}, A. and {Wherry}, N.},
+    title = "{Preparing Red-Green-Blue Images from CCD Data}",
+  journal = {\pasp},
+   eprint = {astro-ph/0312483},
+ keywords = {Techniques: Image Processing, Techniques: Photometric},
+     year = 2004,
+    month = feb,
+   volume = 116,
+    pages = {133-137},
+      doi = {10.1086/382245},
+   adsurl = {http://adsabs.harvard.edu/abs/2004PASP..116..133L},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2016ApJ...832..155F,
+   author = {{F{\"o}rster}, F. and {Maureira}, J.~C. and {San Mart{\'{\i}}n}, J. and
+	{Hamuy}, M. and {Mart{\'{\i}}nez}, J. and {Huijse}, P. and {Cabrera}, G. and
+	{Galbany}, L. and {de Jaeger}, T. and {Gonz{\'a}lez{\ndash}Gait{\'a}n}, S. and
+	{Anderson}, J.~P. and {Kunkarayakti}, H. and {Pignata}, G. and
+	{Bufano}, F. and {Litt{\'{\i}}n}, J. and {Olivares}, F. and
+	{Medina}, G. and {Smith}, R.~C. and {Vivas}, A.~K. and {Est{\'e}vez}, P.~A. and
+	{Mu{\~n}oz}, R. and {Vera}, E.},
+    title = "{The High Cadence Transient Survey (HITS). I. Survey Design and Supernova Shock Breakout Constraints}",
+  journal = {\apj},
+archivePrefix = "arXiv",
+   eprint = {1609.03567},
+ primaryClass = "astro-ph.SR",
+ keywords = {methods: data analysis, supernovae: general, surveys, techniques: image processing},
+     year = 2016,
+    month = dec,
+   volume = 832,
+      eid = {155},
+    pages = {155},
+      doi = {10.3847/0004-637X/832/2/155},
+   adsurl = {http://adsabs.harvard.edu/abs/2016ApJ...832..155F},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2016A&A...595A...2G,
+   author = {{Gaia Collaboration} and {Brown}, A.~G.~A. and {Vallenari}, A. and
+	{Prusti}, T. and {de Bruijne}, J.~H.~J. and {Mignard}, F. and
+	{Drimmel}, R. and {Babusiaux}, C. and {Bailer-Jones}, C.~A.~L. and
+	{Bastian}, U. and et al.},
+    title = "{Gaia Data Release 1. Summary of the astrometric, photometric, and survey properties}",
+  journal = {\aap},
+archivePrefix = "arXiv",
+   eprint = {1609.04172},
+ primaryClass = "astro-ph.IM",
+ keywords = {catalogs, astrometry, parallaxes, proper motions, surveys},
+     year = 2016,
+    month = nov,
+   volume = 595,
+      eid = {A2},
+    pages = {A2},
+      doi = {10.1051/0004-6361/201629512},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+@INPROCEEDINGS{2001misk.conf..638O,
+   author = {{O'Mullane}, W. and {Banday}, A.~J. and {G{\'o}rski}, K.~M. and
+	{Kunszt}, P. and {Szalay}, A.~S.},
+    title = "{Splitting the Sky - HTM and HEALPix}",
+booktitle = {Mining the Sky},
+     year = 2001,
+   editor = {{Banday}, A.~J. and {Zaroubi}, S. and {Bartelmann}, M.},
+    pages = {638},
+      doi = {10.1007/10849171_84},
+   adsurl = {http://ads.nao.ac.jp/abs/2001misk.conf..638O},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+
+@INPROCEEDINGS{2004ASPC..314..372O,
+   author = {{O'Mullane}, W. and {Gray}, J. and {Li}, N. and {Budav{\'a}ri}, T. and
+	{Nieto-Santisteban}, M.~A. and {Szalay}, A.~S.},
+    title = "{Batch Query System with Interactive Local Storage for SDSS and the VO}",
+booktitle = {Astronomical Data Analysis Software and Systems (ADASS) XIII},
+     year = 2004,
+   series = {Astronomical Society of the Pacific Conference Series},
+   volume = 314,
+   editor = {{Ochsenbein}, F. and {Allen}, M.~G. and {Egret}, D.},
+    month = jul,
+    pages = {372},
+   adsurl = {http://ads.nao.ac.jp/abs/2004ASPC..314..372O},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2018ApJ...860L..11K,
+       author = {{Koppelman}, Helmer and {Helmi}, Amina and {Veljanoski}, Jovan},
+        title = "{One Large Blob and Many Streams Frosting the nearby Stellar Halo in
+        Gaia~DR2}",
+      journal = {\apj},
+     keywords = {Galaxy: halo, Galaxy: kinematics and dynamics, solar neighborhood,
+        Astrophysics - Astrophysics of Galaxies},
+         year = 2018,
+        month = Jun,
+       volume = {860},
+          eid = {L11},
+        pages = {L11},
+          doi = {10.3847/2041-8213/aac882},
+       adsurl = {https://ui.adsabs.harvard.edu/#abs/2018ApJ...860L..11K},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2017arXiv170202600H,
+   author = {{Huff}, E. and {Mandelbaum}, R.},
+    title = "{Metacalibration: Direct Self-Calibration of Biases in Shear Measurement}",
+  journal = {ArXiv e-prints},
+archivePrefix = "arXiv",
+   eprint = {1702.02600},
+ keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics},
+     year = 2017,
+    month = feb,
+   adsurl = {http://adsabs.harvard.edu/abs/2017arXiv170202600H},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2014MNRAS.438.1880B,
+   author = {{Bernstein}, G.~M. and {Armstrong}, R.},
+    title = "{Bayesian lensing shear measurement}",
+  journal = {\mnras},
+archivePrefix = "arXiv",
+   eprint = {1304.1843},
+ keywords = {gravitational lensing: weak, methods: data analysis},
+     year = 2014,
+    month = feb,
+   volume = 438,
+    pages = {1880-1893},
+      doi = {10.1093/mnras/stt2326},
+   adsurl = {http://adsabs.harvard.edu/abs/2014MNRAS.438.1880B},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2018SPIE10707E..09J,
+   author = {Tim Jenness and Frossie Economou and Krzysztof Findeisen and
+             Fabio Hernandez and Josh Hoblitt and others},
+    title = "{LSST data management software development practices and tools}",
+booktitle = {Software and Cyberinfrastructure for Astronomy V},
+     year = 2018,
+   series = {\procspie},
+   volume = 10707,
+    month = jul,
+      eid = {1070709},
+    pages = {1070709},
+      doi = {10.1117/12.2312157},
+   adsurl = {http://adsabs.harvard.edu/abs/2018SPIE10707E..09J},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2015ASPC..495..101B,
+   author = {{Beaumont}, C. and {Goodman}, A. and {Greenfield}, P.},
+    title = "{Hackable User Interfaces In Astronomy with Glue}",
+booktitle = {Astronomical Data Analysis Software an Systems XXIV (ADASS XXIV)},
+     year = 2015,
+   series = {Astronomical Society of the Pacific Conference Series},
+   volume = 495,
+   editor = {{Taylor}, A.~R. and {Rosolowsky}, E.},
+    month = sep,
+    pages = {101},
+   adsurl = {http://adsabs.harvard.edu/abs/2015ASPC..495..101B},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2013A&A...549A...8B,
+   author = {{Buton}, C. and {Copin}, Y. and {Aldering}, G. and {Antilogus}, P. and
+             {Aragon}, C. and {Bailey}, S. and {Baltay}, C. and {Bongard}, S.
+             and {Canto}, A. and {Cellier-Holzem}, F. and {Childress}, M. and
+             {Chotard}, N. and {Fakhouri}, H.~K. and {Gangler}, E. and {Guy},
+             J. and {Hsiao}, E.~Y. and {Kerschhaggl}, M. and {Kowalski}, M.
+             and {Loken}, S. and {Nugent}, P. and {Paech}, K. and {Pain}, R.
+             and {P{\'e}contal}, E. and {Pereira}, R. and {Perlmutter}, S.
+             and {Rabinowitz}, D. and {Rigault}, M. and {Runge}, K. and
+             {Scalzo}, R. and {Smadja}, G. and {Tao}, C. and {Thomas}, R.~C.
+             and {Weaver}, B.~A. and {Wu}, C. and {Nearby SuperNova Factory}},
+    title = "{Atmospheric extinction properties above Mauna Kea from the Nearby
+              SuperNova Factory spectro-photometric data set}",
+  journal = {\aap},
+     year = 2013,
+    month = Jan,
+   volume = {549},
+      eid = {A8},
+    pages = {A8},
+      doi = {10.1051/0004-6361/201219834},
+   eprint = {1210.2619},
+   adsurl = {https://ui.adsabs.harvard.edu/#abs/2013A&A...549A...8B},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2018SPIE10704E..20C,
+   author = {{Coughlin}, Michael W. and {Deustua}, Susana and {Guyonnet}, Augustin
+             and {Mondrik}, Nicholas and {Rice}, Joseph P. and {Stubbs},
+             Christopher W. and {Woodward}, John T.},
+    title = "{Testing of the LSST's photometric calibration strategy at the CTIO 0.9
+              meter telescope}",
+ keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+booktitle = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
+     year = 2018,
+   volume = {10704},
+    month = Jul,
+      eid = {1070420},
+    pages = {1070420},
+      doi = {10.1117/12.2309582},
+   adsurl = {https://ui.adsabs.harvard.edu/#abs/2018SPIE10704E..20C},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2018MNRAS.477.5477P,
+   author = {{P{\'e}rez-Jord{\'a}n}, w. and {Castro-Almaz{\'a}n}, J.~A. and {Mu{\~n}oz-Tu{\~n}{\'o}n}, C.},
+    title = "{Precipitable water vapour forecasting: a tool for optimizing IR observations at Roque de los Muchachos Observatory}",
+  journal = {\mnras},
+   eprint = {1804.05200},
+ keywords = {atmospheric effects, methods: data analysis, methods: numerical, methods: statistical, site testing, infrared: general},
+     year = 2018,
+    month = jul,
+   volume = 477,
+    pages = {5477-5485},
+      doi = {10.1093/mnras/sty943},
+   adsurl = {http://adsabs.harvard.edu/abs/2018MNRAS.477.5477P},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@MISC{2011ivoa.spec.0711S,
+   author = {{Seaman}, R. and {Williams}, R. and {Allan}, A. and {Barthelmy}, S. and
+	{Bloom}, J. and {Brewer}, J. and {Denny}, R. and {Fitzpatrick}, M. and
+	{Graham}, M. and {Gray}, N. and {Hessman}, F. and {Marka}, S. and
+	{Rots}, A. and {Vestrand}, T. and {Wozniak}, P.},
+    title = "{Sky Event Reporting Metadata Version 2.0}",
+howpublished = {IVOA Recommendation 11 July 2011},
+     year = 2011,
+    month = jul,
+archivePrefix = "arXiv",
+   eprint = {1110.0523},
+ primaryClass = "astro-ph.IM",
+   editor = {{Seaman}, R. and {Williams}, R.},
+   adsurl = {http://adsabs.harvard.edu/abs/2011ivoa.spec.0711S},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2017arXiv170901264A,
+   author = {{Allan}, A. and {Denny}, R.~B. and {Swinbank}, J.~D.},
+    title = "{IVOA Recommendation: VOEvent Transport Protocol Version 2.0}",
+  journal = {arXiv e-prints},
+archivePrefix = "arXiv",
+   eprint = {1709.01264},
+ primaryClass = "astro-ph.IM",
+ keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+     year = 2017,
+    month = sep,
+   adsurl = {http://adsabs.harvard.edu/abs/2017arXiv170901264A},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2014A&C.....7...12S,
+   author = {{Swinbank}, J.},
+    title = "{Comet: A VOEvent broker}",
+  journal = {Astronomy and Computing},
+archivePrefix = "arXiv",
+   eprint = {1409.4805},
+ primaryClass = "astro-ph.IM",
+ keywords = {VOEvent, Astronomical transients, Time domain astrophysics, Network protocol design},
+     year = 2014,
+    month = nov,
+   volume = 7,
+    pages = {12-26},
+      doi = {10.1016/j.ascom.2014.09.001},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2018SPIE10707E..11S,
+       author = {{Street}, R.~A. and {Bowman}, M. and {Saunders}, E.~S. and {Boroson}, T.},
+        title = "{General-purpose software for managing astronomical observing programs in the LSST era}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+    booktitle = {Software and Cyberinfrastructure for Astronomy V},
+         year = 2018,
+       series = {Proc.\ SPIE},
+       volume = {10707},
+        month = Jul,
+          eid = {1070711},
+        pages = {1070711},
+          doi = {10.1117/12.2312293},
+archivePrefix = {arXiv},
+       eprint = {1806.09557},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/\#abs/2018SPIE10707E..11S},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2002cs........8011G,
+       author = {{Gray}, Jim and {Chong}, Wyman and {Barclay}, Tom and {Szalay}, Alex and
+        {vandenBerg}, Jan},
+        title = "{TeraScale SneakerNet: Using Inexpensive Disks for Backup, Archiving, and Data Exchange}",
+      journal = {arXiv e-prints},
+     keywords = {Computer Science - Networking and Internet Architecture, Computer Science - Distributed, Parallel, and Cluster Computing, C.2.0, C.2.4, C.4.4, H.3, K.6},
+         year = 2002,
+        month = Aug,
+          eid = {cs/0208011},
+        pages = {cs/0208011},
+archivePrefix = {arXiv},
+       eprint = {cs/0208011},
+ primaryClass = {cs.NI},
+       adsurl = {https://ui.adsabs.harvard.edu/\#abs/2002cs........8011G},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2019AAS...23324505B,
+       author = {{Bektesevic}, Dino and {Mehta}, Parmita and {Juric}, Mario and
+         {Slater}, Colin and {Balazinska}, Magdalena and {Connolly}, Andrew},
+        title = "{Cloud Services as an environment for large scale astronomical image analytics.}",
+    booktitle = {American Astronomical Society Meeting Abstracts \#233},
+         year = "2019",
+       series = {American Astronomical Society Meeting Abstracts},
+       volume = {233},
+        month = "Jan",
+          eid = {245.05},
+        pages = {245.05},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2019AAS...23324505B},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2019AAS...23345706M,
+       author = {{Momcheva}, Ivelina and {Smith}, Arfon M. and {Fox}, Mike},
+        title = "{Hubble in the Cloud}",
+    booktitle = {American Astronomical Society Meeting Abstracts \#233},
+         year = "2019",
+       series = {American Astronomical Society Meeting Abstracts},
+       volume = {233},
+        month = "Jan",
+          eid = {457.06},
+        pages = {457.06},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2019AAS...23345706M},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2019arXiv190505116B,
+       author = {{Bauer}, Amanda E. and {Bellm}, Eric C. and {Bolton}, Adam S. and
+         {Chaudhuri}, Surajit and {Connolly}, A.~J. and {Cruz}, Kelle L. and
+         {Desai}, Vandana and {Drlica-Wagner}, Alex and {Economou}, Frossie and
+         {Gaffney}, Niall and {Kavelaars}, J. and {Kinney}, J. and
+         {Li}, Ting S. and {Lundgren}, B. and {Margutti}, R. and {Narayan}, G. and
+         {Nord}, B. and {Norman}, Dara J. and {O'Mullane}, W. and {Padhi}, S. and
+         {Peek}, J.~E.~G. and {Schafer}, C. and {Schwamb}, Megan E. and
+         {Smith}, Arfon M. and {Tollerud}, Erik J. and {Weijmans}, Anne-Marie and
+         {Szalay}, Alexander S.},
+        title = "{Petabytes to Science}",
+      journal = {arXiv e-prints},
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+         year = "2019",
+        month = "May",
+          eid = {arXiv:1905.05116},
+        pages = {arXiv:1905.05116},
+archivePrefix = {arXiv},
+       eprint = {1905.05116},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2019arXiv190505116B},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+
+@ARTICLE{2018AJ....155...41B,
+       author = {{Burke}, D.~L. and {Rykoff}, E.~S. and {Allam}, S. and {Annis}, J. and
+         {Bechtol}, K. and {Bernstein}, G.~M. and {Drlica-Wagner}, A. and
+         {Finley}, D.~A. and {Gruendl}, R.~A. and {James}, D.~J.},
+        title = "{Forward Global Photometric Calibration of the Dark Energy Survey}",
+      journal = {\aj},
+     keywords = {methods: observational, techniques: photometric, Astrophysics - Instrumentation and Methods for Astrophysics},
+         year = "2018",
+        month = "Jan",
+       volume = {155},
+       number = {1},
+          eid = {41},
+        pages = {41},
+          doi = {10.3847/1538-3881/aa9f22},
+archivePrefix = {arXiv},
+       eprint = {1706.01542},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2018AJ....155...41B},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+
+@ARTICLE{2018arXiv181208085J,
+       author = {{Jenness}, Tim and {Bosch}, James F. and {Schellart}, Pim and
+         {Lim}, Kian-Ta and {Salnikov}, Andrei and {Gower}, Michelle},
+        title = "{Abstracting the storage and retrieval of image data at the LSST}",
+      journal = {arXiv e-prints},
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+         year = "2018",
+        month = "Dec",
+          eid = {arXiv:1812.08085},
+        pages = {arXiv:1812.08085},
+archivePrefix = {arXiv},
+       eprint = {1812.08085},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2018arXiv181208085J},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+
+@INPROCEEDINGS{2007ASPC..376..347D,
+       author = {{Dowler}, P.~D. and {Gaudet}, S. and {Durand}, D. and {Redman}, R. and
+         {Hill}, N. and {Goliath}, S.},
+        title = "{Common Archive Observation Model}",
+    booktitle = {Astronomical Data Analysis Software and Systems XVI},
+         year = "2007",
+       editor = {{Shaw}, R.~A. and {Hill}, F. and {Bell}, D.~J.},
+       series = {Astronomical Society of the Pacific Conference Series},
+       volume = {376},
+        month = "Oct",
+        pages = {347},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2007ASPC..376..347D},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2018AJ....156..135H,
+   author = {{Holman}, M.~J. and {Payne}, M.~J. and {Blankley}, P. and {Janssen}, R. and
+	{Kuindersma}, S.},
+    title = "{HelioLinC: A Novel Approach to the Minor Planet Linking Problem}",
+  journal = {\aj},
+ keywords = {astrometry, celestial mechanics, ephemerides, minor planets, asteroids: general},
+     year = 2018,
+    month = sep,
+   volume = 156,
+      eid = {135},
+    pages = {135},
+      doi = {10.3847/1538-3881/aad69a},
+   adsurl = {https://ui.adsabs.harvard.edu/abs/2018AJ....156..135H},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2018A&C....24..129M,
+   author = {{Melchior}, P. and {Moolekamp}, F. and {Jerdee}, M. and {Armstrong}, R. and
+	{Sun}, A.-L. and {Bosch}, J. and {Lupton}, R.},
+    title = "{SCARLET: Source separation in multi-band images by Constrained Matrix Factorization}",
+  journal = {Astronomy and Computing},
+archivePrefix = "arXiv",
+   eprint = {1802.10157},
+ primaryClass = "astro-ph.IM",
+ keywords = {Methods, Data analysis, Techniques, Image processing, Galaxies, Non-negative matrix factorization},
+     year = 2018,
+    month = jul,
+   volume = 24,
+    pages = {129--142},
+      doi = {10.1016/j.ascom.2018.07.001},
+   adsurl = {https://ui.adsabs.harvard.edu/abs/2018A%26C....24..129M},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2014JInst...9C3048A,
+   author = {{Antilogus}, P. and {Astier}, P. and {Doherty}, P. and {Guyonnet}, A. and
+	{Regnault}, N.},
+    title = "{The brighter-fatter effect and pixel correlations in CCD sensors}",
+  journal = {Journal of Instrumentation},
+archivePrefix = "arXiv",
+   eprint = {1402.0725},
+ primaryClass = "astro-ph.IM",
+     year = 2014,
+    month = mar,
+   volume = 9,
+      eid = {C03048},
+    pages = {C03048},
+      doi = {10.1088/1748-0221/9/03/C03048},
+   adsurl = {https://ui.adsabs.harvard.edu/abs/2014JInst...9C3048A},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2018arXiv181004815N,
+       author = {{Naghib}, Elahesadat and {Yoachim}, Peter and {Vanderbei}, Robert J. and
+        {Connolly}, Andrew J. and {Jones}, R. Lynne},
+        title = "{A Framework for Telescope Schedulers: With Applications to the Large Synoptic Survey Telescope}",
+      journal = {arXiv e-prints},
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+         year = 2018,
+        month = Oct,
+          eid = {arXiv:1810.04815},
+        pages = {arXiv:1810.04815},
+archivePrefix = {arXiv},
+       eprint = {1810.04815},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/\#abs/2018arXiv181004815N},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2018Icar..303..181J,
+   author = {{Jones}, R.~L. and {Slater}, C.~T. and {Moeyens}, J. and {Allen}, L. and
+	{Axelrod}, T. and {Cook}, K. and {Ivezi{\'c}}, {\v Z}. and {Juri{\'c}}, M. and
+	{Myers}, J. and {Petry}, C.~E.},
+    title = "{The Large Synoptic Survey Telescope as a Near-Earth Object discovery machine}",
+  journal = {\icarus},
+archivePrefix = "arXiv",
+   eprint = {1711.10621},
+ primaryClass = "astro-ph.EP",
+ keywords = {Near-Earth objects, Image processing, Asteroids},
+     year = 2018,
+    month = mar,
+   volume = 303,
+    pages = {181-202},
+      doi = {10.1016/j.icarus.2017.11.033},
+   adsurl = {http://adsabs.harvard.edu/abs/2018Icar..303..181J},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2015arXiv151207914J,
+       author = {{Juri{\'c}}, M. and {Kantor}, J. and {Lim}, K. -T. and {Lupton}, R.~H. and
+         {Dubois-Felsmann}, G. and {Jenness}, T. and {Axelrod}, T.~S. and
+         {Aleksi{\'c}}, J. and {Allsman}, R.~A. and {AlSayyad}, Y. and
+         {Alt}, J. and {Armstrong}, R. and {Basney}, J. and {Becker}, A.~C. and
+         {Becla}, J. and {Biswas}, R. and {Bosch}, J. and {Boutigny}, D. and
+         {Kind}, M.~C. and {Ciardi}, D.~R. and {Connolly}, A.~J. and
+         {Daniel}, S.~F. and {Daues}, G.~E. and {Economou}, F. and
+         {Chiang}, H. -F. and {Fausti}, A. and {Fisher-Levine}, M. and
+         {Freemon}, D.~M. and {Gris}, P. and {Hernandez}, F. and {Hoblitt}, J. and
+         {Ivezi{\'c}}, Z. and {Jammes}, F. and {Jevremovi{\'c}}, D. and
+         {Jones}, R.~L. and {Kalmbach}, J.~B. and {Kasliwal}, V.~P. and
+         {Krughoff}, K.~S. and {Lurie}, J. and {Lust}, N.~B. and
+         {MacArthur}, L.~A. and {Melchior}, P. and {Moeyens}, J. and
+         {Nidever}, D.~L. and {Owen}, R. and {Parejko}, J.~K. and
+         {Peterson}, J.~M. and {Petravick}, D. and {Pietrowicz}, S.~R. and
+         {Price}, P.~A. and {Reiss}, D.~J. and {Shaw}, R.~A. and {Sick}, J. and
+         {Slater}, C.~T. and {Strauss}, M.~A. and {Sullivan}, I.~S. and
+         {Swinbank}, J.~D. and {Van Dyk}, S. and {Vuj{\v{c}}i{\'c}}, V. and
+         {Withers}, A. and {Yoachim}, P.},
+        title = "{The LSST Data Management System}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+    booktitle = {Astronomical Data Analysis Software and Systems XXV},
+         year = "2017",
+       editor = {{Lorente}, N.~P.~F. and {Shortridge}, K. and {Wayth}, R.},
+       series = {ASP Conf.\ Ser.},
+       volume = {512},
+        month = "Dec",
+        pages = {279},
+archivePrefix = {arXiv},
+       eprint = {1512.07914},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2017ASPC..512..279J},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2017ASPC..512..279J,
+       author = {{Juri{\'c}}, M. and {Kantor}, J. and {Lim}, K. -T. and {Lupton}, R.~H. and
+         {Dubois-Felsmann}, G. and {Jenness}, T. and {Axelrod}, T.~S. and
+         {Aleksi{\'c}}, J. and {Allsman}, R.~A. and {AlSayyad}, Y. and
+         {Alt}, J. and {Armstrong}, R. and {Basney}, J. and {Becker}, A.~C. and
+         {Becla}, J. and {Biswas}, R. and {Bosch}, J. and {Boutigny}, D. and
+         {Kind}, M.~C. and {Ciardi}, D.~R. and {Connolly}, A.~J. and
+         {Daniel}, S.~F. and {Daues}, G.~E. and {Economou}, F. and
+         {Chiang}, H. -F. and {Fausti}, A. and {Fisher-Levine}, M. and
+         {Freemon}, D.~M. and {Gris}, P. and {Hernandez}, F. and {Hoblitt}, J. and
+         {Ivezi{\'c}}, Z. and {Jammes}, F. and {Jevremovi{\'c}}, D. and
+         {Jones}, R.~L. and {Kalmbach}, J.~B. and {Kasliwal}, V.~P. and
+         {Krughoff}, K.~S. and {Lurie}, J. and {Lust}, N.~B. and
+         {MacArthur}, L.~A. and {Melchior}, P. and {Moeyens}, J. and
+         {Nidever}, D.~L. and {Owen}, R. and {Parejko}, J.~K. and
+         {Peterson}, J.~M. and {Petravick}, D. and {Pietrowicz}, S.~R. and
+         {Price}, P.~A. and {Reiss}, D.~J. and {Shaw}, R.~A. and {Sick}, J. and
+         {Slater}, C.~T. and {Strauss}, M.~A. and {Sullivan}, I.~S. and
+         {Swinbank}, J.~D. and {Van Dyk}, S. and {Vuj{\v{c}}i{\'c}}, V. and
+         {Withers}, A. and {Yoachim}, P.},
+        title = "{The LSST Data Management System}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+    booktitle = {Astronomical Data Analysis Software and Systems XXV},
+         year = "2017",
+       editor = {{Lorente}, N.~P.~F. and {Shortridge}, K. and {Wayth}, R.},
+       series = {ASP Conf.\ Ser.},
+       volume = {512},
+        month = "Dec",
+        pages = {279},
+archivePrefix = {arXiv},
+       eprint = {1512.07914},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2017ASPC..512..279J},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2014SPIE.9145E..1AG,
+   author = {{Gressler}, W. and {DeVries}, J. and {Hileman}, E. and {Neill}, D.~R. and {Sebag}, J. and {Wiecha}, O. and {Andrew}, J. and {Lotz}, P. and  {Schoening}, W.},
+   title = "{LSST Telescope and site status}",
+   series = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
+   booktitle = {Ground-based and Airborne Telescopes V},
+   editor = {Larry M. Stepp and Roberto Gilmozzi and Helen J. Hall},
+   year = 2014,
+   volume = 9145,
+   month = jul,
+   eid = {91451A},
+   pages = {1},
+   doi = {10.1117/12.2056711},
+   adsurl = {http://adsabs.harvard.edu/abs/2014SPIE.9145E..1AG},
+   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+   }
+
+@INPROCEEDINGS{2014SPIE.9150E..0MC,
+   author = {{Claver}, C.~F. and {Selvy}, B.~M. and {Angeli}, G. and {Delgado}, F. and
+	{Dubois-Felsmann}, G. and {Hascall}, P. and {Lotz}, P. and {Marshall}, S. and
+	{Schumacher}, G. and {Sebag}, J.},
+    title = "{Systems engineering in the Large Synoptic Survey Telescope project: an application of model based systems engineering}",
+   series = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
+booktitle = {Modeling, Systems Engineering, and Project Management for Astronomy VI},
+   editor = {George Z. Angeli and Philippe Dierickx},
+     year = 2014,
+   volume = 9150,
+      eid = {91500M},
+    pages = {0},
+      doi = {10.1117/12.2056781},
+   adsurl = {http://adsabs.harvard.edu/abs/2014SPIE.9150E..0MC},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+
+@INPROCEEDINGS{2014SPIE.9149E..0BJ,
+   author = {{Jones}, R.~L. and {Yoachim}, P. and {Chandrasekharan}, S. and {Connolly}, A.~J. and {Cook}, K.~H. and {Ivezic}, {\v Z}. and  {Krughoff}, K.~S. and {Petry}, C. and {Ridgway}, S.~T.},
+    title = "{The LSST metrics analysis framework (MAF)}",
+    series = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
+    booktitle = {Observatory Operations: Strategies, Processes, and Systems V},
+    editor = {Alison B. Peck and Chris R. Benn and Robert L. Seaman},
+    year = 2014,
+    volume = 9149,
+    eid = {91490B},
+    pages = {0},
+    doi = {10.1117/12.2056835},
+    adsurl = {http://adsabs.harvard.edu/abs/2014SPIE.9149E..0BJ},
+   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+
+@INPROCEEDINGS{2014SPIE.9150E..15D,
+   author = {{Delgado}, F. and {Saha}, A. and {Chandrasekharan}, S. and {Cook}, K. and {Petry}, C. and {Ridgway}, S.},
+    title = "{The LSST operations simulator}",
+    series = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
+    booktitle = {Modeling, Systems Engineering, and Project Management for Astronomy VI},
+    editor = {George Z. Angeli and Philippe Dierickx},
+    year = {2014},
+    volume = 9150,
+    eid = {915015},
+    pages = {15},
+    doi = {10.1117/12.2056898},
+    adsurl = {http://adsabs.harvard.edu/abs/2014SPIE.9150E..15D},
+   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2010SPIE.7735E..0JK,
+   author = {{Kahn}, S.~M. and {Kurita}, N. and {Gilmore}, K. and {Nordby}, M. and
+	{O'Connor}, P. and {Schindler}, R. and {Oliver}, J. and {Van Berg}, R. and
+	{Olivier}, S. and {Riot}, V. and {Antilogus}, P. and {Schalk}, T. and
+	{Huffer}, M. and {Bowden}, G. and {Singal}, J. and {Foss}, M.
+	},
+    title = "{Design and development of the 3.2 gigapixel camera for the Large Synoptic Survey Telescope}",
+   series = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
+booktitle = {Ground-based and Airborne Instrumentation for Astronomy III},
+   editor = {Ian S. McLean and Suzanne K. Ramsay and Hideki Takami},
+     year = 2010,
+   volume = 7735,
+      eid = {77350J},
+    pages = {0},
+      doi = {10.1117/12.857920},
+   adsurl = {http://adsabs.harvard.edu/abs/2010SPIE.7735E..0JK},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2014SPIE.9150E..14C,
+   author = {{Connolly}, A.~J. and {Angeli}, G.~Z. and {Chandrasekharan}, S. and {Claver}, C.~F. and {Cook}, K. and {Ivezic}, Z. and {Jones}, R.~L. and   {Krughoff}, K.~S. and {Peng}, E.-H. and {Peterson}, J. and {Petry}, C. and    {Rasmussen}, A.~P. and {Ridgway}, S.~T. and {Saha}, A. and {Sembroski}, G. and    {vanderPlas}, J. and {Yoachim}, P.},
+    title = "{An end-to-end simulation framework for the Large Synoptic Survey Telescope}",
+    series = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
+    booktitle = {Modeling, Systems Engineering, and Project Management for Astronomy VI},
+    editor = {George Z. Angeli and Philippe Dierickx},
+    year = 2014,
+    volume = 9150,
+    eid = {915014},
+    pages = {14},
+    doi = {10.1117/12.2054953},
+    adsurl = {http://adsabs.harvard.edu/abs/2014SPIE.9150E..14C},
+    adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2014SPIE.9150E..0NS,
+   author = {{Selvy}, B.~M. and {Claver}, C. and {Angeli}, G.},
+    title = "{Using SysML for verification and validation planning on the Large Synoptic Survey Telescope (LSST)}",
+   series = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
+booktitle = {Modeling, Systems Engineering, and Project Management for Astronomy VI},
+   editor = {George Z. Angeli and Philippe Dierickx},
+     year = 2014,
+   volume = 9150,
+      eid = {91500N},
+    pages = {0},
+      doi = {10.1117/12.2056773},
+   adsurl = {http://adsabs.harvard.edu/abs/2014SPIE.9150E..0NS},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2018PASJ...70S...5B,
+   author = {{Bosch}, J. and {Armstrong}, R. and {Bickerton}, S. and {Furusawa}, H. and
+        {Ikeda}, H. and {Koike}, M. and {Lupton}, R. and {Mineo}, S. and
+        {Price}, P. and {Takata}, T. and {Tanaka}, M. and {Yasuda}, N. and
+        {AlSayyad}, Y. and {Becker}, A.~C. and {Coulton}, W. and {Coupon}, J. and
+        {Garmilla}, J. and {Huang}, S. and {Krughoff}, K.~S. and {Lang}, D. and
+        {Leauthaud}, A. and {Lim}, K.-T. and {Lust}, N.~B. and {MacArthur}, L.~A. and
+        {Mandelbaum}, R. and {Miyatake}, H. and {Miyazaki}, S. and {Murata}, R. and
+        {More}, S. and {Okura}, Y. and {Owen}, R. and {Swinbank}, J.~D. and
+        {Strauss}, M.~A. and {Yamada}, Y. and {Yamanoi}, H.},
+    title = "{The Hyper Suprime-Cam software pipeline}",
+  journal = {\pasj},
+archivePrefix = "arXiv",
+   eprint = {1705.06766},
+ primaryClass = "astro-ph.IM",
+ keywords = {methods: data analysis, surveys, techniques: image processing},
+     year = 2018,
+    month = jan,
+   volume = 70,
+      eid = {S5},
+    pages = {S5},
+      doi = {10.1093/pasj/psx080},
+   adsurl = {http://adsabs.harvard.edu/abs/2018PASJ...70S...5B},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2018AJ....156..123A,
+       author = {{Astropy Collaboration} and {Price-Whelan}, A.~M. and
+         {Sip{\H{o}}cz}, B.~M. and {G{\"u}nther}, H.~M. and {Lim}, P.~L. and
+         {Crawford}, S.~M. and {Conseil}, S. and {Shupe}, D.~L. and
+         {Craig}, M.~W. and {Dencheva}, N. and {Ginsburg}, A. and {Vand
+        erPlas}, J.~T. and {Bradley}, L.~D. and {P{\'e}rez-Su{\'a}rez}, D. and
+         {de Val-Borro}, M. and {Aldcroft}, T.~L. and {Cruz}, K.~L. and
+         {Robitaille}, T.~P. and {Tollerud}, E.~J. and {Ardelean}, C. and
+         {Babej}, T. and {Bach}, Y.~P. and {Bachetti}, M. and {Bakanov}, A.~V. and
+         {Bamford}, S.~P. and {Barentsen}, G. and {Barmby}, P. and
+         {Baumbach}, A. and {Berry}, K.~L. and {Biscani}, F. and {Boquien}, M. and
+         {Bostroem}, K.~A. and {Bouma}, L.~G. and {Brammer}, G.~B. and
+         {Bray}, E.~M. and {Breytenbach}, H. and {Buddelmeijer}, H. and
+         {Burke}, D.~J. and {Calderone}, G. and {Cano Rodr{\'\i}guez}, J.~L. and
+         {Cara}, M. and {Cardoso}, J.~V.~M. and {Cheedella}, S. and {Copin}, Y. and
+         {Corrales}, L. and {Crichton}, D. and {D'Avella}, D. and {Deil}, C. and
+         {Depagne}, {\'E}. and {Dietrich}, J.~P. and {Donath}, A. and
+         {Droettboom}, M. and {Earl}, N. and {Erben}, T. and {Fabbro}, S. and
+         {Ferreira}, L.~A. and {Finethy}, T. and {Fox}, R.~T. and
+         {Garrison}, L.~H. and {Gibbons}, S.~L.~J. and {Goldstein}, D.~A. and
+         {Gommers}, R. and {Greco}, J.~P. and {Greenfield}, P. and
+         {Groener}, A.~M. and {Grollier}, F. and {Hagen}, A. and {Hirst}, P. and
+         {Homeier}, D. and {Horton}, A.~J. and {Hosseinzadeh}, G. and {Hu}, L. and
+         {Hunkeler}, J.~S. and {Ivezi{\'c}}, {\v{Z}}. and {Jain}, A. and
+         {Jenness}, T. and {Kanarek}, G. and {Kendrew}, S. and {Kern}, N.~S. and
+         {Kerzendorf}, W.~E. and {Khvalko}, A. and {King}, J. and {Kirkby}, D. and
+         {Kulkarni}, A.~M. and {Kumar}, A. and {Lee}, A. and {Lenz}, D. and
+         {Littlefair}, S.~P. and {Ma}, Z. and {Macleod}, D.~M. and
+         {Mastropietro}, M. and {McCully}, C. and {Montagnac}, S. and
+         {Morris}, B.~M. and {Mueller}, M. and {Mumford}, S.~J. and {Muna}, D. and
+         {Murphy}, N.~A. and {Nelson}, S. and {Nguyen}, G.~H. and
+         {Ninan}, J.~P. and {N{\"o}the}, M. and {Ogaz}, S. and {Oh}, S. and
+         {Parejko}, J.~K. and {Parley}, N. and {Pascual}, S. and {Patil}, R. and
+         {Patil}, A.~A. and {Plunkett}, A.~L. and {Prochaska}, J.~X. and
+         {Rastogi}, T. and {Reddy Janga}, V. and {Sabater}, J. and
+         {Sakurikar}, P. and {Seifert}, M. and {Sherbert}, L.~E. and
+         {Sherwood-Taylor}, H. and {Shih}, A.~Y. and {Sick}, J. and
+         {Silbiger}, M.~T. and {Singanamalla}, S. and {Singer}, L.~P. and
+         {Sladen}, P.~H. and {Sooley}, K.~A. and {Sornarajah}, S. and
+         {Streicher}, O. and {Teuben}, P. and {Thomas}, S.~W. and
+         {Tremblay}, G.~R. and {Turner}, J.~E.~H. and {Terr{\'o}n}, V. and
+         {van Kerkwijk}, M.~H. and {de la Vega}, A. and {Watkins}, L.~L. and
+         {Weaver}, B.~A. and {Whitmore}, J.~B. and {Woillez}, J. and
+         {Zabalza}, V. and {Astropy Contributors}},
+        title = "{The Astropy Project: Building an Open-science Project and Status of the v2.0 Core Package}",
+      journal = {\aj},
+     keywords = {methods: data analysis, methods: miscellaneous, methods: statistical, reference systems, Astrophysics - Instrumentation and Methods for Astrophysics},
+         year = "2018",
+        month = "Sep",
+       volume = {156},
+       number = {3},
+          eid = {123},
+        pages = {123},
+          doi = {10.3847/1538-3881/aabc4f},
+archivePrefix = {arXiv},
+       eprint = {1801.02634},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2018AJ....156..123A},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2005Scons1377085,
+   author = {S. Knight},
+  journal = {Computing in Science Engineering},
+    title = "{Building software with SCons}",
+     year = {2005},
+   volume = {7},
+   number = {1},
+    pages = {79-88},
+ keywords = {configuration management;programming environments;software libraries;software tools;SCons;commercial packages;har
+dware platforms;next-generation software build tool;open-source packages;operating systems;software building;software creation
+;software libraries;software package;software programming;software projects;source code;Buildings;Open source software;Operati
+ng systems;Packaging;Program processors;Software libraries;Software packages;libraries;programming;software},
+      doi = {10.1109/MCSE.2005.11},
+     ISSN = {1521-9615},
+}
+
+@MISC{2017ivoa.spec.0519F,
+   author = {{Fernique}, P. and {Allen}, M. and {Boch}, T. and {Donaldson}, T. and
+	{Durand}, D. and {Ebisawa}, K. and {Michel}, L. and {Salgado}, J. and
+	{Stoehr}, F.},
+    title = "{HiPS - Hierarchical Progressive Survey Version 1.0}",
+howpublished = {IVOA Recommendation 19 May 2017},
+     year = 2017,
+    month = may,
+archivePrefix = "arXiv",
+   eprint = {1708.09704},
+ primaryClass = "astro-ph.IM",
+   editor = {{Fernique}, P.},
+      doi = {10.5479/ADS/bib/2017ivoa.spec.0519F},
+   adsurl = {https://ui.adsabs.harvard.edu/abs/2017ivoa.spec.0519F},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2019arXiv190713060O,
+       author = {{O'Mullane}, William and {Gaffney}, Niall and {Economou}, Frossie and
+         {Smith}, Arfon M. and {Thomson}, J. Ross and {Jenness}, Tim},
+        title = "{The demise of the filesystem and multi level service architecture}",
+      journal = {arXiv e-prints},
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics, Computer Science - Databases},
+         year = "2019",
+        month = "Jul",
+          eid = {arXiv:1907.13060},
+        pages = {arXiv:1907.13060},
+archivePrefix = {arXiv},
+       eprint = {1907.13060},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2019arXiv190713060O},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2015ApOpt..54.9045X,
+       author = {{Xin}, Bo and {Claver}, Chuck and {Liang}, Ming and {Chand
+        rasekharan}, Srinivasan and {Angeli}, George and {Shipsey}, Ian},
+        title = "{Curvature wavefront sensing for the large synoptic survey telescope}",
+      journal = {\ao},
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+         year = "2015",
+        month = "Oct",
+       volume = {54},
+       number = {30},
+        pages = {9045},
+          doi = {10.1364/AO.54.009045},
+archivePrefix = {arXiv},
+       eprint = {1506.04839},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2015ApOpt..54.9045X},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INBOOK{2016SPIE.9911E..18A,
+       author = {{Angeli}, G.~Z. and {Xin}, B. and {Claver}, C. and {Cho}, M. and
+         {Dribusch}, C. and {Neill}, D. and {Peterson}, J. and {Sebag}, J. and
+         {Thomas}, S.},
+        title = "{An integrated modeling framework for the Large Synoptic Survey Telescope (LSST)}",
+    booktitle = {\procspie},
+         year = "2016",
+       volume = {9911},
+       series = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
+          eid = {991118},
+        pages = {991118},
+          doi = {10.1117/12.2234078},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2016SPIE.9911E..18A},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2018SPIE10705E..0PX,
+       author = {{Xin}, Bo and {Claver}, Chuck F. and {Ivezi{\'c}}, {\v{Z}}eljko and
+         {Jones}, Lynne and {Peterson}, John and {Selvy}, Brian and
+         {Daniel}, Scott and {Yoachim}, Peter},
+        title = "{Monitoring LSST system performance during construction}",
+    booktitle = {\procspie},
+         year = "2018",
+       series = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
+       volume = {10705},
+        month = "Jul",
+          eid = {107050P},
+        pages = {107050P},
+          doi = {10.1117/12.2313880},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2018SPIE10705E..0PX},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INBOOK{2016SPIE.9906E..4JX,
+       author = {{Xin}, Bo and {Roodman}, Aaron and {Angeli}, George and {Claver}, Chuck and
+         {Thomas}, Sandrine},
+        title = "{Comparison of LSST and DECam wavefront recovery algorithms}",
+    booktitle = {\procspie},
+         year = "2016",
+       volume = {9906},
+       series = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
+          eid = {99064J},
+        pages = {99064J},
+          doi = {10.1117/12.2234456},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2016SPIE.9906E..4JX},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INBOOK{2014SPIE.9150E..0HA,
+       author = {{Angeli}, George Z. and {Xin}, Bo and {Claver}, Charles and
+         {MacMartin}, Douglas and {Neill}, Douglas and {Britton}, Matthew and
+         {Sebag}, Jacques and {Chandrasekharan}, Srinivasan},
+        title = "{Real time wavefront control system for the Large Synoptic Survey Telescope (LSST)}",
+    booktitle = {\procspie},
+         year = "2014",
+       volume = {9150},
+       series = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
+          eid = {91500H},
+        pages = {91500H},
+          doi = {10.1117/12.2055390},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2014SPIE.9150E..0HA},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INBOOK{2012SPIE.8444E..4PC,
+       author = {{Claver}, Charles F. and {Chandrasekharan}, Srinivasan and
+         {Liang}, Ming and {Xin}, Bo and {Alagoz}, Enver and {Arndt}, Kirk and
+         {Shipsey}, Ian P.},
+        title = "{Prototype pipeline for LSST wavefront sensing and reconstruction}",
+    booktitle = {\procspie},
+         year = "2012",
+       volume = {8444},
+       series = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
+          eid = {84444P},
+        pages = {84444P},
+          doi = {10.1117/12.926472},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2012SPIE.8444E..4PC},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2011PASP..123..812S,
+       author = {{Schechter}, Paul L. and {Sobel Levinson}, Rebecca},
+        title = "{Generic Misalignment Aberration Patterns in Wide-Field Telescopes}",
+      journal = {\pasp},
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+         year = "2011",
+        month = "Jul",
+       volume = {123},
+       number = {905},
+        pages = {812},
+          doi = {10.1086/661111},
+archivePrefix = {arXiv},
+       eprint = {1009.0708},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2011PASP..123..812S},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INBOOK{2012SPIE.8444E..55S,
+       author = {{Schechter}, Paul L. and {Levinson}, Rebecca Sobel},
+        title = "{Generic misalignment aberration patterns and the subspace of benign misalignment}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+    booktitle = {\procspie},
+         year = "2012",
+       volume = {8444},
+       series = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
+          eid = {844455},
+        pages = {844455},
+          doi = {10.1117/12.925075},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2012SPIE.8444E..55S},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2017ApJ...841...24S,
+       author = {{Sheldon}, Erin S. and {Huff}, Eric M.},
+        title = "{Practical Weak-lensing Shear Measurement with Metacalibration}",
+      journal = {\apj},
+     keywords = {cosmology: observations, gravitational lensing: weak, methods: observational, Astrophysics - Cosmology and Nongalactic Astrophysics},
+         year = "2017",
+        month = "May",
+       volume = {841},
+       number = {1},
+          eid = {24},
+        pages = {24},
+          doi = {10.3847/1538-4357/aa704b},
+archivePrefix = {arXiv},
+       eprint = {1702.02601},
+ primaryClass = {astro-ph.CO},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2017ApJ...841...24S},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2016MNRAS.459.4467B,
+       author = {{Bernstein}, Gary M. and {Armstrong}, Robert and {Krawiec}, Christina and
+         {March}, Marisa C.},
+        title = "{An accurate and practical method for inference of weak gravitational lensing from galaxy images}",
+      journal = {\mnras},
+     keywords = {gravitational lensing: weak, methods: data analysis, Astrophysics - Instrumentation and Methods for Astrophysics, Astrophysics - Cosmology and Nongalactic Astrophysics},
+         year = "2016",
+        month = "Jul",
+       volume = {459},
+       number = {4},
+        pages = {4467-4484},
+          doi = {10.1093/mnras/stw879},
+archivePrefix = {arXiv},
+       eprint = {1508.05655},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2016MNRAS.459.4467B},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }


### PR DESCRIPTION
The `.gitattributes` file now helps suppress the vendored bibtex files from [GitHub pull requests and linguist stats](https://docs.github.com/en/github/administering-a-repository/customizing-how-changed-files-appear-on-github).