### PR TITLE
[DM-34075] Pull FastAPI images from GHCR by default

### DIFF
--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/.github/workflows/ci.yaml
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/.github/workflows/ci.yaml
@@ -101,7 +101,7 @@ jobs:
           context: .
           push: true
           tags: |
-            lsstsqre/{{ cookiecutter.package_name }}:{{ "${{ steps.vars.outputs.tag }}" }}
-            ghcr.io/lsst-sqre/{{ cookiecutter.package_name }}:{{ "${{ steps.vars.outputs.tag }}" }}
+            lsstsqre/{{ cookiecutter.name | lower }}:{{ "${{ steps.vars.outputs.tag }}" }}
+            ghcr.io/lsst-sqre/{{ cookiecutter.name | lower }}:{{ "${{ steps.vars.outputs.tag }}" }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/manifests/base/deployment.yaml
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/manifests/base/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         - name: app
           imagePullPolicy: "IfNotPresent"
           # Use images field in a Kustomization to set/update image tag
-          image: "ghcr.io/lsst-sqre/{{ cookiecutter.package_name }}"
+          image: "ghcr.io/lsst-sqre/{{ cookiecutter.name | lower }}"
           ports:
             - containerPort: 8080
               name: "app"

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/manifests/base/deployment.yaml
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/manifests/base/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         - name: app
           imagePullPolicy: "IfNotPresent"
           # Use images field in a Kustomization to set/update image tag
-          image: "lsstsqre/{{ cookiecutter.package_name }}"
+          image: "ghcr.io/lsst-sqre/{{ cookiecutter.package_name }}"
           ports:
             - containerPort: 8080
               name: "app"

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/manifests/base/kustomization.yaml
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/manifests/base/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 images:
-  - name: "lsstsqre/{{ cookiecutter.package_name }}"
+  - name: "ghcr.io/lsst-sqre/{{ cookiecutter.package_name }}"
     newTag: 0.0.0
 
 resources:

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/manifests/base/kustomization.yaml
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/manifests/base/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 images:
-  - name: "ghcr.io/lsst-sqre/{{ cookiecutter.package_name }}"
+  - name: "ghcr.io/lsst-sqre/{{ cookiecutter.name | lower }}"
     newTag: 0.0.0
 
 resources:

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/src/{{cookiecutter.package_name}}/config.py
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/src/{{cookiecutter.package_name}}/config.py
@@ -12,7 +12,7 @@ __all__ = ["Configuration", "config"]
 class Configuration:
     """Configuration for {{ cookiecutter.package_name }}."""
 
-    name: str = os.getenv("SAFIR_NAME", "{{ cookiecutter.package_name }}")
+    name: str = os.getenv("SAFIR_NAME", "{{ cookiecutter.name | lower }}")
     """The application's name, which doubles as the root HTTP endpoint path.
 
     Set with the ``SAFIR_NAME`` environment variable.

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/src/{{cookiecutter.package_name}}/handlers/external.py
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/src/{{cookiecutter.package_name}}/handlers/external.py
@@ -1,4 +1,4 @@
-"""Handlers for the app's external root, ``/{{ cookiecutter.package_name }}/``."""
+"""Handlers for the app's external root, ``/{{ cookiecutter.name | lower }}/``."""
 
 from fastapi import APIRouter, Depends
 from safir.dependencies.logger import logger_dependency
@@ -27,7 +27,7 @@ external_router = APIRouter()
 async def get_index(
     logger: BoundLogger = Depends(logger_dependency),
 ) -> Index:
-    """GET ``/{{ cookiecutter.package_name }}/`` (the app's external root).
+    """GET ``/{{ cookiecutter.name | lower }}/`` (the app's external root).
 
     Customize this handler to return whatever the top-level resource of your
     application should return. For example, consider listing key API URLs.

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/src/{{cookiecutter.package_name}}/handlers/internal.py
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/src/{{cookiecutter.package_name}}/handlers/internal.py
@@ -1,7 +1,7 @@
 """Internal HTTP handlers that serve relative to the root path, ``/``.
 
 These handlers aren't externally visible since the app is available at a path,
-``/{{ cookiecutter.name }}``. See `{{ cookiecutter.package_name }}.handlers.external` for
+``/{{ cookiecutter.name | lower }}``. See `{{ cookiecutter.package_name }}.handlers.external` for
 the external endpoint handlers.
 
 These handlers should be used for monitoring, health checks, internal status,

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/tests/handlers/external_test.py
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/tests/handlers/external_test.py
@@ -10,8 +10,8 @@ from {{ cookiecutter.package_name }}.config import config
 
 @pytest.mark.asyncio
 async def test_get_index(client: AsyncClient) -> None:
-    """Test ``GET /{{ cookiecutter.package_name }}/``"""
-    response = await client.get("/{{ cookiecutter.package_name }}/")
+    """Test ``GET /{{ cookiecutter.name | lower }}/``"""
+    response = await client.get("/{{ cookiecutter.name | lower }}/")
     assert response.status_code == 200
     data = response.json()
     metadata = data["metadata"]


### PR DESCRIPTION
In the Kustomization configuration for a FastAPI Safir app, default
to using the GitHub Container Registry as the source for the image
instead of Docker Hub.

Use the lowercased application name for the Docker image and the
default route instead of the Python package name.