### PR TITLE
[DM-31621] Fix Docker tags for app workflows

### DIFF
--- a/project_templates/fastapi_safir_app/example/.github/workflows/ci.yaml
+++ b/project_templates/fastapi_safir_app/example/.github/workflows/ci.yaml
@@ -22,8 +22,9 @@ jobs:
     strategy:
       matrix:
         python:
-          - 3.8
-          - 3.9
+          - "3.8"
+          - "3.9"
+          - "3.10"
 
     steps:
       - uses: actions/checkout@v2
@@ -73,7 +74,7 @@ jobs:
 
       - name: Define the Docker tag
         id: vars
-        run: echo ::set-output name=tag::$(scripts/docker-tag.sh "$GITHUB_REF")
+        run: echo ::set-output name=tag::$(scripts/docker-tag.sh)
 
       - name: Print the tag
         id: print

--- a/project_templates/fastapi_safir_app/example/scripts/docker-tag.sh
+++ b/project_templates/fastapi_safir_app/example/scripts/docker-tag.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 
-# Determine the tag for Docker images.  Takes the Git ref as its only
-# argument.
+# Determine the tag for Docker images based on GitHub Actions environment
+# variables.
 
 set -eo pipefail
 
-if [ -z "$1" ]; then
-    echo 'Usage: scripts/docker-tag.sh $GITHUB_REF' >&2
-    exit 1
+if [ -n "$GITHUB_HEAD_REF" ]; then
+    # For pull requests
+    echo ${GITHUB_HEAD_REF} | sed -E 's,/,-,g'
+else
+    # For push events
+    echo ${GITHUB_REF} | sed -E 's,refs/(heads|tags)/,,' | sed -E 's,/,-,g'
 fi
-
-echo "$1" | sed -E 's,refs/(heads|tags)/,,' | sed -E 's,/,-,g'

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/.github/workflows/ci.yaml
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/.github/workflows/ci.yaml
@@ -22,8 +22,9 @@ jobs:
     strategy:
       matrix:
         python:
-          - 3.8
-          - 3.9
+          - "3.8"
+          - "3.9"
+          - "3.10"
 
     steps:
       - uses: actions/checkout@v2
@@ -73,7 +74,7 @@ jobs:
 
       - name: Define the Docker tag
         id: vars
-        run: echo ::set-output name=tag::$(scripts/docker-tag.sh "$GITHUB_REF")
+        run: echo ::set-output name=tag::$(scripts/docker-tag.sh)
 
       - name: Print the tag
         id: print

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/scripts/docker-tag.sh
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/scripts/docker-tag.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 
-# Determine the tag for Docker images.  Takes the Git ref as its only
-# argument.
+# Determine the tag for Docker images based on GitHub Actions environment
+# variables.
 
 set -eo pipefail
 
-if [ -z "$1" ]; then
-    echo 'Usage: scripts/docker-tag.sh $GITHUB_REF' >&2
-    exit 1
+if [ -n "$GITHUB_HEAD_REF" ]; then
+    # For pull requests
+    echo ${GITHUB_HEAD_REF} | sed -E 's,/,-,g'
+else
+    # For push events
+    echo ${GITHUB_REF} | sed -E 's,refs/(heads|tags)/,,' | sed -E 's,/,-,g'
 fi
-
-echo "$1" | sed -E 's,refs/(heads|tags)/,,' | sed -E 's,/,-,g'

--- a/project_templates/latex_lsstdoc/EXAMPLE-0/bibentry.txt
+++ b/project_templates/latex_lsstdoc/EXAMPLE-0/bibentry.txt
@@ -4,6 +4,6 @@
    author = { First Author },
     title = {Document Title},
      year = 2021,
