### PR TITLE
[DM-35879] Configure Uvicorn logging in FastAPI app

### DIFF
--- a/project_templates/fastapi_safir_app/example/requirements/main.in
+++ b/project_templates/fastapi_safir_app/example/requirements/main.in
@@ -11,4 +11,4 @@ starlette
 uvicorn[standard]
 
 # Other dependencies.
-safir
+safir>=3.3.0

--- a/project_templates/fastapi_safir_app/example/src/example/main.py
+++ b/project_templates/fastapi_safir_app/example/src/example/main.py
@@ -11,7 +11,7 @@ from importlib.metadata import metadata, version
 
 from fastapi import FastAPI
 from safir.dependencies.http_client import http_client_dependency
-from safir.logging import configure_logging
+from safir.logging import configure_logging, configure_uvicorn_logging
 from safir.middleware.x_forwarded import XForwardedMiddleware
 
 from .config import config
@@ -26,6 +26,7 @@ configure_logging(
     log_level=config.log_level,
     name=config.logger_name,
 )
+configure_uvicorn_logging(config.log_level)
 
 app = FastAPI(
     title="example",

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/requirements/main.in
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/requirements/main.in
@@ -11,4 +11,4 @@ starlette
 uvicorn[standard]
 
 # Other dependencies.
-safir
+safir>=3.3.0

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/src/{{cookiecutter.package_name}}/main.py
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/src/{{cookiecutter.package_name}}/main.py
@@ -11,7 +11,7 @@ from importlib.metadata import metadata, version
 
 from fastapi import FastAPI
 from safir.dependencies.http_client import http_client_dependency
-from safir.logging import configure_logging
+from safir.logging import configure_logging, configure_uvicorn_logging
 from safir.middleware.x_forwarded import XForwardedMiddleware
 
 from .config import config
@@ -26,6 +26,7 @@ configure_logging(
     log_level=config.log_level,
     name=config.logger_name,
 )
+configure_uvicorn_logging(config.log_level)
 
 app = FastAPI(
     title="{{ cookiecutter.name }}",


### PR DESCRIPTION
Add a call to the new Safir configure_uvicorn_logging function in the template for the FastAPI Safir app, and set a dependency bound on Safir to ensure that function is available.  This will ensure that Uvicorn logs for FastAPI apps are routed through structlog and the context expected by Google's Cloud Logging is added.