### PR TITLE
DM-40059: Pin documenteer, add dependabot configuration

### DIFF
--- a/project_templates/square_pypi_package/example/pyproject.toml
+++ b/project_templates/square_pypi_package/example/pyproject.toml
@@ -33,7 +33,7 @@ dev = [
     "pre-commit",
     "mypy",
     # Documentation
-    "documenteer[guide]",
+    "documenteer[guide]<1",
 ]
 
 [project.urls]

--- a/project_templates/square_pypi_package/{{cookiecutter.name}}/pyproject.toml
+++ b/project_templates/square_pypi_package/{{cookiecutter.name}}/pyproject.toml
@@ -33,7 +33,7 @@ dev = [
     "pre-commit",
     "mypy",
     # Documentation
-    "documenteer[guide]",
+    "documenteer[guide]<1",
 ]
 
 [project.urls]

--- a/project_templates/technote_rst/testn-000/.github/dependabot.yml
+++ b/project_templates/technote_rst/testn-000/.github/dependabot.yml
@@ -4,3 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/project_templates/technote_rst/testn-000/requirements.txt
+++ b/project_templates/technote_rst/testn-000/requirements.txt
@@ -1,1 +1,1 @@
-documenteer[technote]
+documenteer[technote]<1

--- a/project_templates/technote_rst/{{cookiecutter.repo_name}}/.github/dependabot.yml
+++ b/project_templates/technote_rst/{{cookiecutter.repo_name}}/.github/dependabot.yml
@@ -4,3 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/project_templates/technote_rst/{{cookiecutter.repo_name}}/requirements.txt
+++ b/project_templates/technote_rst/{{cookiecutter.repo_name}}/requirements.txt
@@ -1,1 +1,1 @@
-documenteer[technote]
+documenteer[technote]<1


### PR DESCRIPTION
Pin documenteer to <1 for square_pypi_project and technote_rst so that we have more intentional control over when we move to newer versions of the documentation stack. Add dependabot configuration for PyPI dependencies to technote_rst so that dependabot will create PRs to move to newer versions of documenteer.