### PR TITLE
DM-39989: Add neophile support to project templates

### DIFF
--- a/project_templates/fastapi_safir_app/example/.github/workflows/ci.yaml
+++ b/project_templates/fastapi_safir_app/example/.github/workflows/ci.yaml
@@ -51,6 +51,19 @@ jobs:
           python-version: ${{ matrix.python }}
           tox-envs: "py,coverage-report,typing"
 
+  dependencies:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: lsst-sqre/run-neophile@v1
+        with:
+          python-version: "3.11"
+          mode: check
+          types: python
+
   build:
     runs-on: ubuntu-latest
     needs: [lint, test]

--- a/project_templates/fastapi_safir_app/example/.github/workflows/dependencies.yaml
+++ b/project_templates/fastapi_safir_app/example/.github/workflows/dependencies.yaml
@@ -1,0 +1,33 @@
+name: Dependency Update
+
+"on":
+  schedule:
+    - cron: "0 12 * * 1"
+  workflow_dispatch: {}
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Run neophile
+        uses: lsst-sqre/run-neophile@v1
+        with:
+          python-version: "3.11"
+          mode: pr
+          types: pre-commit
+          app-id: ${{ secrets.NEOPHILE_APP_ID }}
+          app-secret: ${{ secrets.NEOPHILE_PRIVATE_KEY }}
+
+      - name: Report status
+        if: always()
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: ${{ job.status }}
+          notify_when: "failure"
+          notification_title: "Periodic dependency update for {repo} failed"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ALERT_WEBHOOK }}

--- a/project_templates/fastapi_safir_app/example/.github/workflows/periodic-ci.yaml
+++ b/project_templates/fastapi_safir_app/example/.github/workflows/periodic-ci.yaml
@@ -1,0 +1,50 @@
+# This is a separate run of the Python test suite that runs from a schedule,
+# doesn't cache the tox environment, and updates pinned dependencies first.
+# The purpose is to test compatibility with the latest versions of
+# dependencies.
+
+name: Periodic CI
+
+"on":
+  schedule:
+    - cron: "0 12 * * 1"
+  workflow_dispatch: {}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    strategy:
+      matrix:
+        python:
+          - "3.11"
+
+    steps:
+      - uses: actions/checkout@v3
+
+      # Use the oldest supported version of Python to update dependencies,
+      # not the matrixed Python version, since this accurately reflects
+      # how dependencies should later be updated.
+      - name: Run neophile
+        uses: lsst-sqre/run-neophile@v1
+        with:
+          python-version: "3.11"
+          mode: update
+
+      - name: Run tests in tox
+        uses: lsst-sqre/run-tox@v1
+        with:
+          python-version: ${{ matrix.python }}
+          tox-envs: "lint,typing,py"
+          use-cache: false
+
+      - name: Report status
+        if: always()
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: ${{ job.status }}
+          notify_when: "failure"
+          notification_title: "Periodic test for {repo} failed"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ALERT_WEBHOOK }}

--- a/project_templates/fastapi_safir_app/hooks/post_gen_project.py
+++ b/project_templates/fastapi_safir_app/hooks/post_gen_project.py
@@ -5,15 +5,24 @@ addition, cookiecutter interpolates Jinja2 templates to insert any necessary
 variables.
 
 This is used to remove the ``manifests`` directory if the project is using
