### PR TITLE
DM-38425: Add timeouts to CI jobs

### DIFF
--- a/project_templates/fastapi_safir_app/example/.github/workflows/ci.yaml
+++ b/project_templates/fastapi_safir_app/example/.github/workflows/ci.yaml
@@ -21,6 +21,7 @@ jobs:
   lint:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
       - uses: actions/checkout@v3
@@ -36,6 +37,7 @@ jobs:
   test:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     strategy:
       matrix:
@@ -55,6 +57,7 @@ jobs:
 
     runs-on: ubuntu-latest
     needs: [lint, test]
+    timeout-minutes: 10
 
     # Only do Docker builds of tagged releases and pull requests from ticket
     # branches.  This will still trigger on pull requests from untrusted

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/.github/workflows/ci.yaml
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/.github/workflows/ci.yaml
@@ -21,6 +21,7 @@ jobs:
   lint:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
       - uses: actions/checkout@v3
@@ -36,6 +37,7 @@ jobs:
   test:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     strategy:
       matrix:
@@ -55,6 +57,7 @@ jobs:
 
     runs-on: ubuntu-latest
     needs: [lint, test]
+    timeout-minutes: 10
 
     # Only do Docker builds of tagged releases and pull requests from ticket
     # branches.  This will still trigger on pull requests from untrusted

--- a/project_templates/square_pypi_package/example/.github/workflows/ci.yaml
+++ b/project_templates/square_pypi_package/example/.github/workflows/ci.yaml
@@ -21,6 +21,8 @@ jobs:
   lint:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+
     steps:
       - uses: actions/checkout@v3
 
@@ -35,6 +37,7 @@ jobs:
   test:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     strategy:
       matrix:
@@ -53,6 +56,7 @@ jobs:
   docs:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v3
@@ -90,6 +94,7 @@ jobs:
 
     runs-on: ubuntu-latest
     needs: [lint, test, docs]
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v3

--- a/project_templates/square_pypi_package/example/.github/workflows/periodic-ci.yaml
+++ b/project_templates/square_pypi_package/example/.github/workflows/periodic-ci.yaml
@@ -11,13 +11,12 @@ name: Periodic CI
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     strategy:
       matrix:
         python:
-          - "3.8"
-          - "3.9"
-          - "3.10"
+          - "3.11"
 
     steps:
       - uses: actions/checkout@v3
@@ -31,6 +30,7 @@ jobs:
 
   docs:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v3
@@ -38,12 +38,13 @@ jobs:
       - name: Build docs in tox
         uses: lsst-sqre/run-tox@v1
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           tox-envs: "docs,docs-linkcheck"
           use-cache: false
 
   pypi:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v3
@@ -54,5 +55,5 @@ jobs:
         uses: lsst-sqre/build-and-publish-to-pypi@v1
         with:
           pypi-token: ""
-          python-version: "3.10"
+          python-version: "3.11"
           upload: false

--- a/project_templates/square_pypi_package/{{cookiecutter.name}}/.github/workflows/ci.yaml
+++ b/project_templates/square_pypi_package/{{cookiecutter.name}}/.github/workflows/ci.yaml
@@ -21,6 +21,8 @@ jobs:
   lint:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+
     steps:
       - uses: actions/checkout@v3
 
@@ -35,6 +37,7 @@ jobs:
   test:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     strategy:
       matrix:
@@ -53,6 +56,7 @@ jobs:
   docs:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v3
@@ -90,6 +94,7 @@ jobs:
 
     runs-on: ubuntu-latest
     needs: [lint, test, docs]
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v3

--- a/project_templates/square_pypi_package/{{cookiecutter.name}}/.github/workflows/periodic-ci.yaml
+++ b/project_templates/square_pypi_package/{{cookiecutter.name}}/.github/workflows/periodic-ci.yaml
@@ -11,13 +11,12 @@ name: Periodic CI
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     strategy:
       matrix:
         python:
-          - "3.8"
-          - "3.9"
-          - "3.10"
+          - "3.11"
 
     steps:
       - uses: actions/checkout@v3
@@ -31,6 +30,7 @@ jobs:
 
   docs:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v3
@@ -38,12 +38,13 @@ jobs:
       - name: Build docs in tox
         uses: lsst-sqre/run-tox@v1
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           tox-envs: "docs,docs-linkcheck"
           use-cache: false
 
   pypi:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v3
@@ -54,5 +55,5 @@ jobs:
         uses: lsst-sqre/build-and-publish-to-pypi@v1
         with:
           pypi-token: ""
-          python-version: "3.10"
+          python-version: "3.11"
           upload: false


### PR DESCRIPTION
For the default GitHub Actions CI jobs for fastapi_safir_app and square_pypi_package, add a timeout of 5 minutes for linting and 10 minutes for everything else. Nearly all of our packages are small and should complete much faster than that, and the larger ones can increase the timeout. The default GitHub Actions timeout is very long, which delays receiving the failure message when something has gone wrong.

Change the periodic CI job for square_pypi_package to require and only test Python 3.11, matching the default CI job.