### PR TITLE
[DM-35179] Make warnings fatal in rST tech notes

### DIFF
--- a/project_templates/technote_rst/testn-000/Makefile
+++ b/project_templates/technote_rst/testn-000/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = -n
+SPHINXOPTS    = -W --keep-going -n
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build

--- a/project_templates/technote_rst/{{cookiecutter.repo_name}}/Makefile
+++ b/project_templates/technote_rst/{{cookiecutter.repo_name}}/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = -n
+SPHINXOPTS    = -W --keep-going -n
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build


### PR DESCRIPTION
I keep finding missing cross-references or syntax errors in rendered
tech note branches because I don't think to run make html locally to
check for errors and the GitHub Actions workflow ignores them.  Change
the default Sphinx arguments to make warnings fatal, on the grounds
that all Sphinx warnings seem to be avoidable (with an exclusion if
nothing else) and it's better to catch these automatically rather
than requiring human proofreading.