### PR TITLE
DM-36698: Add GitHub Actions workflows to SPIE and ADASS documents

### DIFF
--- a/project_templates/technote_aastex/testn-000/.github/workflows/ci.yaml
+++ b/project_templates/technote_aastex/testn-000/.github/workflows/ci.yaml
@@ -7,15 +7,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # full history for metadata
           submodules: true
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: "3.10"
 
       - name: Python install
         run: |

--- a/project_templates/technote_aastex/testn-000/.github/workflows/ci.yaml
+++ b/project_templates/technote_aastex/testn-000/.github/workflows/ci.yaml
@@ -43,4 +43,4 @@ jobs:
           LTD_PASSWORD: ${{ secrets.LTD_PASSWORD }}
           LTD_USERNAME: ${{ secrets.LTD_USERNAME }}
         run: |
-          lander --upload --pdf TESTN-000.pdf --lsstdoc TESTN-000.tex --ltd-product testn-000
+          lander --upload --pdf TESTN-000.pdf --ltd-product testn-000 --title "Document Title" --handle "TESTN-000"

--- a/project_templates/technote_aastex/{{cookiecutter.series.lower()}}-{{cookiecutter.serial_number}}/.github/workflows/ci.yaml
+++ b/project_templates/technote_aastex/{{cookiecutter.series.lower()}}-{{cookiecutter.serial_number}}/.github/workflows/ci.yaml
@@ -7,15 +7,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # full history for metadata
           submodules: true
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: "3.10"
 
       - name: Python install
         run: |

--- a/project_templates/technote_aastex/{{cookiecutter.series.lower()}}-{{cookiecutter.serial_number}}/.github/workflows/ci.yaml
+++ b/project_templates/technote_aastex/{{cookiecutter.series.lower()}}-{{cookiecutter.serial_number}}/.github/workflows/ci.yaml
@@ -43,4 +43,4 @@ jobs:
           LTD_PASSWORD: {% raw %}${{ secrets.LTD_PASSWORD }}{% endraw %}
           LTD_USERNAME: {% raw %}${{ secrets.LTD_USERNAME }}{% endraw %}
         run: |
-          lander --upload --pdf {{ cookiecutter.series }}-{{ cookiecutter.serial_number }}.pdf --lsstdoc {{ cookiecutter.series }}-{{ cookiecutter.serial_number }}.tex --ltd-product {{ cookiecutter.series.lower() }}-{{ cookiecutter.serial_number }}
+          lander --upload --pdf {{ cookiecutter.series }}-{{ cookiecutter.serial_number }}.pdf --ltd-product {{ cookiecutter.series.lower() }}-{{ cookiecutter.serial_number }} --title "{{cookiecutter.title}}" --handle "{{cookiecutter.series}}-{{cookiecutter.serial_number}}"

--- a/project_templates/technote_adasstex/testn-000/.github/workflows/ci.yaml
+++ b/project_templates/technote_adasstex/testn-000/.github/workflows/ci.yaml
@@ -38,4 +38,4 @@ jobs:
           LTD_PASSWORD: ${{ secrets.LTD_PASSWORD }}
           LTD_USERNAME: ${{ secrets.LTD_USERNAME }}
         run: |
-          lander --upload --pdf TESTN-000.pdf --lsstdoc TESTN-000.tex --ltd-product testn-000
+          lander --upload --pdf TESTN-000.pdf --ltd-product testn-000 --title "Document Title" --handle "TESTN-000"

