### PR TITLE
DM-35808: Add *.xdv to technote_latex gitignore

### DIFF
--- a/project_templates/technote_latex/testn-000/.gitignore
+++ b/project_templates/technote_latex/testn-000/.gitignore
@@ -17,6 +17,7 @@ one.*
 *.fot
 *.cb
 *.cb2
+*.xdv
 
 
 ## Intermediate documents:

--- a/project_templates/technote_latex/{{cookiecutter.series.lower()}}-{{cookiecutter.serial_number}}/.gitignore
+++ b/project_templates/technote_latex/{{cookiecutter.series.lower()}}-{{cookiecutter.serial_number}}/.gitignore
@@ -17,6 +17,7 @@ one.*
 *.fot
 *.cb
 *.cb2
+*.xdv
 
 
 ## Intermediate documents:


### PR DESCRIPTION
This file is produced as a byproduct of xelatex. The other tex-based templates already ignore this file; this must have been missed when we switched from pdflatex to xelatex.