### PR TITLE
DM-34231: Update reStructuredText technote template for documenteer 0.6+

### DIFF
--- a/project_templates/technote_rst/testn-000/.github/dependabot.yml
+++ b/project_templates/technote_rst/testn-000/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/project_templates/technote_rst/testn-000/.github/workflows/ci.yaml
+++ b/project_templates/technote_rst/testn-000/.github/workflows/ci.yaml
@@ -1,36 +1,12 @@
 name: CI
 
-"on": [push, pull_request]
+'on': [push, pull_request, workflow_dispatch]
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0 # full history for metadata
-          submodules: true
-
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-
-      - name: Python install
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -r requirements.txt
-          python -m pip install "ltd-conveyor<2.0.0"
-
-      - name: Build
-        run: |
-          make html
-
-      - name: Upload
-        if: ${{ github.event_name == 'push' }}
-        env:
-          LTD_PASSWORD: ${{ secrets.LTD_PASSWORD }}
-          LTD_USERNAME: ${{ secrets.LTD_USERNAME }}
-        run: |
-          ltd upload --gh --dir _build/html --product testn-000
+  call-workflow:
+    uses: lsst-sqre/rubin-sphinx-technote-workflows/.github/workflows/ci.yaml@v1
+    with:
+      handle: testn-000
+    secrets:
+      ltd_username: ${{ secrets.LTD_USERNAME }}
+      ltd_password: ${{ secrets.LTD_PASSWORD }}

--- a/project_templates/technote_rst/testn-000/conf.py
+++ b/project_templates/technote_rst/testn-000/conf.py
@@ -1,22 +1,9 @@
-#!/usr/bin/env python
-#
-# Sphinx configuration file
-# see metadata.yaml in this repo to update document-specific metadata
+"""Sphinx configuration.
 
-import os
-from documenteer.sphinxconfig.technoteconf import configure_technote
+To learn more about the Sphinx configuration for technotes, and how to
+customize it, see:
 
-# Ingest settings from metadata.yaml and use documenteer's configure_technote()
-# to build a Sphinx configuration that is injected into this script's global
-# namespace.
-metadata_path = os.path.join(os.path.dirname(__file__), 'metadata.yaml')
-with open(metadata_path, 'r') as f:
-    confs = configure_technote(f)
-g = globals()
-g.update(confs)
+https://documenteer.lsst.io/technotes/configuration.html
+"""
 
-# Add intersphinx inventories as needed
-# http://www.sphinx-doc.org/en/stable/ext/intersphinx.html
-# Example:
-#
-#     intersphinx_mapping['python'] = ('https://docs.python.org/3', None)
+from documenteer.conf.technote import *  # noqa: F401, F403

--- a/project_templates/technote_rst/testn-000/index.rst
+++ b/project_templates/technote_rst/testn-000/index.rst
@@ -1,61 +1,29 @@
-..
-  Technote content.
-
-  See https://developer.lsst.io/restructuredtext/style.html
-  for a guide to reStructuredText writing.
-
-  Do not put the title, authors or other metadata in this document;
-  those are automatically added.
-
-  Use the following syntax for sections:
-
-  Sections
-  ========
-
-  and
-
-  Subsections
-  -----------
-
-  and
-
-  Subsubsections
-  ^^^^^^^^^^^^^^
-
-  To add images, add the image file (png, svg or jpeg preferred) to the
-  _static/ directory. The reST syntax for adding the image is
-
-  .. figure:: /_static/filename.ext
-     :name: fig-label
-
-     Caption text.
-
-   Run: ``make html`` and ``open _build/html/index.html`` to preview your work.
-   See the README at https://github.com/lsst-sqre/lsst-technote-bootstrap or
-   this repo's README for more info.
-
-   Feel free to delete this instructional comment.
-
 :tocdepth: 1
 
-.. Please do not modify tocdepth; will be fixed when a new Sphinx theme is shipped.
-
 .. sectnum::
+
+.. Metadata such as the title, authors, and description are set in metadata.yaml
 
 .. TODO: Delete the note below before merging new content to the main branch.
 
 .. note::
 
-   **This technote is not yet published.**
+   **This technote is a work-in-progress.**
 
-   A short description of this document
+Abstract
+========
 
