### PR TITLE
DM-36698: Fixes for SPIE, ADASS, and AASTeX technote templates

### DIFF
--- a/project_templates/technote_aastex/testn-000/.github/workflows/ci.yaml
+++ b/project_templates/technote_aastex/testn-000/.github/workflows/ci.yaml
@@ -43,4 +43,4 @@ jobs:
           LTD_PASSWORD: ${{ secrets.LTD_PASSWORD }}
           LTD_USERNAME: ${{ secrets.LTD_USERNAME }}
         run: |
-          lander --upload --pdf TESTN-000.pdf --ltd-product testn-000 --title "Document Title" --handle "TESTN-000"
+          lander --upload --pdf TESTN-000.pdf --ltd-product testn-000 --title "Document Title" --handle "TESTN-000" --lsstdoc "TESTN-000.tex"

--- a/project_templates/technote_aastex/testn-000/README.rst
+++ b/project_templates/technote_aastex/testn-000/README.rst
@@ -1,7 +1,7 @@
 .. image:: https://img.shields.io/badge/testn--000-lsst.io-brightgreen.svg
    :target: https://testn-000.lsst.io
-.. image:: https://travis-ci.com/lsst-dm/testn-000.svg
-   :target: https://travis-ci.com/lsst-dm/testn-000
+.. image:: https://github.com/lsst-dm/testn-000/workflows/CI/badge.svg
+   :target: https://github.com/lsst-dm/testn-000/actions/
 
 ##############
 Document Title

--- a/project_templates/technote_aastex/{{cookiecutter.series.lower()}}-{{cookiecutter.serial_number}}/.github/workflows/ci.yaml
+++ b/project_templates/technote_aastex/{{cookiecutter.series.lower()}}-{{cookiecutter.serial_number}}/.github/workflows/ci.yaml
@@ -43,4 +43,4 @@ jobs:
           LTD_PASSWORD: {% raw %}${{ secrets.LTD_PASSWORD }}{% endraw %}
           LTD_USERNAME: {% raw %}${{ secrets.LTD_USERNAME }}{% endraw %}
         run: |
-          lander --upload --pdf {{ cookiecutter.series }}-{{ cookiecutter.serial_number }}.pdf --ltd-product {{ cookiecutter.series.lower() }}-{{ cookiecutter.serial_number }} --title "{{cookiecutter.title}}" --handle "{{cookiecutter.series}}-{{cookiecutter.serial_number}}"
+          lander --upload --pdf {{ cookiecutter.series }}-{{ cookiecutter.serial_number }}.pdf --ltd-product {{ cookiecutter.series.lower() }}-{{ cookiecutter.serial_number }} --title "{{cookiecutter.title}}" --handle "{{cookiecutter.series}}-{{cookiecutter.serial_number}}" --lsstdoc "{{ cookiecutter.series }}-{{ cookiecutter.serial_number }}.tex"

--- a/project_templates/technote_aastex/{{cookiecutter.series.lower()}}-{{cookiecutter.serial_number}}/README.rst
+++ b/project_templates/technote_aastex/{{cookiecutter.series.lower()}}-{{cookiecutter.serial_number}}/README.rst
@@ -1,7 +1,7 @@
 .. image:: https://img.shields.io/badge/{{ cookiecutter.series.lower() }}--{{ cookiecutter.serial_number }}-lsst.io-brightgreen.svg
    :target: https://{{ cookiecutter.series.lower() }}-{{ cookiecutter.serial_number }}.lsst.io
-.. image:: https://travis-ci.com/{{ cookiecutter.github_org }}/{{ cookiecutter.series.lower() }}-{{ cookiecutter.serial_number }}.svg
-   :target: https://travis-ci.com/{{ cookiecutter.github_org }}/{{ cookiecutter.series.lower() }}-{{ cookiecutter.serial_number }}
+.. image:: https://github.com/{{ cookiecutter.github_org }}/{{ cookiecutter.series.lower() }}-{{ cookiecutter.serial_number }}/workflows/CI/badge.svg
+   :target: https://github.com/{{ cookiecutter.github_org }}/{{ cookiecutter.series.lower() }}-{{ cookiecutter.serial_number }}/actions/
 
 {{ "#" * cookiecutter.title|length }}
 {{ cookiecutter.title }}

