### PR TITLE
Add update-deps-no-hashes to FastAPI template

### DIFF
--- a/project_templates/fastapi_safir_app/example/Makefile
+++ b/project_templates/fastapi_safir_app/example/Makefile
@@ -4,6 +4,13 @@ update-deps:
 	pip-compile --upgrade --build-isolation --generate-hashes --output-file requirements/main.txt requirements/main.in
 	pip-compile --upgrade --build-isolation --generate-hashes --output-file requirements/dev.txt requirements/dev.in
 
+# Useful for testing against a Git version of Safir.
+.PHONY: update-deps-no-hashes
+update-deps-no-hashes:
+	pip install --upgrade pip-tools pip setuptools
+	pip-compile --upgrade --build-isolation --allow-unsafe --output-file requirements/main.txt requirements/main.in
+	pip-compile --upgrade --build-isolation --allow-unsafe --output-file requirements/dev.txt requirements/dev.in
+
 .PHONY: init
 init:
 	pip install --editable .

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/Makefile
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/Makefile
@@ -4,6 +4,13 @@ update-deps:
 	pip-compile --upgrade --build-isolation --generate-hashes --output-file requirements/main.txt requirements/main.in
 	pip-compile --upgrade --build-isolation --generate-hashes --output-file requirements/dev.txt requirements/dev.in
 
+# Useful for testing against a Git version of Safir.
+.PHONY: update-deps-no-hashes
+update-deps-no-hashes:
+	pip install --upgrade pip-tools pip setuptools
+	pip-compile --upgrade --build-isolation --allow-unsafe --output-file requirements/main.txt requirements/main.in
+	pip-compile --upgrade --build-isolation --allow-unsafe --output-file requirements/dev.txt requirements/dev.in
+
 .PHONY: init
 init:
 	pip install --editable .


### PR DESCRIPTION
Add a new Makefile target update-deps-no-hashes that omits the
hashes from the generated dependencies.  This is useful when one
is testing against an unreleased dependency via Git and therefore
cannot generate hashes.