-Helm rather than Kustomize.
+Helm rather than Kustomize, and remove empty files that aren't relevant in
+some configuration cases.
 """
 
+import os
 import shutil
 
 # These variables are interpolated by cookiecutter before this hook is run
 uses_helm = True if '{{ cookiecutter.uses_helm }}' == 'True' else False
+github_org = '{{ cookiecutter.github_org }}'
 
 # Remove the Kustomize configuration if the package will be using Helm.
 if uses_helm:
     print(f"(post-gen hook) Removing manifests directory")
     shutil.rmtree("manifests", ignore_errors=True)
+
+# Remove the empty dependency update GitHub Actions workflow if the GitHub
+# organization is not lsst-sqre.
+if github_org != "lsst-sqre":
+    print("(post-gen hook) Removing empty dependency update workflow")
+    os.remove(".github/workflows/dependencies.yaml")

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/.github/workflows/ci.yaml
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/.github/workflows/ci.yaml
@@ -51,6 +51,19 @@ jobs:
           python-version: {{ "${{ matrix.python }}" }}
           tox-envs: "py,coverage-report,typing"
 
+  dependencies:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: lsst-sqre/run-neophile@v1
+        with:
+          python-version: "3.11"
+          mode: check
+          types: python
+
   build:
     runs-on: ubuntu-latest
     needs: [lint, test]

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/.github/workflows/dependencies.yaml
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/.github/workflows/dependencies.yaml
@@ -1,0 +1,35 @@
+{% if cookiecutter.github_org == "lsst-sqre" -%}
+name: Dependency Update
+
+"on":
+  schedule:
+    - cron: "0 12 * * 1"
+  workflow_dispatch: {}
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Run neophile
+        uses: lsst-sqre/run-neophile@v1
+        with:
+          python-version: "3.11"
+          mode: pr
+          types: pre-commit
+          app-id: {{ "${{ secrets.NEOPHILE_APP_ID }}" }}
+          app-secret: {{ "${{ secrets.NEOPHILE_PRIVATE_KEY }}" }}
+
+      - name: Report status
+        if: always()
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: {{ "${{ job.status }}" }}
+          notify_when: "failure"
+          notification_title: "Periodic dependency update for {repo} failed"
+        env:
+          SLACK_WEBHOOK_URL: {{ "${{ secrets.SLACK_ALERT_WEBHOOK }}" }}
+{%- endif %}

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/.github/workflows/periodic-ci.yaml
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/.github/workflows/periodic-ci.yaml
@@ -1,0 +1,51 @@
+# This is a separate run of the Python test suite that runs from a schedule,
+# doesn't cache the tox environment, and updates pinned dependencies first.
+# The purpose is to test compatibility with the latest versions of
+# dependencies.
+
+name: Periodic CI
+
+"on":
+  schedule:
+    - cron: "0 12 * * 1"
+  workflow_dispatch: {}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    strategy:
+      matrix:
+        python:
+          - "3.11"
+
+    steps:
+      - uses: actions/checkout@v3
+
+      # Use the oldest supported version of Python to update dependencies,
+      # not the matrixed Python version, since this accurately reflects
+      # how dependencies should later be updated.
+      - name: Run neophile
+        uses: lsst-sqre/run-neophile@v1
+        with:
+          python-version: "3.11"
+          mode: update
+
+      - name: Run tests in tox
+        uses: lsst-sqre/run-tox@v1
+        with:
+          python-version: {{ "${{ matrix.python }}" }}
+          tox-envs: "lint,typing,py"
+          use-cache: false
+{% if cookiecutter.github_org == "lsst-sqre" %}
+      - name: Report status
+        if: always()
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: {{ "${{ job.status }}" }}
+          notify_when: "failure"
+          notification_title: "Periodic test for {repo} failed"
+        env:
+          SLACK_WEBHOOK_URL: {{ "${{ secrets.SLACK_ALERT_WEBHOOK }}" }}
+{%- endif %}

--- a/project_templates/square_pypi_package/example/.github/workflows/dependencies.yaml
+++ b/project_templates/square_pypi_package/example/.github/workflows/dependencies.yaml
@@ -1,0 +1,33 @@
+name: Dependency Update
+
+"on":
+  schedule:
+    - cron: "0 12 * * 1"
+  workflow_dispatch: {}
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Run neophile
+        uses: lsst-sqre/run-neophile@v1
+        with:
+          python-version: "3.11"
+          mode: pr
+          types: pre-commit
+          app-id: ${{ secrets.NEOPHILE_APP_ID }}
+          app-secret: ${{ secrets.NEOPHILE_PRIVATE_KEY }}
+
+      - name: Report status
+        if: always()
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: ${{ job.status }}
+          notify_when: "failure"
+          notification_title: "Periodic dependency update for {repo} failed"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ALERT_WEBHOOK }}

--- a/project_templates/square_pypi_package/hooks/post_gen_project.py
+++ b/project_templates/square_pypi_package/hooks/post_gen_project.py
@@ -5,11 +5,20 @@ addition, cookiecutter interpolates Jinja2 templates to insert any necessary
 variables.
 """
 
+import os
 from pathlib import Path
 
-print("(post-gen hook) Symlinking changelog to docs")
+# These variables are interpolated by cookiecutter before this hook is run
+github_org = '{{ cookiecutter.github_org }}'
 
+print("(post-gen hook) Symlinking changelog to docs")
 changelog_doc_path = Path("docs") / "changelog.md"
 if changelog_doc_path.is_symlink():
     changelog_doc_path.unlink(missing_ok=True)
 changelog_doc_path.symlink_to("../CHANGELOG.md")
+
+# Remove the empty dependency update GitHub Actions workflow if the GitHub
+# organization is not lsst-sqre.
+if github_org != "lsst-sqre":
+    print("(post-gen hook) Removing empty dependency update workflow")
+    os.remove(".github/workflows/dependencies.yaml")

--- a/project_templates/square_pypi_package/{{cookiecutter.name}}/.github/workflows/dependencies.yaml
+++ b/project_templates/square_pypi_package/{{cookiecutter.name}}/.github/workflows/dependencies.yaml
@@ -1,0 +1,35 @@
+{% if cookiecutter.github_org == "lsst-sqre" -%}
+name: Dependency Update
+
+"on":
+  schedule:
+    - cron: "0 12 * * 1"
+  workflow_dispatch: {}
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Run neophile
+        uses: lsst-sqre/run-neophile@v1
+        with:
+          python-version: "3.11"
+          mode: pr
+          types: pre-commit
+          app-id: {{ "${{ secrets.NEOPHILE_APP_ID }}" }}
+          app-secret: {{ "${{ secrets.NEOPHILE_PRIVATE_KEY }}" }}
+
+      - name: Report status
+        if: always()
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: {{ "${{ job.status }}" }}
+          notify_when: "failure"
+          notification_title: "Periodic dependency update for {repo} failed"
+        env:
+          SLACK_WEBHOOK_URL: {{ "${{ secrets.SLACK_ALERT_WEBHOOK }}" }}
+{%- endif %}


### PR DESCRIPTION
Add support for neophile to both the fastapi_safir_app and square_pypi_package project templates.

For FastAPI apps with frozen dependencies, this means running neophile as a separate CI check on each pull request, running a periodic CI check that runs neophile and then the test suite, and adding a periodic GitHub Actions workflow to create a PR to update pre-commit dependencies.

For SQuaRE PyPI packages, this means running only the periodic workflow to create a PR to update pre-commit dependencies, since the other two steps are related to frozen dependencies.

If the created package is in lsst-sqre, report failures of the periodic GitHub Actions workflows to Slack.