### PR TITLE
[DM-34075] Update FastAPI template for 3.10, drop 3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ See [Troubleshooting](#troubleshooting) for solutions to common issues.
 **Project templates** have multiple files and are intended to bootstrap new Git repositories.
 Find these templates in the `project_templates/` directory:
 
+- [fastapi_safir_app](project_templates/fastapi_safir_app/)
 - [latex_lsstdoc](project_templates/latex_lsstdoc/)
 - [nbreport](project_templates/nbreport/)
 - [roundtable_aiohttp_bot](project_templates/roundtable_aiohttp_bot/)

--- a/project_templates/fastapi_safir_app/example/.github/workflows/ci.yaml
+++ b/project_templates/fastapi_safir_app/example/.github/workflows/ci.yaml
@@ -22,7 +22,6 @@ jobs:
     strategy:
       matrix:
         python:
-          - "3.8"
           - "3.9"
           - "3.10"
 

--- a/project_templates/fastapi_safir_app/example/Dockerfile
+++ b/project_templates/fastapi_safir_app/example/Dockerfile
@@ -14,7 +14,7 @@
 #   - Runs a non-root user.
 #   - Sets up the entrypoint and port.
 
-FROM python:3.9.8-slim-bullseye as base-image
+FROM python:3.10.2-slim-bullseye as base-image
 
 # Update system packages
 COPY scripts/install-base-packages.sh .

--- a/project_templates/fastapi_safir_app/example/setup.cfg
+++ b/project_templates/fastapi_safir_app/example/setup.cfg
@@ -16,8 +16,8 @@ classifiers =
     License :: OSI Approved :: MIT License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Natural Language :: English
     Operating System :: POSIX
 keywords =
@@ -29,7 +29,7 @@ include_package_data = True
 package_dir =
     = src
 packages=find:
-python_requires = >=3.8
+python_requires = >=3.9
 setup_requires =
     setuptools_scm
 # Use requirements/main.in for runtime dependencies instead of install_requires

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/.github/workflows/ci.yaml
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/.github/workflows/ci.yaml
@@ -22,7 +22,6 @@ jobs:
     strategy:
       matrix:
         python:
-          - "3.8"
           - "3.9"
           - "3.10"
 

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/Dockerfile
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/Dockerfile
@@ -14,7 +14,7 @@
 #   - Runs a non-root user.
 #   - Sets up the entrypoint and port.
 
-FROM python:3.9.8-slim-bullseye as base-image
+FROM python:3.10.2-slim-bullseye as base-image
 
 # Update system packages
 COPY scripts/install-base-packages.sh .

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/setup.cfg
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/setup.cfg
@@ -16,8 +16,8 @@ classifiers =
     License :: OSI Approved :: MIT License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Natural Language :: English
     Operating System :: POSIX
 keywords =
@@ -29,7 +29,7 @@ include_package_data = True
 package_dir =
     = src
 packages=find:
-python_requires = >=3.8
+python_requires = >=3.9
 setup_requires =
     setuptools_scm
 # Use requirements/main.in for runtime dependencies instead of install_requires


### PR DESCRIPTION
Add Python 3.10 for new FastAPI projects, drop Python 3.8 support,
and set the default Docker image to use Python 3.10.  Keep 3.9 in
the matrix since it may be required for packages with a Kafka
dependency.