### PR TITLE
Add a PSTR document series to the test_report template

### DIFF
--- a/project_templates/test_report/cookiecutter.json
+++ b/project_templates/test_report/cookiecutter.json
@@ -1,6 +1,6 @@
 {
   "series": ["DMTR", "PSTR", "SCTR", "TESTTR"],
-  "namespace": ["DM", "CAM", "EPO", "OCS", "OPS", "PSE", "T&S"],
+  "namespace": ["DM", "CAM", "EPO", "OCS", "OPS", "PSE", "T&S", "SE", "PST"],
   "serial_number": "0",
   "github_org": ["lsst-dm", "lsst-pst", "lsst-sitcom", "lsst-sqre-testing"],
   "title": "Document Title",

--- a/project_templates/test_report/templatekit.yaml
+++ b/project_templates/test_report/templatekit.yaml
@@ -24,21 +24,25 @@ dialog_fields:
         presets:
           series: "DMTR"
           github_org: "lsst-dm"
+          namespace: "DM"
       - label: "PSTR"
         value: "PSTR"
         presets:
           series: "PSTR"
           github_org: "lsst-pstn"
+          namespace: "PST"
       - label: "SCTR"
         value: "SCTR"
         presets:
           series: "SCTR"
           github_org: "lsst-sitcom"
+          namespace: "SE"
       - label: "Test"
         value: "test"
         presets:
           series: "TESTTR"
           github_org: "lsst-sqre-testing"
+          namespace: "DM"
   - key: "serial_number"
     label: "Document number"
     placeholder: "0"


### PR DESCRIPTION
Adds the PSTR series to test_report, which is configured to use the lsst-pst GitHub organization.