### PR TITLE
DM-38526: Add path_prefix support to FastAPI template

### DIFF
--- a/project_templates/fastapi_safir_app/example/src/example/config.py
+++ b/project_templates/fastapi_safir_app/example/src/example/config.py
@@ -14,8 +14,13 @@ class Configuration(BaseSettings):
     name: str = Field(
         "example",
         title="Name of application",
-        description="Doubles as the root HTTP endpoint path.",
         env="SAFIR_NAME",
+    )
+
+    path_prefix: str = Field(
+        "/example",
+        title="URL prefix for application",
+        env="SAFIR_PATH_PREFIX",
     )
 
     profile: Profile = Field(

--- a/project_templates/fastapi_safir_app/example/src/example/main.py
+++ b/project_templates/fastapi_safir_app/example/src/example/main.py
@@ -32,15 +32,15 @@ app = FastAPI(
     title="example",
     description=metadata("example")["Summary"],
     version=version("example"),
-    openapi_url=f"/{config.name}/openapi.json",
-    docs_url=f"/{config.name}/docs",
-    redoc_url=f"/{config.name}/redoc",
+    openapi_url=f"/{config.path_prefix}/openapi.json",
+    docs_url=f"/{config.path_prefix}/docs",
+    redoc_url=f"/{config.path_prefix}/redoc",
 )
 """The main FastAPI application for example."""
 
 # Attach the routers.
 app.include_router(internal_router)
-app.include_router(external_router, prefix=f"/{config.name}")
+app.include_router(external_router, prefix=f"/{config.path_prefix}")
 
 # Add middleware.
 app.add_middleware(XForwardedMiddleware)

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/README.md
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/README.md
@@ -1,6 +1,6 @@
 # {{cookiecutter.name}}
 
 {{cookiecutter.summary}}
-Learn more at https://{{cookiecutter.name}}.lsst.io
+Learn more at https://{{cookiecutter.name | lower}}.lsst.io
 
 {{ cookiecutter.name }} is developed with [FastAPI](https://fastapi.tiangolo.com) and [Safir](https://safir.lsst.io).

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/pyproject.toml
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/pyproject.toml
@@ -23,10 +23,10 @@ dependencies = []
 dynamic = ["version"]
 
 [project.scripts]
-{{cookiecutter.name}} = "{{cookiecutter.module_name}}.cli:main"
+{{cookiecutter.name | lower}} = "{{cookiecutter.module_name}}.cli:main"
 
 [project.urls]
-Homepage = "https://{{cookiecutter.name}}.lsst.io"
+Homepage = "https://{{cookiecutter.name | lower}}.lsst.io"
 Source = "https://github.com/{{cookiecutter.github_org}}/{{cookiecutter.name}}"
 
 [build-system]

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/src/{{cookiecutter.module_name}}/config.py
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/src/{{cookiecutter.module_name}}/config.py
@@ -12,10 +12,15 @@ class Configuration(BaseSettings):
     """Configuration for {{ cookiecutter.name }}."""
 
     name: str = Field(
-        "{{ cookiecutter.name | lower }}",
+        "{{ cookiecutter.name }}",
         title="Name of application",
-        description="Doubles as the root HTTP endpoint path.",
         env="SAFIR_NAME",
+    )
+
+    path_prefix: str = Field(
+        "/{{ cookiecutter.name | lower }}",
+        title="URL prefix for application",
+        env="SAFIR_PATH_PREFIX",
     )
 
     profile: Profile = Field(

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/src/{{cookiecutter.module_name}}/main.py
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/src/{{cookiecutter.module_name}}/main.py
@@ -32,15 +32,15 @@ app = FastAPI(
     title="{{ cookiecutter.name }}",
     description=metadata("{{ cookiecutter.name }}")["Summary"],
     version=version("{{ cookiecutter.name }}"),
-    openapi_url=f"/{config.name}/openapi.json",
-    docs_url=f"/{config.name}/docs",
-    redoc_url=f"/{config.name}/redoc",
+    openapi_url=f"/{config.path_prefix}/openapi.json",
+    docs_url=f"/{config.path_prefix}/docs",
+    redoc_url=f"/{config.path_prefix}/redoc",
 )
 """The main FastAPI application for {{ cookiecutter.name }}."""
 
 # Attach the routers.
 app.include_router(internal_router)
-app.include_router(external_router, prefix=f"/{config.name}")
+app.include_router(external_router, prefix=f"/{config.path_prefix}")
 
 # Add middleware.
 app.add_middleware(XForwardedMiddleware)


### PR DESCRIPTION
Several of our applications have wanted to be able to override the base URL of the application (to test a parallel installation, for example), and while this was supported via overriding the package name, that approach is limited. (For instance, it's awkward to use that to configure a multipart path prefix such as /api/example.)

Follow times-square and jupyterlab-controller and add a path_prefix configuration option and environment variable to explicitly set the prefix.

Fix a few places where the potentially-uppercase package name was used in command-line entry points or URLs instead of the lowercased version.