### PR TITLE
DM-34274: Add github_org to dialog fields

### DIFF
--- a/project_templates/sitcom_personal_notebooks/cookiecutter.json
+++ b/project_templates/sitcom_personal_notebooks/cookiecutter.json
@@ -1,7 +1,7 @@
 {
   "username": "username",
   "repo_name": "notebooks_{{ cookiecutter.username }}",
-  "github_org": "lsst-sitcom",
+  "github_org": ["lsst-sitcom"],
   "copyright_year": "{% now 'utc', '%Y' %}",
   "copyright_holder": [
     "Association of Universities for Research in Astronomy, Inc. (AURA)",

--- a/project_templates/sitcom_personal_notebooks/templatekit.yaml
+++ b/project_templates/sitcom_personal_notebooks/templatekit.yaml
@@ -9,3 +9,7 @@ dialog_fields:
   - label: "Copyright holder"
     key: "copyright_holder"
     component: "select"
+  - key: "github_org"
+    label: "GitHub organization"
+    hint: "The repo will be created in this GitHub organization."
+    component: "select"


### PR DESCRIPTION
At the moment templatebot-aide requires a github_org be present in the
dialog, even if there isn't a choice (it's not getting the variable from
cookiecutter.json at this stage).