### PR TITLE
DM-35448: Enable dry runs of builds for PyPI

### DIFF
--- a/project_templates/square_pypi_package/example/.github/workflows/ci.yaml
+++ b/project_templates/square_pypi_package/example/.github/workflows/ci.yaml
@@ -87,7 +87,6 @@ jobs:
 
     runs-on: ubuntu-latest
     needs: [lint, test, docs]
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
 
     steps:
       - uses: actions/checkout@v3
@@ -99,3 +98,4 @@ jobs:
         with:
           pypi-token: ${{ secrets.PYPI_SQRE_ADMIN }}
           python-version: "3.10"
+          upload: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}

--- a/project_templates/square_pypi_package/example/.github/workflows/periodic-ci.yaml
+++ b/project_templates/square_pypi_package/example/.github/workflows/periodic-ci.yaml
@@ -41,3 +41,18 @@ jobs:
           python-version: "3.10"
           tox-envs: "docs,docs-linkcheck"
           use-cache: false
+
+  pypi:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # full history for setuptools_scm
+
+      - name: Build and publish
+        uses: lsst-sqre/build-and-publish-to-pypi@v1
+        with:
+          pypi-token: ""
+          python-version: "3.10"
+          upload: false

--- a/project_templates/square_pypi_package/{{cookiecutter.pypi_name}}/.github/workflows/ci.yaml
+++ b/project_templates/square_pypi_package/{{cookiecutter.pypi_name}}/.github/workflows/ci.yaml
@@ -87,7 +87,6 @@ jobs:
 
     runs-on: ubuntu-latest
     needs: [lint, test, docs]
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
 
     steps:
       - uses: actions/checkout@v3
@@ -99,3 +98,4 @@ jobs:
         with:
           pypi-token: {{ "${{ secrets.PYPI_SQRE_ADMIN }}" }}
           python-version: "3.10"
+          upload: {{ "${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}" }}

--- a/project_templates/square_pypi_package/{{cookiecutter.pypi_name}}/.github/workflows/periodic-ci.yaml
+++ b/project_templates/square_pypi_package/{{cookiecutter.pypi_name}}/.github/workflows/periodic-ci.yaml
@@ -41,3 +41,18 @@ jobs:
           python-version: "3.10"
           tox-envs: "docs,docs-linkcheck"
           use-cache: false
+
+  pypi:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # full history for setuptools_scm
+
+      - name: Build and publish
+        uses: lsst-sqre/build-and-publish-to-pypi@v1
+        with:
+          pypi-token: ""
+          python-version: "3.10"
+          upload: false


### PR DESCRIPTION
The [lsst-sqre/build-and-publish-to-pypi](https://github.com/lsst-sqre/build-and-publish-to-pypi) action has an upload input that allows us to disable uploads in certain circumstances. This lets us run the action in a dry-run mode for PR and the weekly CI to validate that the packaging works.

This has been implemented in https://github.com/lsst-sqre/kafkit already.