### PR TITLE
DM-37933: Add .vscode to .dockerignore

### DIFF
--- a/project_templates/fastapi_safir_app/example/.dockerignore
+++ b/project_templates/fastapi_safir_app/example/.dockerignore
@@ -1,3 +1,6 @@
+# VSCode
+.vscode/
+
 # Everything below this point is a copy of .gitignore.
 
 # Byte-compiled / optimized / DLL files

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/.dockerignore
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/.dockerignore
@@ -1,3 +1,6 @@
+# VSCode
+.vscode/
+
 # Everything below this point is a copy of .gitignore.
 
 # Byte-compiled / optimized / DLL files


### PR DESCRIPTION
This was added to jupyterlab-controller, but it seems like a good idea everywhere, so add it to the fastapi_safir_app.