### PR TITLE
[DM-33014] Unpin documenteer in tech note template

### DIFF
--- a/project_templates/technote_rst/testn-000/requirements.txt
+++ b/project_templates/technote_rst/testn-000/requirements.txt
@@ -1,1 +1,1 @@
-documenteer[technote]>=0.5.4,<0.6.0
+documenteer[technote]

--- a/project_templates/technote_rst/{{cookiecutter.repo_name}}/requirements.txt
+++ b/project_templates/technote_rst/{{cookiecutter.repo_name}}/requirements.txt
@@ -1,1 +1,1 @@
-documenteer[technote]>=0.5.4,<0.6.0
+documenteer[technote]


### PR DESCRIPTION
Versions of documenteer prior to 0.6.0 no longer work because the
current version of Jinja2 is incompatible with the LaTeX extension
forced by the older version of Sphinx.  Documentation builds fail
with the error:

> Could not import extension sphinx.builders.latex (exception: cannot import name 'contextfunction' from 'jinja2'

Rather than move the pin, unpin documenteer in the hope that using
the latest release will be more likely to succeed than older
partly-pinned versions.