### PR TITLE
[DM-31621] Fix Docker builds on ticket branches

### DIFF
--- a/project_templates/fastapi_safir_app/example/.github/workflows/ci.yaml
+++ b/project_templates/fastapi_safir_app/example/.github/workflows/ci.yaml
@@ -11,6 +11,8 @@ name: CI
       - "renovate/**"
       - "tickets/**"
       - "u/**"
+    tags:
+      - "*"
   pull_request: {}
 
 jobs:
@@ -55,8 +57,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
 
-    # Only do Docker builds of ticket branches and tagged releases.
-    if: startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/tickets/')
+    # Only do Docker builds of tagged releases and pull requests from ticket
+    # branches.  This will still trigger on pull requests from untrusted
+    # repositories whose branch names match our tickets/* branch convention,
+    # but in this case the build will fail with an error since the secret
+    # won't be set.
+    if: >
+      startsWith(github.ref, 'refs/tags/')
+      || startsWith(github.head_ref, 'tickets/')
 
     steps:
       - uses: actions/checkout@v2

--- a/project_templates/fastapi_safir_app/example/src/example/handlers/external.py
+++ b/project_templates/fastapi_safir_app/example/src/example/handlers/external.py
@@ -32,7 +32,7 @@ async def get_index(
     Customize this handler to return whatever the top-level resource of your
     application should return. For example, consider listing key API URLs.
     When doing so, also change or customize the response model in
-    example.models.metadata.
+    `example.models.Index`.
 
     By convention, the root of the external API includes a field called
     ``metadata`` that provides the same Safir-generated metadata as the

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/.github/workflows/ci.yaml
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/.github/workflows/ci.yaml
@@ -11,6 +11,8 @@ name: CI
       - "renovate/**"
       - "tickets/**"
       - "u/**"
+    tags:
+      - "*"
   pull_request: {}
 
 jobs:
@@ -55,8 +57,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
 
-    # Only do Docker builds of ticket branches and tagged releases.
-    if: startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/tickets/')
+    # Only do Docker builds of tagged releases and pull requests from ticket
+    # branches.  This will still trigger on pull requests from untrusted
+    # repositories whose branch names match our tickets/* branch convention,
+    # but in this case the build will fail with an error since the secret
+    # won't be set.
+    if: >
+      startsWith(github.ref, 'refs/tags/')
+      || startsWith(github.head_ref, 'tickets/')
 
     steps:
       - uses: actions/checkout@v2

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/src/{{cookiecutter.package_name}}/handlers/external.py
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/src/{{cookiecutter.package_name}}/handlers/external.py
@@ -32,7 +32,7 @@ async def get_index(
     Customize this handler to return whatever the top-level resource of your
     application should return. For example, consider listing key API URLs.
     When doing so, also change or customize the response model in
-    {{ cookiecutter.package_name }}.models.metadata.
+    `{{ cookiecutter.package_name }}.models.Index`.
 
     By convention, the root of the external API includes a field called
     ``metadata`` that provides the same Safir-generated metadata as the

--- a/project_templates/roundtable_aiohttp_bot/example/.github/workflows/ci.yaml
+++ b/project_templates/roundtable_aiohttp_bot/example/.github/workflows/ci.yaml
@@ -11,6 +11,8 @@ name: CI
       - "renovate/**"
       - "tickets/**"
       - "u/**"
+    tags:
+      - "*"
   pull_request: {}
 
 jobs:
@@ -55,8 +57,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
 
-    # Only do Docker builds of ticket branches and tagged releases.
-    if: startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/tickets/')
+    # Only do Docker builds of tagged releases and pull requests from ticket
+    # branches.  This will still trigger on pull requests from untrusted
+    # repositories whose branch names match our tickets/* branch convention,
+    # but in this case the build will fail with an error since the secret
+    # won't be set.
+    if: >
+      startsWith(github.ref, 'refs/tags/')
+      || startsWith(github.head_ref, 'tickets/')
 
     steps:
       - uses: actions/checkout@v2

--- a/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/.github/workflows/ci.yaml
+++ b/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/.github/workflows/ci.yaml
@@ -11,6 +11,8 @@ name: CI
       - "renovate/**"
       - "tickets/**"
       - "u/**"
+    tags:
+      - "*"
   pull_request: {}
 
 jobs:
@@ -55,8 +57,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
 
-    # Only do Docker builds of ticket branches and tagged releases.
-    if: startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/tickets/')
+    # Only do Docker builds of tagged releases and pull requests from ticket
+    # branches.  This will still trigger on pull requests from untrusted
+    # repositories whose branch names match our tickets/* branch convention,
+    # but in this case the build will fail with an error since the secret
+    # won't be set.
+    if: >
+      startsWith(github.ref, 'refs/tags/')
+      || startsWith(github.head_ref, 'tickets/')
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The change to run CI workflows on pull requests and to avoid running
them on pushes to branches that will be pull requests broke running
the Docker build because github.ref is different for pull request
workflows.  Fix this by looking at the head_ref instead, to trigger
Docker builds for pull requests from ticket branches.

It's not entirely clear form the GitHub Actions documentation
whether having a branches_ignore key prevents running the action
on tags, so be explicit.