### PR TITLE
DM-38414: Add merge_request support to GitHub Actions

### DIFF
--- a/project_templates/fastapi_safir_app/example/.github/workflows/ci.yaml
+++ b/project_templates/fastapi_safir_app/example/.github/workflows/ci.yaml
@@ -1,6 +1,8 @@
 name: CI
 
 "on":
+  merge_request: {}
+  pull_request: {}
   push:
     branches-ignore:
       # These should always correspond to pull requests, so ignore them for
@@ -8,12 +10,12 @@ name: CI
       # trigger, avoiding running the workflow twice.  This is a minor
       # optimization so there's no need to ensure this is comprehensive.
       - "dependabot/**"
+      - "gh-readonly-queue/**"
       - "renovate/**"
       - "tickets/**"
       - "u/**"
     tags:
       - "*"
-  pull_request: {}
 
 jobs:
   lint:
@@ -60,8 +62,9 @@ jobs:
     # but in this case the build will fail with an error since the secret
     # won't be set.
     if: >
-      startsWith(github.ref, 'refs/tags/')
-      || startsWith(github.head_ref, 'tickets/')
+      github.event_name != 'merge_group'
+      && (startsWith(github.ref, 'refs/tags/')
+          || startsWith(github.head_ref, 'tickets/'))
 
     steps:
       - uses: actions/checkout@v3

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/.github/workflows/ci.yaml
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/.github/workflows/ci.yaml
@@ -1,6 +1,8 @@
 name: CI
 
 "on":
+  merge_request: {}
+  pull_request: {}
   push:
     branches-ignore:
       # These should always correspond to pull requests, so ignore them for
@@ -8,12 +10,12 @@ name: CI
       # trigger, avoiding running the workflow twice.  This is a minor
       # optimization so there's no need to ensure this is comprehensive.
       - "dependabot/**"
+      - "gh-readonly-queue/**"
       - "renovate/**"
       - "tickets/**"
       - "u/**"
     tags:
       - "*"
-  pull_request: {}
 
 jobs:
   lint:
@@ -60,8 +62,9 @@ jobs:
     # but in this case the build will fail with an error since the secret
     # won't be set.
     if: >
-      startsWith(github.ref, 'refs/tags/')
-      || startsWith(github.head_ref, 'tickets/')
+      github.event_name != 'merge_group'
+      && (startsWith(github.ref, 'refs/tags/')
+          || startsWith(github.head_ref, 'tickets/'))
 
     steps:
       - uses: actions/checkout@v3

--- a/project_templates/square_pypi_package/example/.github/workflows/ci.yaml
+++ b/project_templates/square_pypi_package/example/.github/workflows/ci.yaml
@@ -1,6 +1,8 @@
 name: Python CI
 
 "on":
+  merge_request: {}
+  pull_request: {}
   push:
     branches-ignore:
       # These should always correspond to pull requests, so ignore them for
@@ -8,12 +10,12 @@ name: Python CI
       # trigger, avoiding running the workflow twice.  This is a minor
       # optimization so there's no need to ensure this is comprehensive.
       - "dependabot/**"
+      - "gh-readonly-queue/**"
       - "renovate/**"
       - "tickets/**"
       - "u/**"
     tags:
       - "*"
-  pull_request: {}
 
 jobs:
   lint:
@@ -80,8 +82,9 @@ jobs:
           username: ${{ secrets.LTD_USERNAME }}
           password: ${{ secrets.LTD_PASSWORD }}
         if: >
-          github.event_name != 'pull_request'
-          || startsWith(github.head_ref, 'tickets/')
+          github.event_name != 'merge_group'
+          && (github.event_name != 'pull_request'
+              || startsWith(github.head_ref, 'tickets/'))
 
   pypi:
 

--- a/project_templates/square_pypi_package/{{cookiecutter.name}}/.github/workflows/ci.yaml
+++ b/project_templates/square_pypi_package/{{cookiecutter.name}}/.github/workflows/ci.yaml
@@ -1,6 +1,8 @@
 name: Python CI
 
 "on":
+  merge_request: {}
+  pull_request: {}
   push:
     branches-ignore:
       # These should always correspond to pull requests, so ignore them for
@@ -8,12 +10,12 @@ name: Python CI
       # trigger, avoiding running the workflow twice.  This is a minor
       # optimization so there's no need to ensure this is comprehensive.
       - "dependabot/**"
+      - "gh-readonly-queue/**"
       - "renovate/**"
       - "tickets/**"
       - "u/**"
     tags:
       - "*"
-  pull_request: {}
 
 jobs:
   lint:
@@ -80,8 +82,9 @@ jobs:
           username: {{ "${{ secrets.LTD_USERNAME }}" }}
           password: {{ "${{ secrets.LTD_PASSWORD }}" }}
         if: >
-          github.event_name != 'pull_request'
-          || startsWith(github.head_ref, 'tickets/')
+          github.event_name != 'merge_group'
+          && (github.event_name != 'pull_request'
+              || startsWith(github.head_ref, 'tickets/'))
 
   pypi:
 


### PR DESCRIPTION
For fastapi_safir_app and square_pypi_package, add support for merge_request to the default GitHub Actions. We don't enable this by default since for a lot of projects it won't make sense, but this makes it eassier to enable if desired.