### PR TITLE
DM-41517: Minor updates to early-adopter technote templates and SQR for ADASS

### DIFF
--- a/project_templates/technote_adasstex/cookiecutter.json
+++ b/project_templates/technote_adasstex/cookiecutter.json
@@ -8,6 +8,7 @@
     "DMTN",
     "PSTN",
     "SMTN",
+    "SQR",
     "TSTN",
     "ITTN",
     "TESTN"

--- a/project_templates/technote_adasstex/templatekit.yaml
+++ b/project_templates/technote_adasstex/templatekit.yaml
@@ -38,6 +38,12 @@ dialog_fields:
           series: "SMTN"
           github_org: "lsst-sims"
           org: "SE"
+      - label: "SQR"
+        value: "sqr"
+        presets:
+          series: "SQR"
+          github_org: "lsst-sqre"
+          org: "DM"
       - label: "TSTN"
         value: "tstn"
         presets:

--- a/project_templates/technote_md_early_adopter/testn-000/.pre-commit-config.yaml
+++ b/project_templates/technote_md_early_adopter/testn-000/.pre-commit-config.yaml
@@ -2,6 +2,6 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:
-      - id: trailing-whitespace
+      # - id: trailing-whitespace
       - id: check-yaml
       - id: check-toml

--- a/project_templates/technote_md_early_adopter/testn-000/technote.toml
+++ b/project_templates/technote_md_early_adopter/testn-000/technote.toml
@@ -4,7 +4,7 @@ series_id = "TESTN"
 canonical_url = "https://testn-000.lsst.io"
 github_url = "https://github.com/lsst/testn-000"
 github_default_branch = "main"
-date_created = "2023-11-01T17:04:08Z"
+date_created = "2023-11-03T14:04:53Z"
 
 [[technote.authors]]
 name = { name = "First Last" }

--- a/project_templates/technote_md_early_adopter/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
+++ b/project_templates/technote_md_early_adopter/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
@@ -2,6 +2,6 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:
-      - id: trailing-whitespace
+      # - id: trailing-whitespace
       - id: check-yaml
       - id: check-toml

--- a/project_templates/technote_rst_early_adopter/testn-000/.pre-commit-config.yaml
+++ b/project_templates/technote_rst_early_adopter/testn-000/.pre-commit-config.yaml
@@ -2,6 +2,6 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:
-      - id: trailing-whitespace
+      # - id: trailing-whitespace
       - id: check-yaml
       - id: check-toml

--- a/project_templates/technote_rst_early_adopter/testn-000/technote.toml
+++ b/project_templates/technote_rst_early_adopter/testn-000/technote.toml
@@ -4,7 +4,7 @@ series_id = "TESTN"
 canonical_url = "https://testn-000.lsst.io"
 github_url = "https://github.com/lsst/testn-000"
 github_default_branch = "main"
-date_created = "2023-11-01T17:04:08Z"
+date_created = "2023-11-03T14:04:53Z"
 
 [[technote.authors]]
 name = { name = "First Last" }

--- a/project_templates/technote_rst_early_adopter/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
+++ b/project_templates/technote_rst_early_adopter/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
@@ -2,6 +2,6 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:
-      - id: trailing-whitespace
+      # - id: trailing-whitespace
       - id: check-yaml
       - id: check-toml


### PR DESCRIPTION
- In the early-adopter MD and rst technotes, comment out the trailing whitespace pre-commit hook to make it opt-in (@frossie)
- In the ADASS template, add SQR as a eligible series.