### PR TITLE
DM-37637: Mark requirements files as conf files for Emacs

### DIFF
--- a/project_templates/fastapi_safir_app/example/requirements/dev.in
+++ b/project_templates/fastapi_safir_app/example/requirements/dev.in
@@ -1,3 +1,5 @@
+# -*- conf -*-
+#
 # Editable development dependencies
 # Add direct development, test, and documentation dependencies here, as well
 # as implicit dev dependencies with constrained versions.

--- a/project_templates/fastapi_safir_app/example/requirements/main.in
+++ b/project_templates/fastapi_safir_app/example/requirements/main.in
@@ -1,3 +1,5 @@
+# -*- conf -*-
+#
 # Editable runtime dependencies (equivalent to install_requires)
 # Add direct runtime dependencies here, as well as implicit dependencies
 # with constrained versions.

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/requirements/dev.in
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/requirements/dev.in
@@ -1,3 +1,5 @@
+# -*- conf -*-
+#
 # Editable development dependencies
 # Add direct development, test, and documentation dependencies here, as well
 # as implicit dev dependencies with constrained versions.

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/requirements/main.in
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/requirements/main.in
@@ -1,3 +1,5 @@
+# -*- conf -*-
+#
 # Editable runtime dependencies (equivalent to install_requires)
 # Add direct runtime dependencies here, as well as implicit dependencies
 # with constrained versions.


### PR DESCRIPTION
This makes editing them in Emacs a bit easier since it will then autorecognize comments and whatnot.