### PR TITLE
DM-36681: Improve the first-run experience of square_pypi_package

### DIFF
--- a/project_templates/square_pypi_package/example/.github/workflows/ci.yaml
+++ b/project_templates/square_pypi_package/example/.github/workflows/ci.yaml
@@ -66,7 +66,9 @@ jobs:
         uses: lsst-sqre/run-tox@v1
         with:
           python-version: "3.10"
-          tox-envs: "docs,docs-linkcheck"
+          tox-envs: "docs"
+          # Add docs-linkcheck when the docs and PyPI package are published
+          # tox-envs: "docs,docs-linkcheck"
 
       # Only attempt documentation uploads for tagged releases and pull
       # requests from ticket branches in the same repository.  This avoids

--- a/project_templates/square_pypi_package/example/docs/api.rst
+++ b/project_templates/square_pypi_package/example/docs/api.rst
@@ -5,3 +5,4 @@ Python API reference
 ####################
 
 .. automodapi:: example
+   :include-all-objects:

--- a/project_templates/square_pypi_package/example/docs/dev/development.rst
+++ b/project_templates/square_pypi_package/example/docs/dev/development.rst
@@ -101,31 +101,28 @@ The built documentation is located in the :file:`docs/_build/html` directory.
 Updating the change log
 =======================
 
-Each pull request should update the change log (:file:`CHANGELOG.rst`).
+Each pull request should update the change log (:file:`CHANGELOG.md`).
 Add a description of new features and fixes as list items under a section at the top of the change log called "Unreleased:"
 
-.. code-block:: rst
+.. code-block:: md
 
-   Unreleased
-   ----------
+   ## Unreleased
 
    - Description of the feature or fix.
 
