### PR TITLE
[DM-33719] Use new GitHub Action Docker build caching

### DIFF
--- a/project_templates/fastapi_safir_app/example/.github/workflows/ci.yaml
+++ b/project_templates/fastapi_safir_app/example/.github/workflows/ci.yaml
@@ -83,14 +83,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys:
-            ${{ runner.os }}-buildx-
-
       - name: Log in to Docker Hub
         uses: docker/login-action@v1
         with:
@@ -103,13 +95,5 @@ jobs:
           context: .
           push: true
           tags: lsstsqre/example:${{ steps.vars.outputs.tag }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new
-
-      # Temp fix
-      # https://github.com/docker/build-push-action/issues/252
-      # https://github.com/moby/buildkit/issues/1896
-      - name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/.github/workflows/ci.yaml
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/.github/workflows/ci.yaml
@@ -83,14 +83,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: {{ "${{ runner.os }}" }}-buildx-{{ "${{ github.sha }}" }}
-          restore-keys:
-            {{ "${{ runner.os }}" }}-buildx-
-
       - name: Log in to Docker Hub
         uses: docker/login-action@v1
         with:
@@ -103,13 +95,5 @@ jobs:
           context: .
           push: true
           tags: lsstsqre/{{ cookiecutter.package_name }}:{{ "${{ steps.vars.outputs.tag }}" }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new
-
-      # Temp fix
-      # https://github.com/docker/build-push-action/issues/252
-      # https://github.com/moby/buildkit/issues/1896
-      - name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/project_templates/latex_lsstdoc/EXAMPLE-0/bibentry.txt
+++ b/project_templates/latex_lsstdoc/EXAMPLE-0/bibentry.txt
@@ -4,6 +4,6 @@
    author = { First Author },
     title = {Document Title},
      year = 2022,
-    month = Jan,
+    month = Feb,
    handle = {EXAMPLE-0},
       url = {https://example-0-0.lsst.io } }

--- a/project_templates/latex_lsstdoc/EXAMPLE/bibentry.txt
+++ b/project_templates/latex_lsstdoc/EXAMPLE/bibentry.txt
@@ -4,6 +4,6 @@
    author = { First Author },
     title = {Document Title},
      year = 2022,
-    month = Jan,
+    month = Feb,
    handle = {EXAMPLE},
       url = {https://example-.lsst.io } }

--- a/project_templates/roundtable_aiohttp_bot/example/.github/workflows/ci.yaml
+++ b/project_templates/roundtable_aiohttp_bot/example/.github/workflows/ci.yaml
@@ -83,14 +83,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys:
-            ${{ runner.os }}-buildx-
-
       - name: Log in to Docker Hub
         uses: docker/login-action@v1
         with:
@@ -103,13 +95,5 @@ jobs:
           context: .
           push: true
           tags: lsstsqre/example:${{ steps.vars.outputs.tag }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new
-
-      # Temp fix
-      # https://github.com/docker/build-push-action/issues/252
-      # https://github.com/moby/buildkit/issues/1896
-      - name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/.github/workflows/ci.yaml
+++ b/project_templates/roundtable_aiohttp_bot/{{cookiecutter.name}}/.github/workflows/ci.yaml
@@ -83,14 +83,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: {{ "${{ runner.os }}" }}-buildx-{{ "${{ github.sha }}" }}
-          restore-keys:
-            {{ "${{ runner.os }}" }}-buildx-
-
       - name: Log in to Docker Hub
         uses: docker/login-action@v1
         with:
@@ -103,13 +95,5 @@ jobs:
           context: .
           push: true
           tags: lsstsqre/{{ cookiecutter.package_name }}:{{ "${{ steps.vars.outputs.tag }}" }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new
-
-      # Temp fix
-      # https://github.com/docker/build-push-action/issues/252
-      # https://github.com/moby/buildkit/issues/1896
-      - name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/project_templates/technote_latex/testn-000/bibentry.txt
+++ b/project_templates/technote_latex/testn-000/bibentry.txt
@@ -4,6 +4,6 @@
    author = { First Last },
     title = {Document Title},
      year = 2022,
-    month = Jan,
+    month = Feb,
    handle = {TESTN-000},
       url = {https://testn-000.lsst.io } }

--- a/project_templates/technote_rst/testn-000/bibentry.txt
+++ b/project_templates/technote_rst/testn-000/bibentry.txt
@@ -4,6 +4,6 @@
    author = { First Last },
     title = {Document Title},
      year = 2022,
-    month = Jan,
+    month = Feb,
    handle = {TESTN-000},
       url = {https://testn-000.lsst.io } }

--- a/project_templates/test_report/TESTTR-0/bibentry.txt
+++ b/project_templates/test_report/TESTTR-0/bibentry.txt
@@ -4,6 +4,6 @@
    author = { First Author },
     title = {Document Title},
      year = 2022,
-    month = Jan,
+    month = Feb,
    handle = {TESTTR-0},
       url = {https://testtr-0.lsst.io } }


### PR DESCRIPTION
Switch the caching for Docker builds to the new GitHub Actions
cache, and remove the workaround for the problems with the local
cache.

This was tested with vo-cutouts.