-.. Add content here.
-.. Do not include the document title (it's automatically added from metadata.yaml).
+A short description of this document
 
-.. .. rubric:: References
+Add content here
+================
+
+Add content here.
+See the `reStructuredText Style Guide <https://developer.lsst.io/restructuredtext/style.html>`__ to learn how to create sections, links, images, tables, equations, and more.
 
 .. Make in-text citations with: :cite:`bibkey`.
-
+.. Uncomment to use citations
+.. .. rubric:: References
+.. 
 .. .. bibliography:: local.bib lsstbib/books.bib lsstbib/lsst.bib lsstbib/lsst-dm.bib lsstbib/refs.bib lsstbib/refs_ads.bib
 ..    :style: lsst_aa

--- a/project_templates/technote_rst/testn-000/requirements.txt
+++ b/project_templates/technote_rst/testn-000/requirements.txt
@@ -1,1 +1,1 @@
-documenteer[technote]>=0.5.4,<0.6.0
+documenteer[technote]

--- a/project_templates/technote_rst/{{cookiecutter.repo_name}}/.github/dependabot.yml
+++ b/project_templates/technote_rst/{{cookiecutter.repo_name}}/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/project_templates/technote_rst/{{cookiecutter.repo_name}}/.github/workflows/ci.yaml
+++ b/project_templates/technote_rst/{{cookiecutter.repo_name}}/.github/workflows/ci.yaml
@@ -1,36 +1,12 @@
 name: CI
 
-"on": [push, pull_request]
+'on': [push, pull_request, workflow_dispatch]
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0 # full history for metadata
-          submodules: true
-
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-
-      - name: Python install
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -r requirements.txt
-          python -m pip install "ltd-conveyor<2.0.0"
-
-      - name: Build
-        run: |
-          make html
-
-      - name: Upload
-        if: {% raw %}${{ github.event_name == 'push' }}{% endraw %}
-        env:
-          LTD_PASSWORD: {% raw %}${{ secrets.LTD_PASSWORD }}{% endraw %}
-          LTD_USERNAME: {% raw %}${{ secrets.LTD_USERNAME }}{% endraw %}
-        run: |
-          ltd upload --gh --dir _build/html --product {{ cookiecutter.series.lower() }}-{{ cookiecutter.serial_number }}
+  call-workflow:
+    uses: lsst-sqre/rubin-sphinx-technote-workflows/.github/workflows/ci.yaml@v1
+    with:
+      handle: {{ cookiecutter.series.lower() }}-{{ cookiecutter.serial_number }}
+    secrets:
+      ltd_username: {% raw %}${{ secrets.LTD_USERNAME }}{% endraw %}
+      ltd_password: {% raw %}${{ secrets.LTD_PASSWORD }}{% endraw %}

--- a/project_templates/technote_rst/{{cookiecutter.repo_name}}/conf.py
+++ b/project_templates/technote_rst/{{cookiecutter.repo_name}}/conf.py
@@ -1,22 +1,9 @@
-#!/usr/bin/env python
-#
-# Sphinx configuration file
-# see metadata.yaml in this repo to update document-specific metadata
+"""Sphinx configuration.
 
-import os
-from documenteer.sphinxconfig.technoteconf import configure_technote
+To learn more about the Sphinx configuration for technotes, and how to
+customize it, see:
 
-# Ingest settings from metadata.yaml and use documenteer's configure_technote()
-# to build a Sphinx configuration that is injected into this script's global
-# namespace.
-metadata_path = os.path.join(os.path.dirname(__file__), 'metadata.yaml')
-with open(metadata_path, 'r') as f:
-    confs = configure_technote(f)
-g = globals()
-g.update(confs)
+https://documenteer.lsst.io/technotes/configuration.html
+"""
 
-# Add intersphinx inventories as needed
-# http://www.sphinx-doc.org/en/stable/ext/intersphinx.html
-# Example:
-#
-#     intersphinx_mapping['python'] = ('https://docs.python.org/3', None)
+from documenteer.conf.technote import *  # noqa: F401, F403

--- a/project_templates/technote_rst/{{cookiecutter.repo_name}}/index.rst
+++ b/project_templates/technote_rst/{{cookiecutter.repo_name}}/index.rst
@@ -1,61 +1,29 @@
-..
-  Technote content.
-
-  See https://developer.lsst.io/restructuredtext/style.html
-  for a guide to reStructuredText writing.
-
-  Do not put the title, authors or other metadata in this document;
-  those are automatically added.
-
-  Use the following syntax for sections:
-
-  Sections
-  ========
-
-  and
-
-  Subsections
-  -----------
-
-  and
-
-  Subsubsections
-  ^^^^^^^^^^^^^^
-
-  To add images, add the image file (png, svg or jpeg preferred) to the
-  _static/ directory. The reST syntax for adding the image is
-
-  .. figure:: /_static/filename.ext
-     :name: fig-label
-
-     Caption text.
-
-   Run: ``make html`` and ``open _build/html/index.html`` to preview your work.
-   See the README at https://github.com/lsst-sqre/lsst-technote-bootstrap or
-   this repo's README for more info.
-
-   Feel free to delete this instructional comment.
-
 :tocdepth: 1
 
-.. Please do not modify tocdepth; will be fixed when a new Sphinx theme is shipped.
-
 .. sectnum::
+
+.. Metadata such as the title, authors, and description are set in metadata.yaml
 
 .. TODO: Delete the note below before merging new content to the main branch.
 
 .. note::
 
-   **This technote is not yet published.**
+   **This technote is a work-in-progress.**
 
-   {{ cookiecutter.description }}
+Abstract
+========
 
-.. Add content here.
-.. Do not include the document title (it's automatically added from metadata.yaml).
+{{ cookiecutter.description }}
 
-.. .. rubric:: References
+Add content here
+================
+
+Add content here.
+See the `reStructuredText Style Guide <https://developer.lsst.io/restructuredtext/style.html>`__ to learn how to create sections, links, images, tables, equations, and more.
 
 .. Make in-text citations with: :cite:`bibkey`.
-
+.. Uncomment to use citations
+.. .. rubric:: References
+.. 
 .. .. bibliography:: local.bib lsstbib/books.bib lsstbib/lsst.bib lsstbib/lsst-dm.bib lsstbib/refs.bib lsstbib/refs_ads.bib
 ..    :style: lsst_aa

--- a/project_templates/technote_rst/{{cookiecutter.repo_name}}/requirements.txt
+++ b/project_templates/technote_rst/{{cookiecutter.repo_name}}/requirements.txt
@@ -1,1 +1,1 @@
-documenteer[technote]>=0.5.4,<0.6.0
+documenteer[technote]


### PR DESCRIPTION
- Adopt the [new conf.py API](https://documenteer.lsst.io/technotes/configuration.html) available in documenteer 0.6
- Unpin documenteer to start using documenteer 0.6
- Simplify the starter text
- Adopt reusable workflows to streamline GitHub Actions, see https://github.com/lsst-sqre/rubin-sphinx-technote-workflows/pull/1