### PR TITLE
DM-37046: Switch to pydantic.BaseSettings for FastAPI config

### DIFF
--- a/project_templates/fastapi_safir_app/example/.pre-commit-config.yaml
+++ b/project_templates/fastapi_safir_app/example/.pre-commit-config.yaml
@@ -13,11 +13,11 @@ repos:
         additional_dependencies: [toml]
 
   - repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 22.10.0
     hooks:
       - id: black
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 5.0.2
+    rev: 5.0.4
     hooks:
       - id: flake8

--- a/project_templates/fastapi_safir_app/example/Dockerfile
+++ b/project_templates/fastapi_safir_app/example/Dockerfile
@@ -14,7 +14,7 @@
 #   - Runs a non-root user.
 #   - Sets up the entrypoint and port.
 
-FROM python:3.10.5-slim-bullseye as base-image
+FROM python:3.10.7-slim-bullseye as base-image
 
 # Update system packages
 COPY scripts/install-base-packages.sh .

--- a/project_templates/fastapi_safir_app/example/requirements/main.in
+++ b/project_templates/fastapi_safir_app/example/requirements/main.in
@@ -11,4 +11,4 @@ starlette
 uvicorn[standard]
 
 # Other dependencies.
-safir>=3.3.0
+safir>=3.4.0

--- a/project_templates/fastapi_safir_app/example/src/example/config.py
+++ b/project_templates/fastapi_safir_app/example/src/example/config.py
@@ -24,12 +24,6 @@ class Configuration(BaseSettings):
         env="SAFIR_PROFILE",
     )
 
-    logger_name: str = Field(
-        "example",
-        title="Root name of application's logger",
-        env="SAFIR_LOGGER",
-    )
-
     log_level: LogLevel = Field(
         LogLevel.INFO,
         title="Log level of the application's logger",

--- a/project_templates/fastapi_safir_app/example/src/example/config.py
+++ b/project_templates/fastapi_safir_app/example/src/example/config.py
@@ -2,39 +2,39 @@
 
 from __future__ import annotations
 
-import os
-from dataclasses import dataclass
+from pydantic import BaseSettings, Field
+from safir.logging import LogLevel, Profile
 
 __all__ = ["Configuration", "config"]
 
 
-@dataclass
-class Configuration:
+class Configuration(BaseSettings):
     """Configuration for example."""
 
-    name: str = os.getenv("SAFIR_NAME", "example")
-    """The application's name, which doubles as the root HTTP endpoint path.
+    name: str = Field(
+        "example",
+        title="Name of application",
+        description="Doubles as the root HTTP endpoint path.",
+        env="SAFIR_NAME",
+    )
 
-    Set with the ``SAFIR_NAME`` environment variable.
-    """
+    profile: Profile = Field(
+        Profile.development,
+        title="Application logging profile",
+        env="SAFIR_PROFILE",
+    )
 
-    profile: str = os.getenv("SAFIR_PROFILE", "development")
-    """Application run profile: "development" or "production".
+    logger_name: str = Field(
+        "example",
+        title="Root name of application's logger",
+        env="SAFIR_LOGGER",
+    )
 
-    Set with the ``SAFIR_PROFILE`` environment variable.
-    """
-
-    logger_name: str = os.getenv("SAFIR_LOGGER", "example")
-    """The root name of the application's logger.
-
-    Set with the ``SAFIR_LOGGER`` environment variable.
-    """
-
-    log_level: str = os.getenv("SAFIR_LOG_LEVEL", "INFO")
-    """The log level of the application's logger.
-
-    Set with the ``SAFIR_LOG_LEVEL`` environment variable.
-    """
+    log_level: LogLevel = Field(
+        LogLevel.INFO,
+        title="Log level of the application's logger",
+        env="SAFIR_LOG_LEVEL",
+    )
 
 
 config = Configuration()

--- a/project_templates/fastapi_safir_app/example/src/example/main.py
+++ b/project_templates/fastapi_safir_app/example/src/example/main.py
@@ -24,7 +24,7 @@ __all__ = ["app", "config"]
 configure_logging(
     profile=config.profile,
     log_level=config.log_level,
-    name=config.logger_name,
+    name="example",
 )
 configure_uvicorn_logging(config.log_level)
 

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/.pre-commit-config.yaml
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/.pre-commit-config.yaml
@@ -13,11 +13,11 @@ repos:
         additional_dependencies: [toml]
 
   - repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 22.10.0
     hooks:
       - id: black
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 5.0.2
+    rev: 5.0.4
     hooks:
       - id: flake8

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/Dockerfile
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/Dockerfile
@@ -14,7 +14,7 @@
 #   - Runs a non-root user.
 #   - Sets up the entrypoint and port.
 
-FROM python:3.10.5-slim-bullseye as base-image
+FROM python:3.10.7-slim-bullseye as base-image
 
 # Update system packages
 COPY scripts/install-base-packages.sh .

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/requirements/main.in
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/requirements/main.in
@@ -11,4 +11,4 @@ starlette
 uvicorn[standard]
 
 # Other dependencies.
-safir>=3.3.0
+safir>=3.4.0

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/src/{{cookiecutter.package_name}}/config.py
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/src/{{cookiecutter.package_name}}/config.py
@@ -24,12 +24,6 @@ class Configuration(BaseSettings):
         env="SAFIR_PROFILE",
     )
 