--- a/project_templates/technote_adasstex/testn-000/.github/workflows/ci.yaml
+++ b/project_templates/technote_adasstex/testn-000/.github/workflows/ci.yaml
@@ -1,0 +1,41 @@
+name: CI
+
+"on": [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # full history for metadata
+          submodules: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Python install
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "lander<2.0.0"
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: sqrereadonly
+          password: ${{ secrets.DOCKERHUB_SQREREADONLY_TOKEN }}
+
+      - name: TeX build
+        run: |
+          docker run --rm -v `pwd`:/workspace -w /workspace lsstsqre/lsst-texmf:latest sh -c 'make'
+
+      - name: Landing page upload
+        if: ${{ github.event_name == 'push' }}
+        env:
+          LTD_PASSWORD: ${{ secrets.LTD_PASSWORD }}
+          LTD_USERNAME: ${{ secrets.LTD_USERNAME }}
+        run: |
+          lander --upload --pdf TESTN-000.pdf --lsstdoc TESTN-000.tex --ltd-product testn-000

--- a/project_templates/technote_adasstex/{{cookiecutter.series.lower()}}-{{cookiecutter.serial_number}}/.github/workflows/ci.yaml
+++ b/project_templates/technote_adasstex/{{cookiecutter.series.lower()}}-{{cookiecutter.serial_number}}/.github/workflows/ci.yaml
@@ -38,4 +38,4 @@ jobs:
           LTD_PASSWORD: {% raw %}${{ secrets.LTD_PASSWORD }}{% endraw %}
           LTD_USERNAME: {% raw %}${{ secrets.LTD_USERNAME }}{% endraw %}
         run: |
-          lander --upload --pdf {{ cookiecutter.series }}-{{ cookiecutter.serial_number }}.pdf --lsstdoc {{ cookiecutter.series }}-{{ cookiecutter.serial_number }}.tex --ltd-product {{ cookiecutter.series.lower() }}-{{ cookiecutter.serial_number }}
+          lander --upload --pdf {{ cookiecutter.series }}-{{ cookiecutter.serial_number }}.pdf --ltd-product {{ cookiecutter.series.lower() }}-{{ cookiecutter.serial_number }} --title "{{cookiecutter.title}}" --handle "{{cookiecutter.series}}-{{cookiecutter.serial_number}}"

--- a/project_templates/technote_adasstex/{{cookiecutter.series.lower()}}-{{cookiecutter.serial_number}}/.github/workflows/ci.yaml
+++ b/project_templates/technote_adasstex/{{cookiecutter.series.lower()}}-{{cookiecutter.serial_number}}/.github/workflows/ci.yaml
@@ -1,0 +1,41 @@
+name: CI
+
+"on": [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # full history for metadata
+          submodules: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Python install
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "lander<2.0.0"
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: sqrereadonly
+          password: {% raw %}${{ secrets.DOCKERHUB_SQREREADONLY_TOKEN }}{% endraw %}
+
+      - name: TeX build
+        run: |
+          docker run --rm -v `pwd`:/workspace -w /workspace lsstsqre/lsst-texmf:latest sh -c 'make'
+
+      - name: Landing page upload
+        if: {% raw %}${{ github.event_name == 'push' }}{% endraw %}
+        env:
+          LTD_PASSWORD: {% raw %}${{ secrets.LTD_PASSWORD }}{% endraw %}
+          LTD_USERNAME: {% raw %}${{ secrets.LTD_USERNAME }}{% endraw %}
+        run: |
+          lander --upload --pdf {{ cookiecutter.series }}-{{ cookiecutter.serial_number }}.pdf --lsstdoc {{ cookiecutter.series }}-{{ cookiecutter.serial_number }}.tex --ltd-product {{ cookiecutter.series.lower() }}-{{ cookiecutter.serial_number }}

--- a/project_templates/technote_latex/testn-000/.github/workflows/ci.yaml
+++ b/project_templates/technote_latex/testn-000/.github/workflows/ci.yaml
@@ -7,15 +7,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # full history for metadata
           submodules: true
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: "3.10"
 
       - name: Python install
         run: |

--- a/project_templates/technote_latex/{{cookiecutter.series.lower()}}-{{cookiecutter.serial_number}}/.github/workflows/ci.yaml
+++ b/project_templates/technote_latex/{{cookiecutter.series.lower()}}-{{cookiecutter.serial_number}}/.github/workflows/ci.yaml
@@ -7,15 +7,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # full history for metadata
           submodules: true
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: "3.10"
 
       - name: Python install
         run: |

--- a/project_templates/technote_spietex/testn-000/.github/workflows/ci.yaml
+++ b/project_templates/technote_spietex/testn-000/.github/workflows/ci.yaml
@@ -38,4 +38,4 @@ jobs:
           LTD_PASSWORD: ${{ secrets.LTD_PASSWORD }}
           LTD_USERNAME: ${{ secrets.LTD_USERNAME }}
         run: |
-          lander --upload --pdf TESTN-000.pdf --lsstdoc TESTN-000.tex --ltd-product testn-000
+          lander --upload --pdf TESTN-000.pdf --ltd-product testn-000 --title "Document Title" --handle "TESTN-000"

--- a/project_templates/technote_spietex/testn-000/.github/workflows/ci.yaml
+++ b/project_templates/technote_spietex/testn-000/.github/workflows/ci.yaml
@@ -1,0 +1,41 @@
+name: CI
+
+"on": [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # full history for metadata
+          submodules: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Python install
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "lander<2.0.0"
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: sqrereadonly
+          password: ${{ secrets.DOCKERHUB_SQREREADONLY_TOKEN }}
+
+      - name: TeX build
+        run: |
+          docker run --rm -v `pwd`:/workspace -w /workspace lsstsqre/lsst-texmf:latest sh -c 'make'
+
+      - name: Landing page upload
+        if: ${{ github.event_name == 'push' }}
+        env:
+          LTD_PASSWORD: ${{ secrets.LTD_PASSWORD }}
+          LTD_USERNAME: ${{ secrets.LTD_USERNAME }}
+        run: |
+          lander --upload --pdf TESTN-000.pdf --lsstdoc TESTN-000.tex --ltd-product testn-000

--- a/project_templates/technote_spietex/{{cookiecutter.series.lower()}}-{{cookiecutter.serial_number}}/.github/workflows/ci.yaml
+++ b/project_templates/technote_spietex/{{cookiecutter.series.lower()}}-{{cookiecutter.serial_number}}/.github/workflows/ci.yaml
@@ -38,4 +38,4 @@ jobs:
           LTD_PASSWORD: {% raw %}${{ secrets.LTD_PASSWORD }}{% endraw %}
           LTD_USERNAME: {% raw %}${{ secrets.LTD_USERNAME }}{% endraw %}
         run: |
-          lander --upload --pdf {{ cookiecutter.series }}-{{ cookiecutter.serial_number }}.pdf --lsstdoc {{ cookiecutter.series }}-{{ cookiecutter.serial_number }}.tex --ltd-product {{ cookiecutter.series.lower() }}-{{ cookiecutter.serial_number }}
+          lander --upload --pdf {{ cookiecutter.series }}-{{ cookiecutter.serial_number }}.pdf --ltd-product {{ cookiecutter.series.lower() }}-{{ cookiecutter.serial_number }} --title "{{cookiecutter.title}}" --handle "{{cookiecutter.series}}-{{cookiecutter.serial_number}}"

--- a/project_templates/technote_spietex/{{cookiecutter.series.lower()}}-{{cookiecutter.serial_number}}/.github/workflows/ci.yaml
+++ b/project_templates/technote_spietex/{{cookiecutter.series.lower()}}-{{cookiecutter.serial_number}}/.github/workflows/ci.yaml
@@ -1,0 +1,41 @@
+name: CI
+
+"on": [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # full history for metadata
+          submodules: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Python install
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "lander<2.0.0"
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: sqrereadonly
+          password: {% raw %}${{ secrets.DOCKERHUB_SQREREADONLY_TOKEN }}{% endraw %}
+
+      - name: TeX build
+        run: |
+          docker run --rm -v `pwd`:/workspace -w /workspace lsstsqre/lsst-texmf:latest sh -c 'make'
+
+      - name: Landing page upload
+        if: {% raw %}${{ github.event_name == 'push' }}{% endraw %}
+        env:
+          LTD_PASSWORD: {% raw %}${{ secrets.LTD_PASSWORD }}{% endraw %}
+          LTD_USERNAME: {% raw %}${{ secrets.LTD_USERNAME }}{% endraw %}
+        run: |
+          lander --upload --pdf {{ cookiecutter.series }}-{{ cookiecutter.serial_number }}.pdf --lsstdoc {{ cookiecutter.series }}-{{ cookiecutter.serial_number }}.tex --ltd-product {{ cookiecutter.series.lower() }}-{{ cookiecutter.serial_number }}


### PR DESCRIPTION
These GitHub Actions workflows were missing from the initial template introductions.

Also update the actions in all tex-based document templates.

Finally, stop using the Lander v1 `--lsstdoc` option in non-lsstdoc document templates. The --lsstdoc option in lander v1 wasn't intended to be used for other LaTeX document classes, and although it works sometimes, it can fail. Let's try setting core metadata, the title and handle, manually. We'll return to this with Lander v2 where we can either set metadata in a file, or introduce specific tex parsers for SPIE, ADASS, and AASTeX documents.