### PR TITLE
Small fixes to the FastAPI and aiohttp package templates

### DIFF
--- a/project_templates/fastapi_safir_app/example/LICENSE
+++ b/project_templates/fastapi_safir_app/example/LICENSE
@@ -1,7 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2021
-  Association of Universities for Research in Astronomy, Inc. (AURA)
+Copyright (c) 2021 Association of Universities for Research in Astronomy, Inc. (AURA)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/LICENSE
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/LICENSE
@@ -1,7 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) {{ cookiecutter.copyright_year }}
-  {{ cookiecutter.copyright_holder }}
+Copyright (c) {{ cookiecutter.copyright_year }} {{ cookiecutter.copyright_holder }}
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/src/{{cookiecutter.package_name}}/handlers/external.py
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/src/{{cookiecutter.package_name}}/handlers/external.py
@@ -44,7 +44,7 @@ async def get_index(
     logger.info("Request for application metadata")
 
     metadata = get_metadata(
-        package_name="{{ cookiecutter.package_name }}",
+        package_name="{{ cookiecutter.name }}",
         application_name=config.name,
     )
     return Index(metadata=metadata)

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/src/{{cookiecutter.package_name}}/handlers/internal.py
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/src/{{cookiecutter.package_name}}/handlers/internal.py
@@ -1,7 +1,7 @@
 """Internal HTTP handlers that serve relative to the root path, ``/``.
 
 These handlers aren't externally visible since the app is available at a path,
-``/{{ cookiecutter.package_name }}``. See `{{ cookiecutter.package_name }}.handlers.external` for
+``/{{ cookiecutter.name }}``. See `{{ cookiecutter.package_name }}.handlers.external` for
 the external endpoint handlers.
 
 These handlers should be used for monitoring, health checks, internal status,
@@ -36,6 +36,6 @@ async def get_index() -> Metadata:
     By convention, this endpoint returns only the application's metadata.
     """
     return get_metadata(
-        package_name="{{ cookiecutter.package_name }}",
+        package_name="{{ cookiecutter.name }}",
         application_name=config.name,
     )

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/src/{{cookiecutter.package_name}}/main.py
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/src/{{cookiecutter.package_name}}/main.py
@@ -34,8 +34,8 @@ app = FastAPI()
 # interface definition and documentation URLs under the external URL.
 _subapp = FastAPI(
     title="{{ cookiecutter.name }}",
-    description=metadata("{{ cookiecutter.package_name }}").get("Summary", ""),
-    version=metadata("{{ cookiecutter.package_name }}").get("Version", "0.0.0"),
+    description=metadata("{{ cookiecutter.name }}").get("Summary", ""),
+    version=metadata("{{ cookiecutter.name }}").get("Version", "0.0.0"),
 )
 _subapp.include_router(external_router)
 

--- a/project_templates/latex_lsstdoc/EXAMPLE-0/bibentry.txt
+++ b/project_templates/latex_lsstdoc/EXAMPLE-0/bibentry.txt
@@ -4,6 +4,6 @@
    author = { First Author },
     title = {Document Title},
      year = 2021,
-    month = Sep,
+    month = Oct,
    handle = {EXAMPLE-0},
       url = {https://example-0-0.lsst.io } }

--- a/project_templates/latex_lsstdoc/EXAMPLE/bibentry.txt
+++ b/project_templates/latex_lsstdoc/EXAMPLE/bibentry.txt
@@ -4,6 +4,6 @@
    author = { First Author },
     title = {Document Title},
      year = 2021,
-    month = Sep,
+    month = Oct,
    handle = {EXAMPLE},
       url = {https://example-.lsst.io } }

--- a/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/src/{{cookiecutter.package_name}}/app.py
+++ b/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/src/{{cookiecutter.package_name}}/app.py
@@ -23,7 +23,7 @@ def create_app() -> web.Application:
 
     root_app = web.Application()
     root_app["safir/config"] = config
-    setup_metadata(package_name="{{ cookiecutter.package_name }}", app=root_app)
+    setup_metadata(package_name="{{ cookiecutter.name }}", app=root_app)
     setup_middleware(root_app)
     root_app.add_routes(init_internal_routes())
     root_app.cleanup_ctx.append(init_http_session)

--- a/project_templates/technote_latex/testn-000/bibentry.txt
+++ b/project_templates/technote_latex/testn-000/bibentry.txt
@@ -4,6 +4,6 @@
    author = { First Last },
     title = {Document Title},
      year = 2021,
-    month = Sep,
+    month = Oct,
    handle = {TESTN-000},
       url = {https://testn-000.lsst.io } }

--- a/project_templates/technote_rst/testn-000/bibentry.txt
+++ b/project_templates/technote_rst/testn-000/bibentry.txt
@@ -4,6 +4,6 @@
    author = { First Last },
     title = {Document Title},
      year = 2021,
-    month = Sep,
+    month = Oct,
    handle = {TESTN-000},
       url = {https://testn-000.lsst.io } }

--- a/project_templates/test_report/TESTTR-0/bibentry.txt
+++ b/project_templates/test_report/TESTTR-0/bibentry.txt
@@ -4,6 +4,6 @@
    author = { First Author },
     title = {Document Title},
      year = 2021,
-    month = Sep,
+    month = Oct,
    handle = {TESTTR-0},
       url = {https://testtr-0.lsst.io } }


### PR DESCRIPTION
This PR makes a few small fixes/improvements to the aiohttp and FastAPI application templates:

1. Put the copyright entity on the same line as the copyright. This is a better default.
2. Change the argument to the metadata functions to use the name set in `setup.cfg`, rather than the package namespace. importlib uses the package name rather than the Python namespace (the naming of these variables makes it easy to confuse which variable is appropriate). This fix only affects packages that use a hyphen or underscore in their names.