--- a/project_templates/technote_adasstex/testn-000/.github/workflows/ci.yaml
+++ b/project_templates/technote_adasstex/testn-000/.github/workflows/ci.yaml
@@ -38,4 +38,4 @@ jobs:
           LTD_PASSWORD: ${{ secrets.LTD_PASSWORD }}
           LTD_USERNAME: ${{ secrets.LTD_USERNAME }}
         run: |
-          lander --upload --pdf TESTN-000.pdf --ltd-product testn-000 --title "Document Title" --handle "TESTN-000"
+          lander --upload --pdf TESTN-000.pdf --ltd-product testn-000 --lsstdoc "TESTN-000.tex"

--- a/project_templates/technote_adasstex/testn-000/README.rst
+++ b/project_templates/technote_adasstex/testn-000/README.rst
@@ -1,7 +1,7 @@
 .. image:: https://img.shields.io/badge/testn--000-lsst.io-brightgreen.svg
    :target: https://testn-000.lsst.io
-.. image:: https://travis-ci.com/lsst-dm/testn-000.svg
-   :target: https://travis-ci.com/lsst-dm/testn-000
+.. image:: https://github.com/lsst-dm/testn-000/workflows/CI/badge.svg
+   :target: https://github.com/lsst-dm/testn-000/actions/
 
 ##############
 Document Title

--- a/project_templates/technote_adasstex/{{cookiecutter.series.lower()}}-{{cookiecutter.serial_number}}/.github/workflows/ci.yaml
+++ b/project_templates/technote_adasstex/{{cookiecutter.series.lower()}}-{{cookiecutter.serial_number}}/.github/workflows/ci.yaml
@@ -38,4 +38,4 @@ jobs:
           LTD_PASSWORD: {% raw %}${{ secrets.LTD_PASSWORD }}{% endraw %}
           LTD_USERNAME: {% raw %}${{ secrets.LTD_USERNAME }}{% endraw %}
         run: |
-          lander --upload --pdf {{ cookiecutter.series }}-{{ cookiecutter.serial_number }}.pdf --ltd-product {{ cookiecutter.series.lower() }}-{{ cookiecutter.serial_number }} --title "{{cookiecutter.title}}" --handle "{{cookiecutter.series}}-{{cookiecutter.serial_number}}"
+          lander --upload --pdf {{ cookiecutter.series }}-{{ cookiecutter.serial_number }}.pdf --ltd-product {{ cookiecutter.series.lower() }}-{{ cookiecutter.serial_number }} --lsstdoc "{{ cookiecutter.series }}-{{ cookiecutter.serial_number }}.tex"

--- a/project_templates/technote_adasstex/{{cookiecutter.series.lower()}}-{{cookiecutter.serial_number}}/README.rst
+++ b/project_templates/technote_adasstex/{{cookiecutter.series.lower()}}-{{cookiecutter.serial_number}}/README.rst
@@ -1,7 +1,7 @@
 .. image:: https://img.shields.io/badge/{{ cookiecutter.series.lower() }}--{{ cookiecutter.serial_number }}-lsst.io-brightgreen.svg
    :target: https://{{ cookiecutter.series.lower() }}-{{ cookiecutter.serial_number }}.lsst.io
-.. image:: https://travis-ci.com/{{ cookiecutter.github_org }}/{{ cookiecutter.series.lower() }}-{{ cookiecutter.serial_number }}.svg
-   :target: https://travis-ci.com/{{ cookiecutter.github_org }}/{{ cookiecutter.series.lower() }}-{{ cookiecutter.serial_number }}
+.. image:: https://github.com/{{ cookiecutter.github_org }}/{{ cookiecutter.series.lower() }}-{{ cookiecutter.serial_number }}/workflows/CI/badge.svg
+   :target: https://github.com/{{ cookiecutter.github_org }}/{{ cookiecutter.series.lower() }}-{{ cookiecutter.serial_number }}/actions/
 
 {{ "#" * cookiecutter.title|length }}
 {{ cookiecutter.title }}

