### PR TITLE
DM-40495: Better error reporting from Sphinx linkcheck

### DIFF
--- a/project_templates/square_pypi_package/example/Makefile
+++ b/project_templates/square_pypi_package/example/Makefile
@@ -1,3 +1,16 @@
+.PHONY: help
+help:
+	@echo "Make targets for example:"
+	@echo "make clean - Remove generated files"
+	@echo "make init - Set up dev environment (install pre-commit hooks)"
+	@echo "make linkcheck - Check for broken links in documentation"
+
+.PHONY: clean
+clean:
+	rm -rf .tox
+	rm -rf docs/_build
+	rm -rf docs/api
+
 .PHONY: init
 init:
 	pip install --upgrade pip tox pre-commit
@@ -5,8 +18,12 @@ init:
 	pre-commit install
 	rm -rf .tox
 
-.PHONY: clean
-clean:
-	rm -rf .tox
-	rm -rf docs/_build
-	rm -rf docs/api
+# This is defined as a Makefile target instead of only a tox command because
+# if the command fails we want to cat output.txt, which contains the
+# actually useful linkcheck output. tox unfortunately doesn't support this
+# level of shell trickery after failed commands.
+.PHONY: linkcheck
+linkcheck:
+	sphinx-build --keep-going -n -W -T -b linkcheck docs	\
+	    docs/_build/linkcheck				\
+	    || (cat docs/_build/linkcheck/output.txt; exit 1)

--- a/project_templates/square_pypi_package/example/tox.ini
+++ b/project_templates/square_pypi_package/example/tox.ini
@@ -41,5 +41,7 @@ commands =
 
 [testenv:docs-linkcheck]
 description = Check links in the documentation.
+allowlist_externals =
+    make
 commands =
-    sphinx-build --keep-going -n -W -T -b linkcheck -d {envtmpdir}/doctrees docs docs/_build/linkcheck
+    make linkcheck

--- a/project_templates/square_pypi_package/{{cookiecutter.name}}/Makefile
+++ b/project_templates/square_pypi_package/{{cookiecutter.name}}/Makefile
@@ -1,3 +1,16 @@
+.PHONY: help
+help:
+	@echo "Make targets for {{cookiecutter.name}}:"
+	@echo "make clean - Remove generated files"
+	@echo "make init - Set up dev environment (install pre-commit hooks)"
+	@echo "make linkcheck - Check for broken links in documentation"
+
+.PHONY: clean
+clean:
+	rm -rf .tox
+	rm -rf docs/_build
+	rm -rf docs/api
+
 .PHONY: init
 init:
 	pip install --upgrade pip tox pre-commit
@@ -5,8 +18,12 @@ init:
 	pre-commit install
 	rm -rf .tox
 
-.PHONY: clean
-clean:
-	rm -rf .tox
-	rm -rf docs/_build
-	rm -rf docs/api
+# This is defined as a Makefile target instead of only a tox command because
+# if the command fails we want to cat output.txt, which contains the
+# actually useful linkcheck output. tox unfortunately doesn't support this
+# level of shell trickery after failed commands.
+.PHONY: linkcheck
+linkcheck:
+	sphinx-build --keep-going -n -W -T -b linkcheck docs	\
+	    docs/_build/linkcheck				\
+	    || (cat docs/_build/linkcheck/output.txt; exit 1)

--- a/project_templates/square_pypi_package/{{cookiecutter.name}}/tox.ini
+++ b/project_templates/square_pypi_package/{{cookiecutter.name}}/tox.ini
@@ -41,5 +41,7 @@ commands =
 
 [testenv:docs-linkcheck]
 description = Check links in the documentation.
+allowlist_externals =
+    make
 commands =
-    sphinx-build --keep-going -n -W -T -b linkcheck -d {envtmpdir}/doctrees docs docs/_build/linkcheck
+    make linkcheck


### PR DESCRIPTION
Sphinx linkcheck doesn't produce a summary of failed links, but it does write one to output.txt. Move the linkcheck command into the Makefile so that we can use shell trickery to display the contents of that file on failure.

Add a help target as the default target in Makefile.