### PR TITLE
Install pre-commit during make init

### DIFF
--- a/project_templates/fastapi_safir_app/example/Makefile
+++ b/project_templates/fastapi_safir_app/example/Makefile
@@ -9,7 +9,7 @@ init:
 	pip install --editable .
 	pip install --upgrade -r requirements/main.txt -r requirements/dev.txt
 	rm -rf .tox
-	pip install --upgrade tox
+	pip install --upgrade pre-commit tox
 	pre-commit install
 
 .PHONY: update

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/Makefile
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/Makefile
@@ -9,7 +9,7 @@ init:
 	pip install --editable .
 	pip install --upgrade -r requirements/main.txt -r requirements/dev.txt
 	rm -rf .tox
-	pip install --upgrade tox
+	pip install --upgrade pre-commit tox
 	pre-commit install
 
 .PHONY: update

--- a/project_templates/roundtable_aiohttp_bot/example/Makefile
+++ b/project_templates/roundtable_aiohttp_bot/example/Makefile
@@ -9,7 +9,7 @@ init:
 	pip install --editable .
 	pip install --upgrade -r requirements/main.txt -r requirements/dev.txt
 	rm -rf .tox
-	pip install --upgrade tox
+	pip install --upgrade pre-commit tox
 	pre-commit install
 
 .PHONY: update

--- a/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/Makefile
+++ b/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/Makefile
@@ -9,7 +9,7 @@ init:
 	pip install --editable .
 	pip install --upgrade -r requirements/main.txt -r requirements/dev.txt
 	rm -rf .tox
-	pip install --upgrade tox
+	pip install --upgrade pre-commit tox
 	pre-commit install
 
 .PHONY: update


### PR DESCRIPTION
I think this is a reasonable choice because the next command relies on pre-commit being installed. For example, a clean virtual environment may not have pre-commit installed yet, so we'd want to handle that for the developer.