### PR TITLE
[DM-34075] Push FastAPI apps to GHCR by default

### DIFF
--- a/project_templates/fastapi_safir_app/example/.github/workflows/ci.yaml
+++ b/project_templates/fastapi_safir_app/example/.github/workflows/ci.yaml
@@ -88,11 +88,20 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
           context: .
           push: true
-          tags: lsstsqre/example:${{ steps.vars.outputs.tag }}
+          tags: |
+            lsstsqre/example:${{ steps.vars.outputs.tag }}
+            ghcr.io/lsst-sqre/example:${{ steps.vars.outputs.tag }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/.github/workflows/ci.yaml
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/.github/workflows/ci.yaml
@@ -88,11 +88,20 @@ jobs:
           username: {{ "${{ secrets.DOCKER_USERNAME }}" }}
           password: {{ "${{ secrets.DOCKER_TOKEN }}" }}
 
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: {{ "${{ github.repository_owner }}" }}
+          password: {{ "${{ secrets.GITHUB_TOKEN }}" }}
+
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
           context: .
           push: true
-          tags: lsstsqre/{{ cookiecutter.package_name }}:{{ "${{ steps.vars.outputs.tag }}" }}
+          tags: |
+            lsstsqre/{{ cookiecutter.package_name }}:{{ "${{ steps.vars.outputs.tag }}" }}
+            ghcr.io/lsst-sqre/{{ cookiecutter.package_name }}:{{ "${{ steps.vars.outputs.tag }}" }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
Add the GitHub Container Registry as a default target for Docker
images for FastAPI Safir apps.