-    logger_name: str = Field(
-        "{{ cookiecutter.package_name }}",
-        title="Root name of application's logger",
-        env="SAFIR_LOGGER",
-    )
-
     log_level: LogLevel = Field(
         LogLevel.INFO,
         title="Log level of the application's logger",

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/src/{{cookiecutter.package_name}}/config.py
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/src/{{cookiecutter.package_name}}/config.py
@@ -2,39 +2,39 @@
 
 from __future__ import annotations
 
-import os
-from dataclasses import dataclass
+from pydantic import BaseSettings, Field
+from safir.logging import LogLevel, Profile
 
 __all__ = ["Configuration", "config"]
 
 
-@dataclass
-class Configuration:
+class Configuration(BaseSettings):
     """Configuration for {{ cookiecutter.package_name }}."""
 
-    name: str = os.getenv("SAFIR_NAME", "{{ cookiecutter.name | lower }}")
-    """The application's name, which doubles as the root HTTP endpoint path.
+    name: str = Field(
+        "{{ cookiecutter.name | lower }}",
+        title="Name of application",
+        description="Doubles as the root HTTP endpoint path.",
+        env="SAFIR_NAME",
+    )
 
-    Set with the ``SAFIR_NAME`` environment variable.
-    """
+    profile: Profile = Field(
+        Profile.development,
+        title="Application logging profile",
+        env="SAFIR_PROFILE",
+    )
 
-    profile: str = os.getenv("SAFIR_PROFILE", "development")
-    """Application run profile: "development" or "production".
+    logger_name: str = Field(
+        "{{ cookiecutter.package_name }}",
+        title="Root name of application's logger",
+        env="SAFIR_LOGGER",
+    )
 
-    Set with the ``SAFIR_PROFILE`` environment variable.
-    """
-
-    logger_name: str = os.getenv("SAFIR_LOGGER", "{{ cookiecutter.package_name }}")
-    """The root name of the application's logger.
-
-    Set with the ``SAFIR_LOGGER`` environment variable.
-    """
-
-    log_level: str = os.getenv("SAFIR_LOG_LEVEL", "INFO")
-    """The log level of the application's logger.
-
-    Set with the ``SAFIR_LOG_LEVEL`` environment variable.
-    """
+    log_level: LogLevel = Field(
+        LogLevel.INFO,
+        title="Log level of the application's logger",
+        env="SAFIR_LOG_LEVEL",
+    )
 
 
 config = Configuration()

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/src/{{cookiecutter.package_name}}/main.py
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/src/{{cookiecutter.package_name}}/main.py
@@ -24,7 +24,7 @@ __all__ = ["app", "config"]
 configure_logging(
     profile=config.profile,
     log_level=config.log_level,
-    name=config.logger_name,
+    name="{{ cookiecutter.package_name }}",
 )
 configure_uvicorn_logging(config.log_level)
 


### PR DESCRIPTION
Use pydantic.BaseSettings instead of a dataclass to construct the configuration for a FastAPI Safir app.  Use the new enums from Safir to validate the profile and log_level settings.