### PR TITLE
DM-38414: Bump Python version for square_pypi_package

### DIFF
--- a/project_templates/square_pypi_package/example/.github/workflows/ci.yaml
+++ b/project_templates/square_pypi_package/example/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.0
@@ -37,9 +37,7 @@ jobs:
     strategy:
       matrix:
         python:
-          - "3.8"
-          - "3.9"
-          - "3.10"
+          - "3.11"
 
     steps:
       - uses: actions/checkout@v3
@@ -65,7 +63,7 @@ jobs:
       - name: Run tox
         uses: lsst-sqre/run-tox@v1
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           tox-envs: "docs"
           # Add docs-linkcheck when the docs and PyPI package are published
           # tox-envs: "docs,docs-linkcheck"

--- a/project_templates/square_pypi_package/example/pyproject.toml
+++ b/project_templates/square_pypi_package/example/pyproject.toml
@@ -14,15 +14,13 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Intended Audience :: Developers",
     "Natural Language :: English",
     "Operating System :: POSIX",
     "Typing :: Typed",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.11"
 dependencies = []
 dynamic = ["version"]
 

--- a/project_templates/square_pypi_package/{{cookiecutter.name}}/.github/workflows/ci.yaml
+++ b/project_templates/square_pypi_package/{{cookiecutter.name}}/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.0
@@ -37,9 +37,7 @@ jobs:
     strategy:
       matrix:
         python:
-          - "3.8"
-          - "3.9"
-          - "3.10"
+          - "3.11"
 
     steps:
       - uses: actions/checkout@v3
@@ -65,7 +63,7 @@ jobs:
       - name: Run tox
         uses: lsst-sqre/run-tox@v1
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           tox-envs: "docs"
           # Add docs-linkcheck when the docs and PyPI package are published
           # tox-envs: "docs,docs-linkcheck"

--- a/project_templates/square_pypi_package/{{cookiecutter.name}}/pyproject.toml
+++ b/project_templates/square_pypi_package/{{cookiecutter.name}}/pyproject.toml
@@ -14,15 +14,13 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Intended Audience :: Developers",
     "Natural Language :: English",
     "Operating System :: POSIX",
     "Typing :: Typed",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.11"
 dependencies = []
 dynamic = ["version"]
 


### PR DESCRIPTION
Safir will soon require Python 3.11 or later, so do the same thing for square_pypi_package by default.