### PR TITLE
[DM-31361] Use metadata for FastAPI app summary

### DIFF
--- a/project_templates/fastapi_safir_app/example/src/example/main.py
+++ b/project_templates/fastapi_safir_app/example/src/example/main.py
@@ -34,7 +34,7 @@ app = FastAPI()
 # interface definition and documentation URLs under the external URL.
 _subapp = FastAPI(
     title="example",
-    description="Short one-sentence summary of the app",
+    description=metadata("example").get("Summary", ""),
     version=metadata("example").get("Version", "0.0.0"),
 )
 _subapp.include_router(external_router)

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/src/{{cookiecutter.package_name}}/main.py
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/src/{{cookiecutter.package_name}}/main.py
@@ -34,7 +34,7 @@ app = FastAPI()
 # interface definition and documentation URLs under the external URL.
 _subapp = FastAPI(
     title="{{ cookiecutter.name }}",
-    description="{{ cookiecutter.summary }}",
+    description=metadata("{{ cookiecutter.package_name }}").get("Summary", ""),
     version=metadata("{{ cookiecutter.package_name }}").get("Version", "0.0.0"),
 )
 _subapp.include_router(external_router)

--- a/project_templates/latex_lsstdoc/EXAMPLE-0/bibentry.txt
+++ b/project_templates/latex_lsstdoc/EXAMPLE-0/bibentry.txt
@@ -4,6 +4,6 @@
    author = { First Author },
     title = {Document Title},
      year = 2021,
-    month = Jun,
+    month = Aug,
    handle = {EXAMPLE-0},
       url = {https://example-0-0.lsst.io } }

--- a/project_templates/latex_lsstdoc/EXAMPLE/bibentry.txt
+++ b/project_templates/latex_lsstdoc/EXAMPLE/bibentry.txt
@@ -4,6 +4,6 @@
    author = { First Author },
     title = {Document Title},
      year = 2021,
-    month = Jun,
+    month = Aug,
    handle = {EXAMPLE},
       url = {https://example-.lsst.io } }

--- a/project_templates/technote_latex/testn-000/bibentry.txt
+++ b/project_templates/technote_latex/testn-000/bibentry.txt
@@ -4,6 +4,6 @@
    author = { First Last },
     title = {Document Title},
      year = 2021,
-    month = Jun,
+    month = Aug,
    handle = {TESTN-000},
       url = {https://testn-000.lsst.io } }

--- a/project_templates/technote_rst/testn-000/bibentry.txt
+++ b/project_templates/technote_rst/testn-000/bibentry.txt
@@ -4,6 +4,6 @@
    author = { First Last },
     title = {Document Title},
      year = 2021,
-    month = Jun,
+    month = Aug,
    handle = {TESTN-000},
       url = {https://testn-000.lsst.io } }

--- a/project_templates/test_report/TESTTR-0/bibentry.txt
+++ b/project_templates/test_report/TESTTR-0/bibentry.txt
@@ -4,6 +4,6 @@
    author = { First Author },
     title = {Document Title},
      year = 2021,
-    month = Jun,
+    month = Aug,
    handle = {TESTTR-0},
       url = {https://testtr-0.lsst.io } }


### PR DESCRIPTION
Rather than hard-coding the value from the template, pull it from
setup.cfg so that subsequent changes only have to be made in one
place.