### PR TITLE
Update FastAPI project template

### DIFF
--- a/project_templates/fastapi_safir_app/example/.github/workflows/ci.yaml
+++ b/project_templates/fastapi_safir_app/example/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.0
@@ -38,8 +38,7 @@ jobs:
     strategy:
       matrix:
         python:
-          - "3.9"
-          - "3.10"
+          - "3.11"
 
     steps:
       - uses: actions/checkout@v3
@@ -80,12 +79,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN }}
-
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v2
         with:
@@ -99,7 +92,6 @@ jobs:
           context: .
           push: true
           tags: |
-            lsstsqre/example:${{ steps.vars.outputs.tag }}
             ghcr.io/lsst-sqre/example:${{ steps.vars.outputs.tag }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/project_templates/fastapi_safir_app/example/.pre-commit-config.yaml
+++ b/project_templates/fastapi_safir_app/example/.pre-commit-config.yaml
@@ -1,23 +1,23 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: trailing-whitespace
       - id: check-yaml
       - id: check-toml
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.11.4
     hooks:
       - id: isort
         additional_dependencies: [toml]
 
   - repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 22.12.0
     hooks:
       - id: black
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 5.0.4
+    rev: 6.0.0
     hooks:
       - id: flake8

--- a/project_templates/fastapi_safir_app/example/Dockerfile
+++ b/project_templates/fastapi_safir_app/example/Dockerfile
@@ -14,7 +14,7 @@
 #   - Runs a non-root user.
 #   - Sets up the entrypoint and port.
 
-FROM python:3.10.7-slim-bullseye as base-image
+FROM python:3.11.1-slim-bullseye as base-image
 
 # Update system packages
 COPY scripts/install-base-packages.sh .

--- a/project_templates/fastapi_safir_app/example/pyproject.toml
+++ b/project_templates/fastapi_safir_app/example/pyproject.toml
@@ -11,15 +11,13 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Intended Audience :: Developers",
     "Natural Language :: English",
     "Operating System :: POSIX",
     "Typing :: Typed",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.11"
 # Use requirements/main.in for runtime dependencies instead.
 dependencies = []
 dynamic = ["version"]
@@ -61,7 +59,7 @@ exclude_lines = [
 
 [tool.black]
 line-length = 79
-target-version = ['py38']
+target-version = ["py311"]
 exclude = '''
 /(
     \.eggs
@@ -101,6 +99,7 @@ disallow_incomplete_defs = true
 ignore_missing_imports = true
 local_partial_types = true
 no_implicit_reexport = true
+show_error_codes = true
 strict_equality = true
 warn_redundant_casts = true
 warn_unreachable = true

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/.github/workflows/ci.yaml
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.0
@@ -38,8 +38,7 @@ jobs:
     strategy:
       matrix:
         python:
-          - "3.9"
-          - "3.10"
+          - "3.11"
 
     steps:
       - uses: actions/checkout@v3
@@ -80,12 +79,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: {{ "${{ secrets.DOCKER_USERNAME }}" }}
-          password: {{ "${{ secrets.DOCKER_TOKEN }}" }}
-
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v2
         with:
@@ -99,7 +92,6 @@ jobs:
           context: .
           push: true
           tags: |
-            lsstsqre/{{ cookiecutter.name | lower }}:{{ "${{ steps.vars.outputs.tag }}" }}
             ghcr.io/lsst-sqre/{{ cookiecutter.name | lower }}:{{ "${{ steps.vars.outputs.tag }}" }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/.pre-commit-config.yaml
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/.pre-commit-config.yaml
@@ -1,23 +1,23 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: trailing-whitespace
       - id: check-yaml
       - id: check-toml
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.11.4
     hooks:
       - id: isort
         additional_dependencies: [toml]
 
   - repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 22.12.0
     hooks:
       - id: black
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 5.0.4
+    rev: 6.0.0
     hooks:
       - id: flake8

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/Dockerfile
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/Dockerfile
@@ -14,7 +14,7 @@
 #   - Runs a non-root user.
 #   - Sets up the entrypoint and port.
 
-FROM python:3.10.7-slim-bullseye as base-image
+FROM python:3.11.1-slim-bullseye as base-image
 
 # Update system packages
 COPY scripts/install-base-packages.sh .

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/pyproject.toml
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/pyproject.toml
@@ -11,15 +11,13 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Intended Audience :: Developers",
     "Natural Language :: English",
     "Operating System :: POSIX",
     "Typing :: Typed",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.11"
 # Use requirements/main.in for runtime dependencies instead.
 dependencies = []
 dynamic = ["version"]
@@ -61,7 +59,7 @@ exclude_lines = [
 
 [tool.black]
 line-length = 79
-target-version = ['py38']
+target-version = ["py311"]
 exclude = '''
 /(
     \.eggs
@@ -101,6 +99,7 @@ disallow_incomplete_defs = true
 ignore_missing_imports = true
 local_partial_types = true
 no_implicit_reexport = true
+show_error_codes = true
 strict_equality = true
 warn_redundant_casts = true
 warn_unreachable = true


### PR DESCRIPTION
Adopt various updates that we've been making to the projects generated by this template, on the grounds that new projects should default to the latest and greatest configuration.

- Require Python 3.11, update the default Dockerfile accordingly, and don't test against older versions.  If older version support is needed, it can always be re-added.

- Stop pushing containers to Docker Hub by default.  We now use GitHub Artifact Registry as the sole source of containers for many services, and this seems a better default for new packages.

- Enable showing the error code in mypy errors.  This is helpful if one needs to add an override.

- Update .pre-commit-config.yaml to the latest versions.