### PR TITLE
A few small fastapi_safir_app template fixes

### DIFF
--- a/project_templates/fastapi_safir_app/example/Makefile
+++ b/project_templates/fastapi_safir_app/example/Makefile
@@ -24,4 +24,4 @@ update: update-deps init
 
 .PHONY: run
 run:
-	tox -e run
+	tox -e=run

--- a/project_templates/fastapi_safir_app/example/src/example/__init__.py
+++ b/project_templates/fastapi_safir_app/example/src/example/__init__.py
@@ -8,7 +8,7 @@ __version__: str
 """The application version string (PEP 440 / SemVer compatible)."""
 
 try:
-    __version__ = version(__name__)
+    __version__ = version("example")
 except PackageNotFoundError:
     # package is not installed
     __version__ = "0.0.0"

--- a/project_templates/fastapi_safir_app/example/tox.ini
+++ b/project_templates/fastapi_safir_app/example/tox.ini
@@ -21,7 +21,7 @@ commands = coverage report
 [testenv:typing]
 description = Run mypy.
 commands =
-    mypy src/example tests setup.py
+    mypy src/example tests
 
 [testenv:lint]
 description = Lint codebase by running pre-commit (Black, isort, Flake8).

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/Makefile
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/Makefile
@@ -24,4 +24,4 @@ update: update-deps init
 
 .PHONY: run
 run:
-	tox -e run
+	tox -e=run

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/src/{{cookiecutter.module_name}}/__init__.py
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/src/{{cookiecutter.module_name}}/__init__.py
@@ -8,7 +8,7 @@ __version__: str
 """The application version string (PEP 440 / SemVer compatible)."""
 
 try:
-    __version__ = version(__name__)
+    __version__ = version("{{ cookiecutter.name }}")
 except PackageNotFoundError:
     # package is not installed
     __version__ = "0.0.0"

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/tox.ini
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/tox.ini
@@ -21,7 +21,7 @@ commands = coverage report
 [testenv:typing]
 description = Run mypy.
 commands =
-    mypy src/{{ cookiecutter.module_name }} tests setup.py
+    mypy src/{{ cookiecutter.module_name }} tests
 
 [testenv:lint]
 description = Lint codebase by running pre-commit (Black, isort, Flake8).


### PR DESCRIPTION
- Use package name instead of `__name__` to derive `__version__` in top-level `__init__.py`
- `run` tox target collides with tox run subcommand; invoke as `tox -e=run` from Makefile to workaround this
- `setup.py` seems to have been removed from the template; remove from `mypy` invocation