### PR TITLE
Fix "sconsUtils" base package typo in stack package template

### DIFF
--- a/project_templates/latex_lsstdoc/EXAMPLE-0/bibentry.txt
+++ b/project_templates/latex_lsstdoc/EXAMPLE-0/bibentry.txt
@@ -4,6 +4,6 @@
    author = { First Author },
     title = {Document Title},
      year = 2022,
-    month = May,
+    month = Jun,
    handle = {EXAMPLE-0},
       url = {https://example-0-0.lsst.io } }

--- a/project_templates/latex_lsstdoc/EXAMPLE/bibentry.txt
+++ b/project_templates/latex_lsstdoc/EXAMPLE/bibentry.txt
@@ -4,6 +4,6 @@
    author = { First Author },
     title = {Document Title},
      year = 2022,
-    month = May,
+    month = Jun,
    handle = {EXAMPLE},
       url = {https://example-.lsst.io } }

--- a/project_templates/stack_package/SConscript
+++ b/project_templates/stack_package/SConscript
@@ -63,7 +63,7 @@ env.Cookiecutter(AlwaysBuild(Dir('example_standalone')),
                  'cookiecutter.json',
                  cookiecutter_context={'package_name': 'example_standalone',
                                        'stack_name': 'None',
-                                       'base_package': 'setupUtils',
+                                       'base_package': 'sconsUtils',
                                        'uses_cpp': 'False',
                                        'uses_dds': 'False'})
 
@@ -75,7 +75,7 @@ env.Cookiecutter(AlwaysBuild(Dir('example_dds')),
                  'cookiecutter.json',
                  cookiecutter_context={'package_name': 'example_dds',
                                        'stack_name': 'None',
-                                       'base_package': 'setupUtils',
+                                       'base_package': 'sconsUtils',
                                        'uses_cpp': 'False',
                                        'uses_dds': 'True',
                                        'uses_tasks': 'False'})

--- a/project_templates/stack_package/example_dds/ups/example_dds.table
+++ b/project_templates/stack_package/example_dds/ups/example_dds.table
@@ -1,8 +1,8 @@
 # List EUPS dependencies of this package here.
 # - Any package whose API is used directly should be listed explicitly.
 # - Common third-party packages can be assumed to be recursively included by
-#   the "base" package.
-setupRequired(base)
+#   the "sconsUtils" package.
+setupRequired(sconsUtils)
 
 # The following is boilerplate for all packages.
 # See https://dmtn-001.lsst.io for details on LSST_LIBRARY_PATH.

--- a/project_templates/stack_package/example_standalone/ups/example_standalone.table
+++ b/project_templates/stack_package/example_standalone/ups/example_standalone.table
@@ -1,8 +1,8 @@
 # List EUPS dependencies of this package here.
 # - Any package whose API is used directly should be listed explicitly.
 # - Common third-party packages can be assumed to be recursively included by
-#   the "base" package.
-setupRequired(base)
+#   the "sconsUtils" package.
+setupRequired(sconsUtils)
 
 # The following is boilerplate for all packages.
 # See https://dmtn-001.lsst.io for details on LSST_LIBRARY_PATH.

--- a/project_templates/technote_latex/testn-000/bibentry.txt
+++ b/project_templates/technote_latex/testn-000/bibentry.txt
@@ -4,6 +4,6 @@
    author = { First Last },
     title = {Document Title},
      year = 2022,
-    month = May,
+    month = Jun,
    handle = {TESTN-000},
       url = {https://testn-000.lsst.io } }

--- a/project_templates/technote_rst/testn-000/bibentry.txt
+++ b/project_templates/technote_rst/testn-000/bibentry.txt
@@ -4,6 +4,6 @@
    author = { First Last },
     title = {Document Title},
      year = 2022,
-    month = May,
+    month = Jun,
    handle = {TESTN-000},
       url = {https://testn-000.lsst.io } }

--- a/project_templates/test_report/TESTTR-0/bibentry.txt
+++ b/project_templates/test_report/TESTTR-0/bibentry.txt
@@ -4,6 +4,6 @@
    author = { First Author },
     title = {Document Title},
      year = 2022,
-    month = May,
+    month = Jun,
    handle = {TESTTR-0},
       url = {https://testtr-0.lsst.io } }


### PR DESCRIPTION
This was originally fixed in 2019, but two instances of the "setupUtils" typo remained. Cookiecutter now seems to validate its choice options, so this began to trigger a visible error.