### PR TITLE
Substitute name and GitHub org in more places

### DIFF
--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/.github/workflows/ci.yaml
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/.github/workflows/ci.yaml
@@ -98,6 +98,6 @@ jobs:
           context: .
           push: true
           tags: |
-            ghcr.io/lsst-sqre/{{ cookiecutter.name | lower }}:{{ "${{ steps.vars.outputs.tag }}" }}
+            ghcr.io/{{ cookiecutter.github_org }}/{{ cookiecutter.name | lower }}:{{ "${{ steps.vars.outputs.tag }}" }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/manifests/base/deployment.yaml
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/manifests/base/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         - name: app
           imagePullPolicy: "IfNotPresent"
           # Use images field in a Kustomization to set/update image tag
-          image: "ghcr.io/lsst-sqre/{{ cookiecutter.name | lower }}"
+          image: "ghcr.io/{{ cookiecutter.github_org }}/{{ cookiecutter.name | lower }}"
           ports:
             - containerPort: 8080
               name: "app"

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/manifests/base/kustomization.yaml
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/manifests/base/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 images:
-  - name: "ghcr.io/lsst-sqre/{{ cookiecutter.name | lower }}"
+  - name: "ghcr.io/{{ cookiecutter.github_org }}/{{ cookiecutter.name | lower }}"
     newTag: 0.0.0
 
 resources:

--- a/project_templates/square_pypi_package/example/docs/dev/development.rst
+++ b/project_templates/square_pypi_package/example/docs/dev/development.rst
@@ -14,7 +14,7 @@ For that reason, it's a good idea to propose changes with a new `GitHub issue`_ 
 
 example is developed by the Rubin Observatory SQuaRE team.
 
-.. _GitHub issue: https://github.com/lsst-sqre/safir/issues/new
+.. _GitHub issue: https://github.com/lsst-sqre/example/issues/new
 
 .. _dev-environment:
 

--- a/project_templates/square_pypi_package/example/docs/dev/release.rst
+++ b/project_templates/square_pypi_package/example/docs/dev/release.rst
@@ -7,7 +7,7 @@ This information is only useful for maintainers.
 
 example's releases are largely automated through GitHub Actions (see the `ci.yaml`_ workflow file for details).
 When a semantic version tag is pushed to GitHub, `example is released to PyPI`_ with that version.
-Similarly, documentation is built and pushed for each version (see https://safir.lsst.io/v).
+Similarly, documentation is built and pushed for each version (see https://example.lsst.io/v).
 
 .. _`example is released to PyPI`: https://pypi.org/project/example/
 .. _`ci.yaml`: https://github.com/lsst-sqre/example/blob/main/.github/workflows/ci.yaml

--- a/project_templates/square_pypi_package/{{cookiecutter.name}}/docs/dev/development.rst
+++ b/project_templates/square_pypi_package/{{cookiecutter.name}}/docs/dev/development.rst
@@ -14,7 +14,7 @@ For that reason, it's a good idea to propose changes with a new `GitHub issue`_ 
 
 {{cookiecutter.name}} is developed by the Rubin Observatory SQuaRE team.
 
-.. _GitHub issue: https://github.com/lsst-sqre/safir/issues/new
+.. _GitHub issue: https://github.com/{{cookiecutter.github_org}}/{{cookiecutter.name}}/issues/new
 
 .. _dev-environment:
 
@@ -25,7 +25,7 @@ To develop {{cookiecutter.name}}, create a virtual environment with your method 
 
 .. code-block:: sh
 
-   git clone https://github.com/lsst-sqre/{{cookiecutter.name}}.git
+   git clone https://github.com/{{cookiecutter.github_org}}/{{cookiecutter.name}}.git
    cd {{cookiecutter.name}}
    make init
 

--- a/project_templates/square_pypi_package/{{cookiecutter.name}}/docs/dev/release.rst
+++ b/project_templates/square_pypi_package/{{cookiecutter.name}}/docs/dev/release.rst
@@ -7,10 +7,10 @@ This information is only useful for maintainers.
 
 {{cookiecutter.name}}'s releases are largely automated through GitHub Actions (see the `ci.yaml`_ workflow file for details).
 When a semantic version tag is pushed to GitHub, `{{cookiecutter.name}} is released to PyPI`_ with that version.
-Similarly, documentation is built and pushed for each version (see https://safir.lsst.io/v).
+Similarly, documentation is built and pushed for each version (see https://{{cookiecutter.name}}.lsst.io/v).
 
 .. _`{{cookiecutter.name}} is released to PyPI`: https://pypi.org/project/{{cookiecutter.name}}/
-.. _`ci.yaml`: https://github.com/lsst-sqre/{{cookiecutter.name}}/blob/main/.github/workflows/ci.yaml
+.. _`ci.yaml`: https://github.com/{{cookiecutter.github_org}}/{{cookiecutter.name}}/blob/main/.github/workflows/ci.yaml
 
 .. _regular-release:
 


### PR DESCRIPTION
In the FastAPI Safir app and SQuaRE PyPI package templates, there were a few places where the application or library name or the GitHub organization weren't substituted from the template variables. Add substitutions.

(The issue with organization was noticed via build issues with a package based on the FastAPI Safir template in the lsst-dm organization. That use case isn't supported, but this seemed worth fixing anyway in case we have more organizations in the future.)