### PR TITLE
DM-41781: Update author metadata in technotes

### DIFF
--- a/project_templates/technote_md_early_adopter/SConscript
+++ b/project_templates/technote_md_early_adopter/SConscript
@@ -5,5 +5,14 @@ env = Environment(BUILDERS={"Cookiecutter": cookiecutter_project_builder})
 env.Cookiecutter(
     AlwaysBuild(Dir("TESTN-000")),
     "cookiecutter.json",
-    cookiecutter_context={"series": "TESTN"},
+    cookiecutter_context={
+        "series": "TESTN",
+        "first_author_given": "First",
+        "first_author_family": "Author",
+        "first_author_orcid": "https://orcid.org/0000-0003-3001-676X",
+        "first_author_author_id": "test",
+        "first_author_affil_name": "Rubin Observatory",
+        "first_author_affil_internal_id": "RubinObs",
+        "first_author_affil_address": ("950 N. Cherry Ave., Tucson, AZ 85719, USA",),
+    },
 )

--- a/project_templates/technote_md_early_adopter/cookiecutter.json
+++ b/project_templates/technote_md_early_adopter/cookiecutter.json
@@ -1,5 +1,5 @@
 {
-  "first_author": "First Last",
+  "author_id": "ID from lsst-texmf/etc/authordb.yaml",
   "series": [
     "DMTN",
     "ITTN",
@@ -40,6 +40,12 @@
     "University of Illinois Board of Trustees",
     "University of Washington"
   ],
+  "first_author_given": "",
+  "first_author_family": "",
+  "first_author_orcid": "",
+  "first_author_affil_name": "",
+  "first_author_affil_internal_id": "",
+  "first_author_affil_address": "",
   "_copy_without_render": [
     "*.bib"
   ],

--- a/project_templates/technote_md_early_adopter/templatekit.yaml
+++ b/project_templates/technote_md_early_adopter/templatekit.yaml
@@ -12,6 +12,11 @@ dialog_fields:
     hint: "You can use Markdown here."
     component: "textarea"
     placeholder: ""
+  - key: "author_id"
+    label: "First author's ID"
+    hint: "ID is a key from lsst-texmf's authordb.yaml (http://ls.st/uyr)"
+    component: "text"
+    placeholder: ""
   - label: "Series"
     component: "select"
     preset_options:

--- a/project_templates/technote_md_early_adopter/testn-000/technote.toml
+++ b/project_templates/technote_md_early_adopter/testn-000/technote.toml
@@ -4,14 +4,19 @@ series_id = "TESTN"
 canonical_url = "https://testn-000.lsst.io"
 github_url = "https://github.com/lsst/testn-000"
 github_default_branch = "main"
-date_created = "2023-11-03T14:04:53Z"
-
-[[technote.authors]]
-name = { name = "First Last" }
-# orcid = "https://orcid.org/..."
-# affiliations = [
-#     { name = "Rubin Observatory", ror = "https://ror.org/048g3cy84" }
-# ]
+date_created = 2023-11-28T18:49:47Z
+organization.name = "Vera C. Rubin Observatory"
+organization.ror = "https://ror.org/048g3cy84"
 
 [technote.status]
 state = "draft"
+
+[[technote.authors]]
+name.given "First"
+name.family "Author"
+orcid = "https://orcid.org/0000-0003-3001-676X"
+internal_id = "ID from lsst-texmf/etc/authordb.yaml"
+[[technote.authors.affiliations]]
+name = "Rubin Observatory"
+internal_id = "RubinObs"
+address = "('950 N. Cherry Ave., Tucson, AZ 85719, USA',)"

--- a/project_templates/technote_md_early_adopter/{{cookiecutter.repo_name}}/technote.toml
+++ b/project_templates/technote_md_early_adopter/{{cookiecutter.repo_name}}/technote.toml
@@ -4,14 +4,19 @@ series_id = "{{ cookiecutter.series | escape_yaml_doublequoted }}"
 canonical_url = "{{ cookiecutter.url | escape_yaml_doublequoted }}"
 github_url = "https://github.com/{{ cookiecutter.github_namespace | escape_yaml_doublequoted }}"
 github_default_branch = "main"
-date_created = "{% now 'utc', '%Y-%m-%dT%H:%M:%SZ' %}"
-
-[[technote.authors]]
-name = { name = "{{ cookiecutter.first_author }}" }
-# orcid = "https://orcid.org/..."
-# affiliations = [
-#     { name = "Rubin Observatory", ror = "https://ror.org/048g3cy84" }
-# ]
+date_created = {% now 'utc', '%Y-%m-%dT%H:%M:%SZ' %}
+organization.name = "Vera C. Rubin Observatory"
+organization.ror = "https://ror.org/048g3cy84"
 
 [technote.status]
 state = "draft"
+
+[[technote.authors]]
+name.given "{{ cookiecutter.first_author_given }}"
+name.family "{{ cookiecutter.first_author_family }}"
+orcid = "{{ cookiecutter.first_author_orcid }}"
+internal_id = "{{ cookiecutter.author_id }}"
+[[technote.authors.affiliations]]
+name = "{{ cookiecutter.first_author_affil_name }}"
+internal_id = "{{ cookiecutter.first_author_affil_internal_id }}"
+address = "{{ cookiecutter.first_author_affil_address }}"

--- a/project_templates/technote_rst_early_adopter/SConscript
+++ b/project_templates/technote_rst_early_adopter/SConscript
@@ -5,5 +5,14 @@ env = Environment(BUILDERS={"Cookiecutter": cookiecutter_project_builder})
 env.Cookiecutter(
     AlwaysBuild(Dir("TESTN-000")),
     "cookiecutter.json",
-    cookiecutter_context={"series": "TESTN"},
+    cookiecutter_context={
+        "series": "TESTN",
+        "first_author_given": "First",
+        "first_author_family": "Author",
+        "first_author_orcid": "https://orcid.org/0000-0003-3001-676X",
+        "first_author_author_id": "test",
+        "first_author_affil_name": "Rubin Observatory",
+        "first_author_affil_internal_id": "RubinObs",
+        "first_author_affil_address": ("950 N. Cherry Ave., Tucson, AZ 85719, USA",),
+    },
 )

--- a/project_templates/technote_rst_early_adopter/cookiecutter.json
+++ b/project_templates/technote_rst_early_adopter/cookiecutter.json
@@ -1,5 +1,5 @@
 {
-  "first_author": "First Last",
+  "author_id": "ID from lsst-texmf/etc/authordb.yaml",
   "series": [
     "DMTN",
     "ITTN",
@@ -40,6 +40,12 @@
     "University of Illinois Board of Trustees",
     "University of Washington"
   ],
+  "first_author_given": "",
+  "first_author_family": "",
+  "first_author_orcid": "",
+  "first_author_affil_name": "",
+  "first_author_affil_internal_id": "",
+  "first_author_affil_address": "",
   "_copy_without_render": [
     "*.bib"
   ],

--- a/project_templates/technote_rst_early_adopter/templatekit.yaml
+++ b/project_templates/technote_rst_early_adopter/templatekit.yaml
@@ -12,6 +12,11 @@ dialog_fields:
     hint: "You can use reStructuredText here."
     component: "textarea"
     placeholder: ""
+  - key: "author_id"
+    label: "First author's ID"
+    hint: "ID is a key from lsst-texmf's authordb.yaml (http://ls.st/uyr)"
+    component: "text"
+    placeholder: ""
   - label: "Series"
     component: "select"
     preset_options:

--- a/project_templates/technote_rst_early_adopter/testn-000/technote.toml
+++ b/project_templates/technote_rst_early_adopter/testn-000/technote.toml
@@ -4,14 +4,19 @@ series_id = "TESTN"
 canonical_url = "https://testn-000.lsst.io"
 github_url = "https://github.com/lsst/testn-000"
 github_default_branch = "main"
-date_created = "2023-11-03T14:04:53Z"
-
-[[technote.authors]]
-name = { name = "First Last" }
-# orcid = "https://orcid.org/..."
-# affiliations = [
-#     { name = "Rubin Observatory", ror = "https://ror.org/048g3cy84" }
-# ]
+date_created = 2023-11-28T18:49:47Z
+organization.name = "Vera C. Rubin Observatory"
+organization.ror = "https://ror.org/048g3cy84"
 
 [technote.status]
 state = "draft"
+
+[[technote.authors]]
+name.given "First"
+name.family "Author"
+orcid = "https://orcid.org/0000-0003-3001-676X"
+internal_id = "ID from lsst-texmf/etc/authordb.yaml"
+[[technote.authors.affiliations]]
+name = "Rubin Observatory"
+internal_id = "RubinObs"
+address = "('950 N. Cherry Ave., Tucson, AZ 85719, USA',)"

--- a/project_templates/technote_rst_early_adopter/{{cookiecutter.repo_name}}/technote.toml
+++ b/project_templates/technote_rst_early_adopter/{{cookiecutter.repo_name}}/technote.toml
@@ -4,14 +4,19 @@ series_id = "{{ cookiecutter.series | escape_yaml_doublequoted }}"
 canonical_url = "{{ cookiecutter.url | escape_yaml_doublequoted }}"
 github_url = "https://github.com/{{ cookiecutter.github_namespace | escape_yaml_doublequoted }}"
 github_default_branch = "main"
-date_created = "{% now 'utc', '%Y-%m-%dT%H:%M:%SZ' %}"
-
-[[technote.authors]]
-name = { name = "{{ cookiecutter.first_author }}" }
-# orcid = "https://orcid.org/..."
-# affiliations = [
-#     { name = "Rubin Observatory", ror = "https://ror.org/048g3cy84" }
-# ]
+date_created = {% now 'utc', '%Y-%m-%dT%H:%M:%SZ' %}
+organization.name = "Vera C. Rubin Observatory"
+organization.ror = "https://ror.org/048g3cy84"
 
 [technote.status]
 state = "draft"
+
+[[technote.authors]]
+name.given "{{ cookiecutter.first_author_given }}"
+name.family "{{ cookiecutter.first_author_family }}"
+orcid = "{{ cookiecutter.first_author_orcid }}"
+internal_id = "{{ cookiecutter.author_id }}"
+[[technote.authors.affiliations]]
+name = "{{ cookiecutter.first_author_affil_name }}"
+internal_id = "{{ cookiecutter.first_author_affil_internal_id }}"
+address = "{{ cookiecutter.first_author_affil_address }}"


### PR DESCRIPTION
The rst and md-formatted Sphinx technotes now use the author ID to correspond with the authodb.yaml file in github.com/lsst/lsst-texmf. This allows us to add more structured metadata about authors that is necessary for crosswalking to bibliographic schemas like Zenodo or CITATION.cff.

Other changes in technote.toml templating:

- add the organization field to technote.toml
- record `date_created` as a native TOML date-time, rather than a string.