### PR TITLE
DM-37977: Stop adding middleware in the startup hook

### DIFF
--- a/project_templates/fastapi_safir_app/example/src/example/main.py
+++ b/project_templates/fastapi_safir_app/example/src/example/main.py
@@ -42,10 +42,8 @@ app = FastAPI(
 app.include_router(internal_router)
 app.include_router(external_router, prefix=f"/{config.name}")
 
-
-@app.on_event("startup")
-async def startup_event() -> None:
-    app.add_middleware(XForwardedMiddleware)
+# Add middleware.
+app.add_middleware(XForwardedMiddleware)
 
 
 @app.on_event("shutdown")

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/src/{{cookiecutter.module_name}}/main.py
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/src/{{cookiecutter.module_name}}/main.py
@@ -42,10 +42,8 @@ app = FastAPI(
 app.include_router(internal_router)
 app.include_router(external_router, prefix=f"/{config.name}")
 
-
-@app.on_event("startup")
-async def startup_event() -> None:
-    app.add_middleware(XForwardedMiddleware)
+# Add middleware.
+app.add_middleware(XForwardedMiddleware)
 
 
 @app.on_event("shutdown")


### PR DESCRIPTION
This pattern was originally copied from Gafaelfawr, where I had done this to defer adding the XForwardedMiddleware until after configuration parsing so that the list of proxies could be configured. It turned out to be a bad idea, since during the test suite, where the application is repeatedly started and stopped, a new copy of the middleware was added each time, eventually making the application extremely slow.

I fixed this in Gafaelfawr (by switching to a callable to construct the app) and forgot to ever fix the template. Now, Starlette prohibits doing this (for good reasons), so it no longer works with the current versions of FastAPI and Starlette.

Move the middleware construction to the top level, which will be fine for any application that doesn't need to customize it. Apps that do need to customize the middleware will need to use the callable pattern to construct the app.