-    month = Oct,
+    month = Nov,
    handle = {EXAMPLE-0},
       url = {https://example-0-0.lsst.io } }

--- a/project_templates/latex_lsstdoc/EXAMPLE/bibentry.txt
+++ b/project_templates/latex_lsstdoc/EXAMPLE/bibentry.txt
@@ -4,6 +4,6 @@
    author = { First Author },
     title = {Document Title},
      year = 2021,
-    month = Oct,
+    month = Nov,
    handle = {EXAMPLE},
       url = {https://example-.lsst.io } }

--- a/project_templates/roundtable_aiohttp_bot/example/.github/workflows/ci.yaml
+++ b/project_templates/roundtable_aiohttp_bot/example/.github/workflows/ci.yaml
@@ -22,8 +22,9 @@ jobs:
     strategy:
       matrix:
         python:
-          - 3.8
-          - 3.9
+          - "3.8"
+          - "3.9"
+          - "3.10"
 
     steps:
       - uses: actions/checkout@v2
@@ -34,7 +35,7 @@ jobs:
           python-version: ${{ matrix.python }}
 
       - name: Run pre-commit
-        uses: pre-commit/action@v2.0.0
+        uses: pre-commit/action@v2.0.3
 
       - name: Install tox
         run: pip install tox
@@ -68,10 +69,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Define the Docker tag
         id: vars
-        run: echo ::set-output name=tag::$(scripts/docker-tag.sh "$GITHUB_REF")
+        run: echo ::set-output name=tag::$(scripts/docker-tag.sh)
 
       - name: Print the tag
         id: print

--- a/project_templates/roundtable_aiohttp_bot/example/scripts/docker-tag.sh
+++ b/project_templates/roundtable_aiohttp_bot/example/scripts/docker-tag.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 
-# Determine the tag for Docker images.  Takes the Git ref as its only
-# argument.
+# Determine the tag for Docker images based on GitHub Actions environment
+# variables.
 
 set -eo pipefail
 
-if [ -z "$1" ]; then
-    echo 'Usage: scripts/docker-tag.sh $GITHUB_REF' >&2
-    exit 1
+if [ -n "$GITHUB_HEAD_REF" ]; then
+    # For pull requests
+    echo ${GITHUB_HEAD_REF} | sed -E 's,/,-,g'
+else
+    # For push events
+    echo ${GITHUB_REF} | sed -E 's,refs/(heads|tags)/,,' | sed -E 's,/,-,g'
 fi
-
-echo "$1" | sed -E 's,refs/(heads|tags)/,,' | sed -E 's,/,-,g'

--- a/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/.github/workflows/ci.yaml
+++ b/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/.github/workflows/ci.yaml
@@ -22,8 +22,9 @@ jobs:
     strategy:
       matrix:
         python:
-          - 3.8
-          - 3.9
+          - "3.8"
+          - "3.9"
+          - "3.10"
 
     steps:
       - uses: actions/checkout@v2
@@ -34,7 +35,7 @@ jobs:
           python-version: {{ "${{ matrix.python }}" }}
 
       - name: Run pre-commit
-        uses: pre-commit/action@v2.0.0
+        uses: pre-commit/action@v2.0.3
 
       - name: Install tox
         run: pip install tox
@@ -68,10 +69,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Define the Docker tag
         id: vars
-        run: echo ::set-output name=tag::$(scripts/docker-tag.sh "$GITHUB_REF")
+        run: echo ::set-output name=tag::$(scripts/docker-tag.sh)
 
       - name: Print the tag
         id: print

--- a/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/scripts/docker-tag.sh
+++ b/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/scripts/docker-tag.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 
-# Determine the tag for Docker images.  Takes the Git ref as its only
-# argument.
+# Determine the tag for Docker images based on GitHub Actions environment
+# variables.
 
 set -eo pipefail
 
-if [ -z "$1" ]; then
-    echo 'Usage: scripts/docker-tag.sh $GITHUB_REF' >&2
-    exit 1
+if [ -n "$GITHUB_HEAD_REF" ]; then
+    # For pull requests
+    echo ${GITHUB_HEAD_REF} | sed -E 's,/,-,g'
+else
+    # For push events
+    echo ${GITHUB_REF} | sed -E 's,refs/(heads|tags)/,,' | sed -E 's,/,-,g'
 fi
-
-echo "$1" | sed -E 's,refs/(heads|tags)/,,' | sed -E 's,/,-,g'

--- a/project_templates/technote_latex/testn-000/bibentry.txt
+++ b/project_templates/technote_latex/testn-000/bibentry.txt
@@ -4,6 +4,6 @@
    author = { First Last },
     title = {Document Title},
      year = 2021,
-    month = Oct,
+    month = Nov,
    handle = {TESTN-000},
       url = {https://testn-000.lsst.io } }

--- a/project_templates/technote_rst/testn-000/bibentry.txt
+++ b/project_templates/technote_rst/testn-000/bibentry.txt
@@ -4,6 +4,6 @@
    author = { First Last },
     title = {Document Title},
      year = 2021,
-    month = Oct,
+    month = Nov,
    handle = {TESTN-000},
       url = {https://testn-000.lsst.io } }

--- a/project_templates/test_report/TESTTR-0/bibentry.txt
+++ b/project_templates/test_report/TESTTR-0/bibentry.txt
@@ -4,6 +4,6 @@
    author = { First Author },
     title = {Document Title},
      year = 2021,
-    month = Oct,
+    month = Nov,
    handle = {TESTTR-0},
       url = {https://testtr-0.lsst.io } }


### PR DESCRIPTION
In the roundtable_aiohttp_bot and fastapi_safir_app project
templates, fix the script to determine the Docker tag of a build
to work correctly with pull requests as well as pushes.  Add
Python 3.10 to the default test matrix for both app types.

In the roundtable_aiohttp_bot project template, set fetch-depth
to 0 when building Docker images (matching fastapi_safir_app) so
that setuptools_scm will generate correct version numbers.

Taken from @jonathansick's fixes for noteburst.