### PR TITLE
DM-38757: Fix duplicate root "/" in external routes of FastAPI template

### DIFF
--- a/project_templates/fastapi_safir_app/example/src/example/main.py
+++ b/project_templates/fastapi_safir_app/example/src/example/main.py
@@ -40,7 +40,7 @@ app = FastAPI(
 
 # Attach the routers.
 app.include_router(internal_router)
-app.include_router(external_router, prefix=f"/{config.path_prefix}")
+app.include_router(external_router, prefix=f"{config.path_prefix}")
 
 # Add middleware.
 app.add_middleware(XForwardedMiddleware)

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/src/{{cookiecutter.module_name}}/main.py
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/src/{{cookiecutter.module_name}}/main.py
@@ -40,7 +40,7 @@ app = FastAPI(
 
 # Attach the routers.
 app.include_router(internal_router)
-app.include_router(external_router, prefix=f"/{config.path_prefix}")
+app.include_router(external_router, prefix=f"{config.path_prefix}")
 
 # Add middleware.
 app.add_middleware(XForwardedMiddleware)


### PR DESCRIPTION
The way external routes were being mounted in the FastAPI app template introduced an extraneous extra slash in front of the URL, which is significant and thus broke the default test suite (and would break other expectations). Drop the extra slash.