### PR TITLE
DM-39948: Pin cookiecutter < 2.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-templatekit
+templatekit<0.6
+cookiecutter<2.2


### PR DESCRIPTION
We're doing this temporarily to continue support for the jinja2_time extension used by our templates.

See https://github.com/cookiecutter/cookiecutter/pull/1779

The next step of this resolution is to update templatebot and the templates here in concert to adopt the new inlined time extension available in cookiecutter 2.2+.