### PR TITLE
DM-35809: Drop bibtentry.txt files

### DIFF
--- a/project_templates/latex_lsstdoc/EXAMPLE-0/bibentry.txt
+++ b/project_templates/latex_lsstdoc/EXAMPLE-0/bibentry.txt
@@ -1,9 +1,0 @@
-% bibentry template for lsst.bib in https://github.com/lsst/lsst-texmf/blob/main/texmf/bibtex/bib/lsst.bib
-
-@DocuShare{EXAMPLE-0,
-   author = { First Author },
-    title = {Document Title},
-     year = 2022,
-    month = Aug,
-   handle = {EXAMPLE-0},
-      url = {https://example-0-0.lsst.io } }

--- a/project_templates/latex_lsstdoc/EXAMPLE/bibentry.txt
+++ b/project_templates/latex_lsstdoc/EXAMPLE/bibentry.txt
@@ -1,9 +1,0 @@
-% bibentry template for lsst.bib in https://github.com/lsst/lsst-texmf/blob/main/texmf/bibtex/bib/lsst.bib
-
-@DocuShare{EXAMPLE,
-   author = { First Author },
-    title = {Document Title},
-     year = 2022,
-    month = Aug,
-   handle = {EXAMPLE},
-      url = {https://example-.lsst.io } }

--- a/project_templates/latex_lsstdoc/{{cookiecutter.handle}}/bibentry.txt
+++ b/project_templates/latex_lsstdoc/{{cookiecutter.handle}}/bibentry.txt
@@ -1,9 +1,0 @@
-% bibentry template for lsst.bib in https://github.com/lsst/lsst-texmf/blob/main/texmf/bibtex/bib/lsst.bib
-
-@DocuShare{ {{- cookiecutter.handle -}},
-   author = { {{ cookiecutter.author }} },
-    title = { {{- cookiecutter.title -}} },
-     year = {% now 'local', '%Y' %},
-    month = {% now 'local', '%b' %},
-   handle = { {{- cookiecutter.handle -}} },
-      url = {https://{{- cookiecutter.handle.lower() -}}-{{- cookiecutter.serial_number -}}.lsst.io } }

--- a/project_templates/technote_rst/testn-000/bibentry.txt
+++ b/project_templates/technote_rst/testn-000/bibentry.txt
@@ -1,9 +1,0 @@
-% bibentry template for lsst.bib in https://github.com/lsst/lsst-texmf/blob/main/texmf/bibtex/bib/lsst.bib
-
-@DocuShare{TESTN-000,
-   author = { First Last },
-    title = {Document Title},
-     year = 2022,
-    month = Aug,
-   handle = {TESTN-000},
-      url = {https://testn-000.lsst.io } }

--- a/project_templates/technote_rst/{{cookiecutter.repo_name}}/bibentry.txt
+++ b/project_templates/technote_rst/{{cookiecutter.repo_name}}/bibentry.txt
@@ -1,9 +1,0 @@
-% bibentry template for lsst.bib in https://github.com/lsst/lsst-texmf/blob/main/texmf/bibtex/bib/lsst.bib
-
-@DocuShare{ {{- cookiecutter.series.upper() -}}-{{- cookiecutter.serial_number -}},
-   author = { {{ cookiecutter.first_author }} },
-    title = { {{- cookiecutter.title -}} },
-     year = {% now 'local', '%Y' %},
-    month = {% now 'local', '%b' %},
-   handle = { {{- cookiecutter.series.upper() -}}-{{- cookiecutter.serial_number -}} },
-      url = {https://{{- cookiecutter.series.lower() -}}-{{- cookiecutter.serial_number -}}.lsst.io } }


### PR DESCRIPTION
Now that the lsst-texmf bib files are being automatically updated based on metadata extracted by Ook and hosted out of Algolia, there's no need for these bibentry files. Besides, that, these embedded bibentry files create monthly churn in the examples, and become quickly outdated in the documents they're injected into.