### PR TITLE
DM-38757: Refresh pre-commit hooks

### DIFF
--- a/project_templates/fastapi_safir_app/example/.pre-commit-config.yaml
+++ b/project_templates/fastapi_safir_app/example/.pre-commit-config.yaml
@@ -2,22 +2,21 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
-      - id: trailing-whitespace
       - id: check-yaml
       - id: check-toml
 
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.11.4
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
     hooks:
       - id: isort
         additional_dependencies: [toml]
 
   - repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 23.3.0
     hooks:
       - id: black
 
-  - repo: https://github.com/PyCQA/flake8
+  - repo: https://github.com/pycqa/flake8
     rev: 6.0.0
     hooks:
       - id: flake8

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/.pre-commit-config.yaml
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/.pre-commit-config.yaml
@@ -2,22 +2,21 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
-      - id: trailing-whitespace
       - id: check-yaml
       - id: check-toml
 
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.11.4
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
     hooks:
       - id: isort
         additional_dependencies: [toml]
 
   - repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 23.3.0
     hooks:
       - id: black
 
-  - repo: https://github.com/PyCQA/flake8
+  - repo: https://github.com/pycqa/flake8
     rev: 6.0.0
     hooks:
       - id: flake8

--- a/project_templates/square_pypi_package/example/.pre-commit-config.yaml
+++ b/project_templates/square_pypi_package/example/.pre-commit-config.yaml
@@ -1,19 +1,19 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: trailing-whitespace
       - id: check-yaml
       - id: check-toml
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         additional_dependencies: [toml]
 
   - repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 23.3.0
     hooks:
       - id: black
 
@@ -21,16 +21,16 @@ repos:
     rev: v1.12.1
     hooks:
       - id: blacken-docs
-        additional_dependencies: [black==22.6.0]
-        args: [-l, '79', -t, py38]
+        additional_dependencies: [black==23.3.0]
+        args: [-l, "79", -t, py38]
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 5.0.2
+    rev: 6.0.0
     hooks:
       - id: flake8
 
   - repo: https://github.com/PyCQA/pydocstyle
-    rev: 6.1.1
+    rev: 6.3.0
     hooks:
-    - id: pydocstyle
-      additional_dependencies: [toml]
+      - id: pydocstyle
+        additional_dependencies: [toml]

--- a/project_templates/square_pypi_package/{{cookiecutter.name}}/.pre-commit-config.yaml
+++ b/project_templates/square_pypi_package/{{cookiecutter.name}}/.pre-commit-config.yaml
@@ -1,19 +1,19 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: trailing-whitespace
       - id: check-yaml
       - id: check-toml
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         additional_dependencies: [toml]
 
   - repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 23.3.0
     hooks:
       - id: black
 
@@ -21,16 +21,16 @@ repos:
     rev: v1.12.1
     hooks:
       - id: blacken-docs
-        additional_dependencies: [black==22.6.0]
-        args: [-l, '79', -t, py38]
+        additional_dependencies: [black==23.3.0]
+        args: [-l, "79", -t, py38]
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 5.0.2
+    rev: 6.0.0
     hooks:
       - id: flake8
 
   - repo: https://github.com/PyCQA/pydocstyle
-    rev: 6.1.1
+    rev: 6.3.0
     hooks:
-    - id: pydocstyle
-      additional_dependencies: [toml]
+      - id: pydocstyle
+        additional_dependencies: [toml]


### PR DESCRIPTION
Normally developers will maintain pre-commit hooks either through neophile or on their own with `pre-commit autoupdate`, but older versions of the isort hook have a particular issue with poetry that makes the first-run experience more confusing.