### PR TITLE
Avoid get on PackageMetadata in FastAPI template

### DIFF
--- a/project_templates/fastapi_safir_app/example/src/example/main.py
+++ b/project_templates/fastapi_safir_app/example/src/example/main.py
@@ -7,7 +7,7 @@ constructed when this module is loaded and is not deferred until a function is
 called.
 """
 
-from importlib.metadata import metadata
+from importlib.metadata import metadata, version
 
 from fastapi import FastAPI
 from safir.dependencies.http_client import http_client_dependency
@@ -29,8 +29,8 @@ configure_logging(
 
 app = FastAPI(
     title="example",
-    description=metadata("example").get("Summary", ""),
-    version=metadata("example").get("Version", "0.0.0"),
+    description=metadata("example")["Summary"],
+    version=version("example"),
     openapi_url=f"/{config.name}/openapi.json",
     docs_url=f"/{config.name}/docs",
     redoc_url=f"/{config.name}/redoc",

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/src/{{cookiecutter.package_name}}/main.py
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/src/{{cookiecutter.package_name}}/main.py
@@ -7,7 +7,7 @@ constructed when this module is loaded and is not deferred until a function is
 called.
 """
 
-from importlib.metadata import metadata
+from importlib.metadata import metadata, version
 
 from fastapi import FastAPI
 from safir.dependencies.http_client import http_client_dependency
@@ -29,8 +29,8 @@ configure_logging(
 
 app = FastAPI(
     title="{{ cookiecutter.name }}",
-    description=metadata("{{ cookiecutter.name }}").get("Summary", ""),
-    version=metadata("{{ cookiecutter.name }}").get("Version", "0.0.0"),
+    description=metadata("{{ cookiecutter.name }}")["Summary"],
+    version=version("{{ cookiecutter.name }}"),
     openapi_url=f"/{config.name}/openapi.json",
     docs_url=f"/{config.name}/docs",
     redoc_url=f"/{config.name}/redoc",

--- a/project_templates/latex_lsstdoc/EXAMPLE-0/bibentry.txt
+++ b/project_templates/latex_lsstdoc/EXAMPLE-0/bibentry.txt
@@ -4,6 +4,6 @@
    author = { First Author },
     title = {Document Title},
      year = 2022,
-    month = Apr,
+    month = May,
    handle = {EXAMPLE-0},
       url = {https://example-0-0.lsst.io } }

--- a/project_templates/latex_lsstdoc/EXAMPLE/bibentry.txt
+++ b/project_templates/latex_lsstdoc/EXAMPLE/bibentry.txt
@@ -4,6 +4,6 @@
    author = { First Author },
     title = {Document Title},
      year = 2022,
-    month = Apr,
+    month = May,
    handle = {EXAMPLE},
       url = {https://example-.lsst.io } }

--- a/project_templates/technote_latex/testn-000/bibentry.txt
+++ b/project_templates/technote_latex/testn-000/bibentry.txt
@@ -4,6 +4,6 @@
    author = { First Last },
     title = {Document Title},
      year = 2022,
-    month = Apr,
+    month = May,
    handle = {TESTN-000},
       url = {https://testn-000.lsst.io } }

--- a/project_templates/technote_rst/testn-000/bibentry.txt
+++ b/project_templates/technote_rst/testn-000/bibentry.txt
@@ -4,6 +4,6 @@
    author = { First Last },
     title = {Document Title},
      year = 2022,
-    month = Apr,
+    month = May,
    handle = {TESTN-000},
       url = {https://testn-000.lsst.io } }

--- a/project_templates/test_report/TESTTR-0/bibentry.txt
+++ b/project_templates/test_report/TESTTR-0/bibentry.txt
@@ -4,6 +4,6 @@
    author = { First Author },
     title = {Document Title},
      year = 2022,
-    month = Apr,
+    month = May,
    handle = {TESTTR-0},
       url = {https://testtr-0.lsst.io } }


### PR DESCRIPTION
The current mypy plus typeshed plus the Python 3.10 core library
has a bug causing mypy to not think get is a valid method on the
return value of importlib.metadata.metadata because it returns a
Protocol that doesn't implement get.  I've filed a issue in case
this is not intended (https://github.com/python/typeshed/issues/7767),
but we know that any package created by this template will always
have Summary and Version metadata, so we can use them
unconditionally.

Previously, this may not have worked in situations where the
package was being used uninstalled, but since we now do everything
including local development servers from inside tox, and make init
also installs the package for running pytest directly, this should
no longer be an issue.  setuptools_scm should always generate a
version, even if it's an unuseful one.