### PR TITLE
[DM-34075] Stop using if TYPE_CHECKING in FastAPI template

### DIFF
--- a/project_templates/fastapi_safir_app/example/tests/conftest.py
+++ b/project_templates/fastapi_safir_app/example/tests/conftest.py
@@ -2,18 +2,14 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import AsyncIterator
 
 import pytest_asyncio
 from asgi_lifespan import LifespanManager
+from fastapi import FastAPI
 from httpx import AsyncClient
 
 from example import main
-
-if TYPE_CHECKING:
-    from typing import AsyncIterator
-
-    from fastapi import FastAPI
 
 
 @pytest_asyncio.fixture

--- a/project_templates/fastapi_safir_app/example/tests/handlers/external_test.py
+++ b/project_templates/fastapi_safir_app/example/tests/handlers/external_test.py
@@ -2,14 +2,10 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import pytest
+from httpx import AsyncClient
 
 from example.config import config
-
-if TYPE_CHECKING:
-    from httpx import AsyncClient
 
 
 @pytest.mark.asyncio

--- a/project_templates/fastapi_safir_app/example/tests/handlers/internal_test.py
+++ b/project_templates/fastapi_safir_app/example/tests/handlers/internal_test.py
@@ -2,14 +2,10 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import pytest
+from httpx import AsyncClient
 
 from example.config import config
-
-if TYPE_CHECKING:
-    from httpx import AsyncClient
 
 
 @pytest.mark.asyncio

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/tests/conftest.py
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/tests/conftest.py
@@ -2,18 +2,14 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import AsyncIterator
 
 import pytest_asyncio
 from asgi_lifespan import LifespanManager
+from fastapi import FastAPI
 from httpx import AsyncClient
 
 from {{ cookiecutter.package_name }} import main
-
-if TYPE_CHECKING:
-    from typing import AsyncIterator
-
-    from fastapi import FastAPI
 
 
 @pytest_asyncio.fixture

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/tests/handlers/external_test.py
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/tests/handlers/external_test.py
@@ -2,14 +2,10 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import pytest
+from httpx import AsyncClient
 
 from {{ cookiecutter.package_name }}.config import config
-
-if TYPE_CHECKING:
-    from httpx import AsyncClient
 
 
 @pytest.mark.asyncio

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/tests/handlers/internal_test.py
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/tests/handlers/internal_test.py
@@ -2,14 +2,10 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import pytest
+from httpx import AsyncClient
 
 from {{ cookiecutter.package_name }}.config import config
-
-if TYPE_CHECKING:
-    from httpx import AsyncClient
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Using this construct is optional in our code, but we're starting to
lean away from using it routinely since it can mask some errors.
The uses in the test suite of the FastAPI app are not significant
or necessary, so remove this construction there to not create a
confusing example.