### PR TITLE
DM-38170: Enable pydantic mypy plugin in fastapi_safir_app

### DIFF
--- a/project_templates/fastapi_safir_app/example/pyproject.toml
+++ b/project_templates/fastapi_safir_app/example/pyproject.toml
@@ -98,10 +98,16 @@ disallow_untyped_defs = true
 disallow_incomplete_defs = true
 ignore_missing_imports = true
 local_partial_types = true
+plugins = ["pydantic.mypy"]
 no_implicit_reexport = true
 show_error_codes = true
 strict_equality = true
 warn_redundant_casts = true
 warn_unreachable = true
 warn_unused_ignores = true
-# plugins =
+
+[tool.pydantic-mypy]
+init_forbid_extra = true
+init_typed = true
+warn_required_dynamic_aliases = true
+warn_untyped_fields = true

--- a/project_templates/fastapi_safir_app/example/requirements/dev.in
+++ b/project_templates/fastapi_safir_app/example/requirements/dev.in
@@ -14,6 +14,7 @@ coverage[toml]
 httpx
 mypy
 pre-commit
+pydantic
 pytest
 pytest-asyncio
 pytest-cov

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/pyproject.toml
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/pyproject.toml
@@ -98,10 +98,16 @@ disallow_untyped_defs = true
 disallow_incomplete_defs = true
 ignore_missing_imports = true
 local_partial_types = true
+plugins = ["pydantic.mypy"]
 no_implicit_reexport = true
 show_error_codes = true
 strict_equality = true
 warn_redundant_casts = true
 warn_unreachable = true
 warn_unused_ignores = true
-# plugins =
+
+[tool.pydantic-mypy]
+init_forbid_extra = true
+init_typed = true
+warn_required_dynamic_aliases = true
+warn_untyped_fields = true

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/requirements/dev.in
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/requirements/dev.in
@@ -14,6 +14,7 @@ coverage[toml]
 httpx
 mypy
 pre-commit
+pydantic
 pytest
 pytest-asyncio
 pytest-cov


### PR DESCRIPTION
This plugin offers better type checking and handles some edge cases more correctly, and all FastAPI apps are going to be using Pydantic so there's no reason not to enable it. Enable all the strict checking options; they all seem useful and haven't caused me problems in Gafaelfawr or the lab controller.