-If the next version is known (because Safir's main branch is being prepared for a new major or minor version), the section may contain that version information:
+If the next version is known (because example's main branch is being prepared for a new major or minor version), the section may contain that version information:
 
-.. code-block:: rst
+.. code-block:: md
 
-   X.Y.0 (unreleased)
-   ------------------
+   ## X.Y.0 (unreleased)
 
    - Description of the feature or fix.
 
 If the exact version and release date is known (:doc:`because a release is being prepared <release>`), the section header is formatted as:
 
-.. code-block:: rst
+.. code-block:: md
 
-   X.Y.0 (YYYY-MM-DD)
-   ------------------
+   ## X.Y.0 (YYYY-MM-DD)
 
    - Description of the feature or fix.
 

--- a/project_templates/square_pypi_package/example/docs/dev/development.rst
+++ b/project_templates/square_pypi_package/example/docs/dev/development.rst
@@ -76,9 +76,9 @@ To see a listing of test environments, run:
 
 To run a specific test or list of tests, you can add test file names (and any other pytest_ options) after ``--`` when executing the ``py`` tox environment.
 .. For example:
-.. 
+..
 .. .. code-block:: sh
-.. 
+..
 ..    tox -e py -- tests/database_test.py
 
 .. _dev-build-docs:

--- a/project_templates/square_pypi_package/example/docs/dev/release.rst
+++ b/project_templates/square_pypi_package/example/docs/dev/release.rst
@@ -6,10 +6,10 @@ This page gives an overview of how example releases are made.
 This information is only useful for maintainers.
 
 example's releases are largely automated through GitHub Actions (see the `ci.yaml`_ workflow file for details).
-When a semantic version tag is pushed to GitHub, `Safir is released to PyPI`_ with that version.
+When a semantic version tag is pushed to GitHub, `example is released to PyPI`_ with that version.
 Similarly, documentation is built and pushed for each version (see https://safir.lsst.io/v).
 
-.. _`Safir is released to PyPI`: https://pypi.org/project/example/
+.. _`example is released to PyPI`: https://pypi.org/project/example/
 .. _`ci.yaml`: https://github.com/lsst-sqre/example/blob/main/.github/workflows/ci.yaml
 
 .. _regular-release:
@@ -33,7 +33,7 @@ In particular, replace the "Unreleased" section headline with the semantic versi
 See :ref:`dev-change-log` in the *Developer guide* for details.
 
 2. GitHub release and tag
-------------------
+-------------------------
 
 Use `GitHub's Release feature <https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository>`__ to create releases and their corresponding Git tags.
 
@@ -45,7 +45,7 @@ Use `GitHub's Release feature <https://docs.github.com/en/repositories/releasing
 3. Fill in the release notes, copied from the release notes.
    You can use GitHub's change log feature to additionally generate a list of PRs included in the release.
 
-The tag **must** follow the :pep:`440` specification since Safir uses setuptools_scm_ to set version metadata based on Git tags.
+The tag **must** follow the :pep:`440` specification since example uses setuptools_scm_ to set version metadata based on Git tags.
 In particular, **don't** prefix the tag with ``v``.
 
 .. _setuptools_scm: https://github.com/pypa/setuptools_scm

--- a/project_templates/square_pypi_package/example/src/example/__init__.py
+++ b/project_templates/square_pypi_package/example/src/example/__init__.py
@@ -4,7 +4,6 @@ __all__ = ["__version__"]
 
 from importlib.metadata import PackageNotFoundError, version
 
-
 __version__: str
 """The version string of example
 (PEP 440 / SemVer compatible).

--- a/project_templates/square_pypi_package/example/tests/version_test.py
+++ b/project_templates/square_pypi_package/example/tests/version_test.py
@@ -1,0 +1,12 @@
+"""Test the packaging."""
+
+from __future__ import annotations
+
+from example import __version__
+
+
+def test_version() -> None:
+    """Ensure that the version is set."""
+    assert isinstance(__version__, str)
+    # Indicates the package is not installed otherwise
+    assert __version__ != "0.0.0"

--- a/project_templates/square_pypi_package/example/tox.ini
+++ b/project_templates/square_pypi_package/example/tox.ini
@@ -25,7 +25,7 @@ commands =
 [testenv:typing]
 description = Run mypy.
 commands =
-    mypy src/example tests setup.py
+    mypy src/example tests
 
 [testenv:lint]
 description = Lint codebase by running pre-commit (Black, isort, Flake8).

--- a/project_templates/square_pypi_package/{{cookiecutter.name}}/.github/workflows/ci.yaml
+++ b/project_templates/square_pypi_package/{{cookiecutter.name}}/.github/workflows/ci.yaml
@@ -66,7 +66,9 @@ jobs:
         uses: lsst-sqre/run-tox@v1
         with:
           python-version: "3.10"
-          tox-envs: "docs,docs-linkcheck"
+          tox-envs: "docs"
+          # Add docs-linkcheck when the docs and PyPI package are published
+          # tox-envs: "docs,docs-linkcheck"
 
       # Only attempt documentation uploads for tagged releases and pull
       # requests from ticket branches in the same repository.  This avoids

--- a/project_templates/square_pypi_package/{{cookiecutter.name}}/docs/api.rst
+++ b/project_templates/square_pypi_package/{{cookiecutter.name}}/docs/api.rst
@@ -5,3 +5,4 @@ Python API reference
 ####################
 
 .. automodapi:: {{ cookiecutter.module_name }}
+   :include-all-objects:

--- a/project_templates/square_pypi_package/{{cookiecutter.name}}/docs/dev/development.rst
+++ b/project_templates/square_pypi_package/{{cookiecutter.name}}/docs/dev/development.rst
@@ -76,9 +76,9 @@ To see a listing of test environments, run:
 
 To run a specific test or list of tests, you can add test file names (and any other pytest_ options) after ``--`` when executing the ``py`` tox environment.
 .. For example:
-.. 
+..
 .. .. code-block:: sh
-.. 
+..
 ..    tox -e py -- tests/database_test.py
 
 .. _dev-build-docs:

--- a/project_templates/square_pypi_package/{{cookiecutter.name}}/docs/dev/development.rst
+++ b/project_templates/square_pypi_package/{{cookiecutter.name}}/docs/dev/development.rst
@@ -101,31 +101,28 @@ The built documentation is located in the :file:`docs/_build/html` directory.
 Updating the change log
 =======================
 
-Each pull request should update the change log (:file:`CHANGELOG.rst`).
+Each pull request should update the change log (:file:`CHANGELOG.md`).
 Add a description of new features and fixes as list items under a section at the top of the change log called "Unreleased:"
 
-.. code-block:: rst
+.. code-block:: md
 
-   Unreleased
-   ----------
+   ## Unreleased
 
    - Description of the feature or fix.
 
-If the next version is known (because Safir's main branch is being prepared for a new major or minor version), the section may contain that version information:
+If the next version is known (because {{cookiecutter.name}}'s main branch is being prepared for a new major or minor version), the section may contain that version information:
 
-.. code-block:: rst
+.. code-block:: md
 
-   X.Y.0 (unreleased)
-   ------------------
+   ## X.Y.0 (unreleased)
 
    - Description of the feature or fix.
 
 If the exact version and release date is known (:doc:`because a release is being prepared <release>`), the section header is formatted as:
 
-.. code-block:: rst
+.. code-block:: md
 
-   X.Y.0 (YYYY-MM-DD)
-   ------------------
+   ## X.Y.0 (YYYY-MM-DD)
 
    - Description of the feature or fix.
 

--- a/project_templates/square_pypi_package/{{cookiecutter.name}}/docs/dev/release.rst
+++ b/project_templates/square_pypi_package/{{cookiecutter.name}}/docs/dev/release.rst
@@ -6,10 +6,10 @@ This page gives an overview of how {{cookiecutter.name}} releases are made.
 This information is only useful for maintainers.
 
 {{cookiecutter.name}}'s releases are largely automated through GitHub Actions (see the `ci.yaml`_ workflow file for details).
-When a semantic version tag is pushed to GitHub, `Safir is released to PyPI`_ with that version.
+When a semantic version tag is pushed to GitHub, `{{cookiecutter.name}} is released to PyPI`_ with that version.
 Similarly, documentation is built and pushed for each version (see https://safir.lsst.io/v).
 
-.. _`Safir is released to PyPI`: https://pypi.org/project/{{cookiecutter.name}}/
+.. _`{{cookiecutter.name}} is released to PyPI`: https://pypi.org/project/{{cookiecutter.name}}/
 .. _`ci.yaml`: https://github.com/lsst-sqre/{{cookiecutter.name}}/blob/main/.github/workflows/ci.yaml
 
 .. _regular-release:
@@ -33,7 +33,7 @@ In particular, replace the "Unreleased" section headline with the semantic versi
 See :ref:`dev-change-log` in the *Developer guide* for details.
 
 2. GitHub release and tag
-------------------
+-------------------------
 
 Use `GitHub's Release feature <https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository>`__ to create releases and their corresponding Git tags.
 
@@ -45,7 +45,7 @@ Use `GitHub's Release feature <https://docs.github.com/en/repositories/releasing
 3. Fill in the release notes, copied from the release notes.
    You can use GitHub's change log feature to additionally generate a list of PRs included in the release.
 
-The tag **must** follow the :pep:`440` specification since Safir uses setuptools_scm_ to set version metadata based on Git tags.
+The tag **must** follow the :pep:`440` specification since {{cookiecutter.name}} uses setuptools_scm_ to set version metadata based on Git tags.
 In particular, **don't** prefix the tag with ``v``.
 
 .. _setuptools_scm: https://github.com/pypa/setuptools_scm

--- a/project_templates/square_pypi_package/{{cookiecutter.name}}/src/{{cookiecutter.module_name}}/__init__.py
+++ b/project_templates/square_pypi_package/{{cookiecutter.name}}/src/{{cookiecutter.module_name}}/__init__.py
@@ -4,7 +4,6 @@ __all__ = ["__version__"]
 
 from importlib.metadata import PackageNotFoundError, version
 
-
 __version__: str
 """The version string of {{cookiecutter.module_name}}
 (PEP 440 / SemVer compatible).

--- a/project_templates/square_pypi_package/{{cookiecutter.name}}/tests/version_test.py
+++ b/project_templates/square_pypi_package/{{cookiecutter.name}}/tests/version_test.py
@@ -1,0 +1,12 @@
+"""Test the packaging."""
+
+from __future__ import annotations
+
+from {{cookiecutter.module_name}} import __version__
+
+
+def test_version() -> None:
+    """Ensure that the version is set."""
+    assert isinstance(__version__, str)
+    # Indicates the package is not installed otherwise
+    assert __version__ != "0.0.0"

--- a/project_templates/square_pypi_package/{{cookiecutter.name}}/tox.ini
+++ b/project_templates/square_pypi_package/{{cookiecutter.name}}/tox.ini
@@ -25,7 +25,7 @@ commands =
 [testenv:typing]
 description = Run mypy.
 commands =
-    mypy src/{{cookiecutter.module_name}} tests setup.py
+    mypy src/{{cookiecutter.module_name}} tests
 
 [testenv:lint]
 description = Lint codebase by running pre-commit (Black, isort, Flake8).


### PR DESCRIPTION
- Fix some syntax and whitespace issues we found in the first run
- Add a simple test module so that pytest will run on the first commit
- Don't initially use docs-linkcheck in GitHub Actions because the project's own docs and PyPI package won't be available yet.