### PR TITLE
[DM-30907] Fix version number for FastAPI applications

### DIFF
--- a/project_templates/fastapi_safir_app/example/.dockerignore
+++ b/project_templates/fastapi_safir_app/example/.dockerignore
@@ -1,7 +1,3 @@
-# Some additional things to ignore beyond what .gitignore already handles.
-# We cannot exclude the .git directory because setuptools_scm requires it.
-tests/
-
 # Everything below this point is a copy of .gitignore.
 
 # Byte-compiled / optimized / DLL files

--- a/project_templates/fastapi_safir_app/example/.github/workflows/ci.yaml
+++ b/project_templates/fastapi_safir_app/example/.github/workflows/ci.yaml
@@ -49,6 +49,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Define the Docker tag
         id: vars

--- a/project_templates/fastapi_safir_app/example/Dockerfile
+++ b/project_templates/fastapi_safir_app/example/Dockerfile
@@ -43,8 +43,8 @@ FROM dependencies-image AS install-image
 # Use the virtualenv
 ENV PATH="/opt/venv/bin:$PATH"
 
-COPY . /app
-WORKDIR /app
+COPY . /workdir
+WORKDIR /workdir
 RUN pip install --no-cache-dir .
 
 FROM base-image AS runtime-image

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/.dockerignore
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/.dockerignore
@@ -1,7 +1,3 @@
-# Some additional things to ignore beyond what .gitignore already handles.
-# We cannot exclude the .git directory because setuptools_scm requires it.
-tests/
-
 # Everything below this point is a copy of .gitignore.
 
 # Byte-compiled / optimized / DLL files

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/.github/workflows/ci.yaml
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/.github/workflows/ci.yaml
@@ -49,6 +49,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Define the Docker tag
         id: vars

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/Dockerfile
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/Dockerfile
@@ -43,8 +43,8 @@ FROM dependencies-image AS install-image
 # Use the virtualenv
 ENV PATH="/opt/venv/bin:$PATH"
 
-COPY . /app
-WORKDIR /app
+COPY . /workdir
+WORKDIR /workdir
 RUN pip install --no-cache-dir .
 
 FROM base-image AS runtime-image


### PR DESCRIPTION
The version number was incorrectly set to a development working
version instead of the tagged version when building from a tag.
Fix this by including tags in the checkout so that setuptools_scm
can use them, not excluding any files from the Docker copy, and
using a separate working directory from the /app directory that's
used by the FastAPI image.