### PR TITLE
[DM-32556] Stop using FastAPI Docker image

### DIFF
--- a/project_templates/fastapi_safir_app/example/Dockerfile
+++ b/project_templates/fastapi_safir_app/example/Dockerfile
@@ -14,7 +14,7 @@
 #   - Runs a non-root user.
 #   - Sets up the entrypoint and port.
 
-FROM tiangolo/uvicorn-gunicorn:python3.8-slim as base-image
+FROM python:3.9.8-slim-bullseye as base-image
 
 # Update system packages
 COPY scripts/install-base-packages.sh .
@@ -49,24 +49,20 @@ RUN pip install --no-cache-dir .
 
 FROM base-image AS runtime-image
 
+# Create a non-root user
+RUN useradd --create-home appuser
+
 # Copy the virtualenv
 COPY --from=install-image /opt/venv /opt/venv
 
 # Make sure we use the virtualenv
 ENV PATH="/opt/venv/bin:$PATH"
 
-# We use a module name other than app, so tell the base image that.  This
-# does not copy the app into /app as is recommended by the base Docker
-# image documentation and instead relies on the module search path as
-# modified by the virtualenv.
-ENV MODULE_NAME=example.main
+# Switch to the non-root user.
+USER appuser
 
-# The default starts 40 workers, which exhausts the available connections
-# on a micro Cloud SQL PostgreSQL server and seems excessive since we can
-# scale with Kubernetes.  Most of our applications are tiny so cap the
-# workers at 2.
-ENV MAX_WORKERS=2
+# Expose the port.
+EXPOSE 8080
 
-# Run on port 8080 instead of the FastAPI default to avoid requiring
-# capabilities.
-ENV PORT=8080
+# Run the application.
+CMD ["uvicorn", "example.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/project_templates/fastapi_safir_app/example/requirements/dev.in
+++ b/project_templates/fastapi_safir_app/example/requirements/dev.in
@@ -15,4 +15,3 @@ pre-commit
 pytest
 pytest-asyncio
 pytest-cov
-uvicorn

--- a/project_templates/fastapi_safir_app/example/requirements/main.in
+++ b/project_templates/fastapi_safir_app/example/requirements/main.in
@@ -7,7 +7,6 @@
 
 # These dependencies are for fastapi including some optional features.
 fastapi
-gunicorn
 starlette
 uvicorn[standard]
 

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/Dockerfile
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/Dockerfile
@@ -14,7 +14,7 @@
 #   - Runs a non-root user.
 #   - Sets up the entrypoint and port.
 
-FROM tiangolo/uvicorn-gunicorn:python3.8-slim as base-image
+FROM python:3.9.8-slim-bullseye as base-image
 
 # Update system packages
 COPY scripts/install-base-packages.sh .
@@ -49,24 +49,20 @@ RUN pip install --no-cache-dir .
 
 FROM base-image AS runtime-image
 
+# Create a non-root user
+RUN useradd --create-home appuser
+
 # Copy the virtualenv
 COPY --from=install-image /opt/venv /opt/venv
 
 # Make sure we use the virtualenv
 ENV PATH="/opt/venv/bin:$PATH"
 
-# We use a module name other than app, so tell the base image that.  This
-# does not copy the app into /app as is recommended by the base Docker
-# image documentation and instead relies on the module search path as
-# modified by the virtualenv.
-ENV MODULE_NAME={{ cookiecutter.package_name }}.main
+# Switch to the non-root user.
+USER appuser
 
-# The default starts 40 workers, which exhausts the available connections
-# on a micro Cloud SQL PostgreSQL server and seems excessive since we can
-# scale with Kubernetes.  Most of our applications are tiny so cap the
-# workers at 2.
-ENV MAX_WORKERS=2
+# Expose the port.
+EXPOSE 8080
 
-# Run on port 8080 instead of the FastAPI default to avoid requiring
-# capabilities.
-ENV PORT=8080
+# Run the application.
+CMD ["uvicorn", "{{ cookiecutter.package_name }}.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/requirements/dev.in
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/requirements/dev.in
@@ -15,4 +15,3 @@ pre-commit
 pytest
 pytest-asyncio
 pytest-cov
-uvicorn

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/requirements/main.in
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/requirements/main.in
@@ -7,7 +7,6 @@
 
 # These dependencies are for fastapi including some optional features.
 fastapi
-gunicorn
 starlette
 uvicorn[standard]
 


### PR DESCRIPTION
For the fastapi_safir_app template, stop using the FastAPI Docker
image as a base since it's been deprecated upstream.  It uses
gunicorn to start a bunch of worker processes, which is unnecessary
in Kubernetes (one can just spawn more pods) and often not desired
for applications that use in-memory data structures and should only
run one copy.

Instead, base the Docker image on the normal Python base image and
run the application directly using uvicorn.  Remove gunicorn from
the default dependencies.