### PR TITLE
[DM-33604] Update pytest fixtures for fastapi_safir_app

### DIFF
--- a/project_templates/fastapi_safir_app/example/pyproject.toml
+++ b/project_templates/fastapi_safir_app/example/pyproject.toml
@@ -53,3 +53,18 @@ include_trailing_comma = true
 multi_line_output = 3
 known_first_party = ["example", "tests"]
 skip = ["docs/conf.py"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "strict"
+# The python_files setting is not for test detection (pytest will pick up any
+# test files named *_test.py without this setting) but to enable special
+# assert processing in any non-test supporting files under tests.  We
+# conventionally put test support functions under tests.support and may
+# sometimes use assert in test fixtures in conftest.py, and pytest only
+# enables magical assert processing (showing a full diff on assert failures
+# with complex data structures rather than only the assert message) in files
+# listed in python_files.
+python_files = [
+    "tests/*.py",
+    "tests/*/*.py"
+]

--- a/project_templates/fastapi_safir_app/example/tests/conftest.py
+++ b/project_templates/fastapi_safir_app/example/tests/conftest.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pytest
+import pytest_asyncio
 from asgi_lifespan import LifespanManager
 from httpx import AsyncClient
 
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from fastapi import FastAPI
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def app() -> AsyncIterator[FastAPI]:
     """Return a configured test application.
 
@@ -27,7 +27,7 @@ async def app() -> AsyncIterator[FastAPI]:
         yield main.app
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def client(app: FastAPI) -> AsyncIterator[AsyncClient]:
     """Return an ``httpx.AsyncClient`` configured to talk to the test app."""
     async with AsyncClient(app=app, base_url="https://example.com/") as client:

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/pyproject.toml
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/pyproject.toml
@@ -53,3 +53,18 @@ include_trailing_comma = true
 multi_line_output = 3
 known_first_party = ["{{ cookiecutter.package_name }}", "tests"]
 skip = ["docs/conf.py"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "strict"
+# The python_files setting is not for test detection (pytest will pick up any
+# test files named *_test.py without this setting) but to enable special
+# assert processing in any non-test supporting files under tests.  We
+# conventionally put test support functions under tests.support and may
+# sometimes use assert in test fixtures in conftest.py, and pytest only
+# enables magical assert processing (showing a full diff on assert failures
+# with complex data structures rather than only the assert message) in files
+# listed in python_files.
+python_files = [
+    "tests/*.py",
+    "tests/*/*.py"
+]

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/tests/conftest.py
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/tests/conftest.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pytest
+import pytest_asyncio
 from asgi_lifespan import LifespanManager
 from httpx import AsyncClient
 
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from fastapi import FastAPI
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def app() -> AsyncIterator[FastAPI]:
     """Return a configured test application.
 
@@ -27,7 +27,7 @@ async def app() -> AsyncIterator[FastAPI]:
         yield main.app
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def client(app: FastAPI) -> AsyncIterator[AsyncClient]:
     """Return an ``httpx.AsyncClient`` configured to talk to the test app."""
     async with AsyncClient(app=app, base_url="https://example.com/") as client:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,5 @@
 templatekit>=0.4.0,<0.5.0
+
+# templatekit depends on Jinja2<3, which is incompatible with MarkupSafe
+# 2.0.1 and later.
+MarkupSafe<2.0.1


### PR DESCRIPTION
Enable strict asyncio mode and mark the fixtures accordingly, to
support the latest pytest-asyncio.  Tell pytest that all Python
files under tests are tests, so that pytest will automatically
generate verbose diffs for failed asserts.

Tested by creating an example application and confirming that all
of its tests passed without warnings.