--- a/project_templates/technote_spietex/testn-000/.github/workflows/ci.yaml
+++ b/project_templates/technote_spietex/testn-000/.github/workflows/ci.yaml
@@ -38,4 +38,4 @@ jobs:
           LTD_PASSWORD: ${{ secrets.LTD_PASSWORD }}
           LTD_USERNAME: ${{ secrets.LTD_USERNAME }}
         run: |
-          lander --upload --pdf TESTN-000.pdf --ltd-product testn-000 --title "Document Title" --handle "TESTN-000"
+          lander --upload --pdf TESTN-000.pdf --ltd-product testn-000 --lsstdoc "TESTN-000.tex"

--- a/project_templates/technote_spietex/testn-000/README.rst
+++ b/project_templates/technote_spietex/testn-000/README.rst
@@ -1,7 +1,7 @@
 .. image:: https://img.shields.io/badge/testn--000-lsst.io-brightgreen.svg
    :target: https://testn-000.lsst.io
-.. image:: https://travis-ci.com/lsst-dm/testn-000.svg
-   :target: https://travis-ci.com/lsst-dm/testn-000
+.. image:: https://github.com/lsst-dm/testn-000/workflows/CI/badge.svg
+   :target: https://github.com/lsst-dm/testn-000/actions/
 
 ##############
 Document Title

--- a/project_templates/technote_spietex/{{cookiecutter.series.lower()}}-{{cookiecutter.serial_number}}/.github/workflows/ci.yaml
+++ b/project_templates/technote_spietex/{{cookiecutter.series.lower()}}-{{cookiecutter.serial_number}}/.github/workflows/ci.yaml
@@ -38,4 +38,4 @@ jobs:
           LTD_PASSWORD: {% raw %}${{ secrets.LTD_PASSWORD }}{% endraw %}
           LTD_USERNAME: {% raw %}${{ secrets.LTD_USERNAME }}{% endraw %}
         run: |
-          lander --upload --pdf {{ cookiecutter.series }}-{{ cookiecutter.serial_number }}.pdf --ltd-product {{ cookiecutter.series.lower() }}-{{ cookiecutter.serial_number }} --title "{{cookiecutter.title}}" --handle "{{cookiecutter.series}}-{{cookiecutter.serial_number}}"
+          lander --upload --pdf {{ cookiecutter.series }}-{{ cookiecutter.serial_number }}.pdf --ltd-product {{ cookiecutter.series.lower() }}-{{ cookiecutter.serial_number }} --lsstdoc "{{ cookiecutter.series }}-{{ cookiecutter.serial_number }}.tex"

--- a/project_templates/technote_spietex/{{cookiecutter.series.lower()}}-{{cookiecutter.serial_number}}/README.rst
+++ b/project_templates/technote_spietex/{{cookiecutter.series.lower()}}-{{cookiecutter.serial_number}}/README.rst
@@ -1,7 +1,7 @@
 .. image:: https://img.shields.io/badge/{{ cookiecutter.series.lower() }}--{{ cookiecutter.serial_number }}-lsst.io-brightgreen.svg
    :target: https://{{ cookiecutter.series.lower() }}-{{ cookiecutter.serial_number }}.lsst.io
-.. image:: https://travis-ci.com/{{ cookiecutter.github_org }}/{{ cookiecutter.series.lower() }}-{{ cookiecutter.serial_number }}.svg
-   :target: https://travis-ci.com/{{ cookiecutter.github_org }}/{{ cookiecutter.series.lower() }}-{{ cookiecutter.serial_number }}
+.. image:: https://github.com/{{ cookiecutter.github_org }}/{{ cookiecutter.series.lower() }}-{{ cookiecutter.serial_number }}/workflows/CI/badge.svg
+   :target: https://github.com/{{ cookiecutter.github_org }}/{{ cookiecutter.series.lower() }}-{{ cookiecutter.serial_number }}/actions/
 
 {{ "#" * cookiecutter.title|length }}
 {{ cookiecutter.title }}


### PR DESCRIPTION
- Reverts the move to drop the lander `--lsstdoc` usage from #186. Although its not really correct, these templates do add Rubin lsstdoc-specific metadata macros that potentially lander v1 can pick up. Again, this will get resolved in Lander v2.
- Updates the README templates in these documents to point to GitHub Actions, rather than Travis CI, for the CI badge.