### PR TITLE
DM-36197: Minor fixes for test-report template

### DIFF
--- a/project_templates/technote_latex/testn-000/bibentry.txt
+++ b/project_templates/technote_latex/testn-000/bibentry.txt
@@ -1,9 +1,0 @@
-% bibentry template for lsst.bib in https://github.com/lsst/lsst-texmf/blob/main/texmf/bibtex/bib/lsst.bib
-
-@DocuShare{TESTN-000,
-   author = { First Last },
-    title = {Document Title},
-     year = 2022,
-    month = Aug,
-   handle = {TESTN-000},
-      url = {https://testn-000.lsst.io } }

--- a/project_templates/technote_latex/{{cookiecutter.series.lower()}}-{{cookiecutter.serial_number}}/bibentry.txt
+++ b/project_templates/technote_latex/{{cookiecutter.series.lower()}}-{{cookiecutter.serial_number}}/bibentry.txt
@@ -1,9 +1,0 @@
-% bibentry template for lsst.bib in https://github.com/lsst/lsst-texmf/blob/main/texmf/bibtex/bib/lsst.bib
-
-@DocuShare{ {{- cookiecutter.series.upper() -}}-{{- cookiecutter.serial_number -}},
-   author = { {{ cookiecutter.first_author }} },
-    title = { {{- cookiecutter.title -}} },
-     year = {% now 'local', '%Y' %},
-    month = {% now 'local', '%b' %},
-   handle = { {{- cookiecutter.series.upper() -}}-{{- cookiecutter.serial_number -}} },
-      url = {https://{{- cookiecutter.series.lower() -}}-{{- cookiecutter.serial_number -}}.lsst.io } }

--- a/project_templates/test_report/TESTTR-0/.github/workflows/docgen_from_Jira.yaml
+++ b/project_templates/test_report/TESTTR-0/.github/workflows/docgen_from_Jira.yaml
@@ -58,4 +58,4 @@ jobs:
           LTD_PASSWORD: ${{ secrets.LTD_PASSWORD }}
           LTD_USERNAME: ${{ secrets.LTD_USERNAME }}
         run: |
-          lander --upload --pdf TESTTR-0.pdf --lsstdoc TESTTR-0.tex --ltd-product testtr-0 --extra-download testtr-0-plan.pdf
+          lander --upload --pdf TESTTR-0.pdf --lsstdoc TESTTR-0.tex --ltd-product testtr-0 --extra-download TESTTR-0-plan.pdf

--- a/project_templates/test_report/TESTTR-0/bibentry.txt
+++ b/project_templates/test_report/TESTTR-0/bibentry.txt
@@ -1,9 +1,0 @@
-% bibentry template for lsst.bib in https://github.com/lsst/lsst-texmf/blob/main/texmf/bibtex/bib/lsst.bib
-
-@DocuShare{TESTTR-0,
-   author = { First Author },
-    title = {Document Title},
-     year = 2022,
-    month = Aug,
-   handle = {TESTTR-0},
-      url = {https://testtr-0.lsst.io } }

--- a/project_templates/test_report/{{cookiecutter.series.upper()}}-{{cookiecutter.serial_number}}/.github/workflows/docgen_from_Jira.yaml
+++ b/project_templates/test_report/{{cookiecutter.series.upper()}}-{{cookiecutter.serial_number}}/.github/workflows/docgen_from_Jira.yaml
@@ -58,4 +58,4 @@ jobs:
           LTD_PASSWORD: {% raw %}${{ secrets.LTD_PASSWORD }}{% endraw %}
           LTD_USERNAME: {% raw %}${{ secrets.LTD_USERNAME }}{% endraw %}
         run: |
-          lander --upload --pdf {{ cookiecutter.series }}-{{ cookiecutter.serial_number }}.pdf --lsstdoc {{ cookiecutter.series }}-{{ cookiecutter.serial_number }}.tex --ltd-product {{ cookiecutter.series.lower() }}-{{ cookiecutter.serial_number }} --extra-download {{ cookiecutter.series.lower() }}-{{ cookiecutter.serial_number }}-plan.pdf
+          lander --upload --pdf {{ cookiecutter.series }}-{{ cookiecutter.serial_number }}.pdf --lsstdoc {{ cookiecutter.series }}-{{ cookiecutter.serial_number }}.tex --ltd-product {{ cookiecutter.series.lower() }}-{{ cookiecutter.serial_number }} --extra-download {{ cookiecutter.series }}-{{ cookiecutter.serial_number }}-plan.pdf

--- a/project_templates/test_report/{{cookiecutter.series.upper()}}-{{cookiecutter.serial_number}}/bibentry.txt
+++ b/project_templates/test_report/{{cookiecutter.series.upper()}}-{{cookiecutter.serial_number}}/bibentry.txt
@@ -1,9 +1,0 @@
-% bibentry template for lsst.bib in https://github.com/lsst/lsst-texmf/blob/main/texmf/bibtex/bib/lsst.bib
-
-@DocuShare{ {{- cookiecutter.series.upper() -}}-{{- cookiecutter.serial_number -}},
-   author = { {{ cookiecutter.author }} },
-    title = { {{- cookiecutter.title -}} },
-     year = {% now 'local', '%Y' %},
-    month = {% now 'local', '%b' %},
-   handle = { {{- cookiecutter.series.upper() -}}-{{- cookiecutter.serial_number -}} },
-      url = {https://{{- cookiecutter.series.lower() -}}-{{- cookiecutter.serial_number -}}.lsst.io } }


### PR DESCRIPTION
- Fix capitalization of the --extra-download option in the Jira workflow
- Drop bibentry.txt since it's replaced by lsst-texmf's automatic bib file maintenance