### PR TITLE
[DM-34075] Stop using subapps for FastAPI apps

### DIFF
--- a/project_templates/fastapi_safir_app/example/src/example/handlers/internal.py
+++ b/project_templates/fastapi_safir_app/example/src/example/handlers/internal.py
@@ -26,6 +26,7 @@ internal_router = APIRouter()
         " a health check. This route is not exposed outside the cluster and"
         " therefore cannot be used by external clients."
     ),
+    include_in_schema=False,
     response_model=Metadata,
     response_model_exclude_none=True,
     summary="Application metadata",

--- a/project_templates/fastapi_safir_app/example/src/example/main.py
+++ b/project_templates/fastapi_safir_app/example/src/example/main.py
@@ -27,21 +27,19 @@ configure_logging(
     name=config.logger_name,
 )
 
-app = FastAPI()
-"""The main FastAPI application for example."""
-
-# Define the external routes in a subapp so that it will serve its own OpenAPI
-# interface definition and documentation URLs under the external URL.
-_subapp = FastAPI(
+app = FastAPI(
     title="example",
     description=metadata("example").get("Summary", ""),
     version=metadata("example").get("Version", "0.0.0"),
+    openapi_url=f"/{config.name}/openapi.json",
+    docs_url=f"/{config.name}/docs",
+    redoc_url=f"/{config.name}/redoc",
 )
-_subapp.include_router(external_router)
+"""The main FastAPI application for example."""
 
-# Attach the internal routes and subapp to the main application.
+# Attach the routers.
 app.include_router(internal_router)
-app.mount(f"/{config.name}", _subapp)
+app.include_router(external_router, prefix=f"/{config.name}")
 
 
 @app.on_event("startup")

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/src/{{cookiecutter.package_name}}/handlers/internal.py
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/src/{{cookiecutter.package_name}}/handlers/internal.py
@@ -26,6 +26,7 @@ internal_router = APIRouter()
         " a health check. This route is not exposed outside the cluster and"
         " therefore cannot be used by external clients."
     ),
+    include_in_schema=False,
     response_model=Metadata,
     response_model_exclude_none=True,
     summary="Application metadata",

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/src/{{cookiecutter.package_name}}/main.py
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/src/{{cookiecutter.package_name}}/main.py
@@ -27,21 +27,19 @@ configure_logging(
     name=config.logger_name,
 )
 
-app = FastAPI()
-"""The main FastAPI application for {{ cookiecutter.name }}."""
-
-# Define the external routes in a subapp so that it will serve its own OpenAPI
-# interface definition and documentation URLs under the external URL.
-_subapp = FastAPI(
+app = FastAPI(
     title="{{ cookiecutter.name }}",
     description=metadata("{{ cookiecutter.name }}").get("Summary", ""),
     version=metadata("{{ cookiecutter.name }}").get("Version", "0.0.0"),
+    openapi_url=f"/{config.name}/openapi.json",
+    docs_url=f"/{config.name}/docs",
+    redoc_url=f"/{config.name}/redoc",
 )
-_subapp.include_router(external_router)
+"""The main FastAPI application for {{ cookiecutter.name }}."""
 
-# Attach the internal routes and subapp to the main application.
+# Attach the routers.
 app.include_router(internal_router)
-app.mount(f"/{config.name}", _subapp)
+app.include_router(external_router, prefix=f"/{config.name}")
 
 
 @app.on_event("startup")


### PR DESCRIPTION
Unfortunately, FastAPI or Starlette has a bug where exceptions
thrown by subapps are swallowed and not logged by the parent app.
Since we can simulate what we were doing with subapps using
routers, use a single FastAPI app by default to avoid this problem.

Mark the internal top-level route as undocumented so that it won't
be added to the public-facing API documentation, matching the
previous behavior where the subapp was exposing its own separate
API documentation.

We do lose the internal API documentation for non-visible routes,
but this doesn't seem like a significant loss.