### PR TITLE
DM-42140: Add the add-author and sync-authors commands to technote tox envs

### DIFF
--- a/project_templates/technote_md_early_adopter/testn-000/Makefile
+++ b/project_templates/technote_md_early_adopter/testn-000/Makefile
@@ -12,6 +12,14 @@ lint:
 	tox run -e lint,link-check
 
 .PHONY:
+add-author:
+	tox run -e add-author
+
+.PHONY:
+sync-authors:
+	tox run -e sync-authors
+
+.PHONY:
 clean:
 	rm -rf _build
 	rm -rf .technote

--- a/project_templates/technote_md_early_adopter/testn-000/technote.toml
+++ b/project_templates/technote_md_early_adopter/testn-000/technote.toml
@@ -4,7 +4,7 @@ series_id = "TESTN"
 canonical_url = "https://testn-000.lsst.io"
 github_url = "https://github.com/lsst/testn-000"
 github_default_branch = "main"
-date_created = 2023-11-28T19:40:44Z
+date_created = 2023-12-12T20:30:05Z
 organization.name = "Vera C. Rubin Observatory"
 organization.ror = "https://ror.org/048g3cy84"
 

--- a/project_templates/technote_md_early_adopter/testn-000/tox.ini
+++ b/project_templates/technote_md_early_adopter/testn-000/tox.ini
@@ -16,5 +16,6 @@ commands =
    sphinx-build --keep-going -n -W -T -b linkcheck -d _build/doctrees . _build/linkcheck
 
 [testenv:lint]
+deps = pre-commit
 commands =
    pre-commit run --all-files

--- a/project_templates/technote_md_early_adopter/testn-000/tox.ini
+++ b/project_templates/technote_md_early_adopter/testn-000/tox.ini
@@ -19,3 +19,11 @@ commands =
 deps = pre-commit
 commands =
    pre-commit run --all-files
+
+[testenv:add-author]
+commands =
+   documenteer technote add-author
+
+[testenv:sync-authors]
+commands =
+   documenteer technote sync-authors

--- a/project_templates/technote_md_early_adopter/{{cookiecutter.repo_name}}/Makefile
+++ b/project_templates/technote_md_early_adopter/{{cookiecutter.repo_name}}/Makefile
@@ -12,6 +12,14 @@ lint:
 	tox run -e lint,link-check
 
 .PHONY:
+add-author:
+	tox run -e add-author
+
+.PHONY:
+sync-authors:
+	tox run -e sync-authors
+
+.PHONY:
 clean:
 	rm -rf _build
 	rm -rf .technote

--- a/project_templates/technote_md_early_adopter/{{cookiecutter.repo_name}}/tox.ini
+++ b/project_templates/technote_md_early_adopter/{{cookiecutter.repo_name}}/tox.ini
@@ -16,5 +16,6 @@ commands =
    sphinx-build --keep-going -n -W -T -b linkcheck -d _build/doctrees . _build/linkcheck
 
 [testenv:lint]
+deps = pre-commit
 commands =
    pre-commit run --all-files

--- a/project_templates/technote_md_early_adopter/{{cookiecutter.repo_name}}/tox.ini
+++ b/project_templates/technote_md_early_adopter/{{cookiecutter.repo_name}}/tox.ini
@@ -19,3 +19,11 @@ commands =
 deps = pre-commit
 commands =
    pre-commit run --all-files
+
+[testenv:add-author]
+commands =
+   documenteer technote add-author
+
+[testenv:sync-authors]
+commands =
+   documenteer technote sync-authors

--- a/project_templates/technote_rst_early_adopter/testn-000/Makefile
+++ b/project_templates/technote_rst_early_adopter/testn-000/Makefile
@@ -12,6 +12,14 @@ lint:
 	tox run -e lint,link-check
 
 .PHONY:
+add-author:
+	tox run -e add-author
+
+.PHONY:
+sync-authors:
+	tox run -e sync-authors
+
+.PHONY:
 clean:
 	rm -rf _build
 	rm -rf .technote

--- a/project_templates/technote_rst_early_adopter/testn-000/technote.toml
+++ b/project_templates/technote_rst_early_adopter/testn-000/technote.toml
@@ -4,7 +4,7 @@ series_id = "TESTN"
 canonical_url = "https://testn-000.lsst.io"
 github_url = "https://github.com/lsst/testn-000"
 github_default_branch = "main"
-date_created = 2023-11-28T19:40:44Z
+date_created = 2023-12-12T20:30:05Z
 organization.name = "Vera C. Rubin Observatory"
 organization.ror = "https://ror.org/048g3cy84"
 

--- a/project_templates/technote_rst_early_adopter/testn-000/tox.ini
+++ b/project_templates/technote_rst_early_adopter/testn-000/tox.ini
@@ -16,5 +16,6 @@ commands =
    sphinx-build --keep-going -n -W -T -b linkcheck -d _build/doctrees . _build/linkcheck
 
 [testenv:lint]
+deps = pre-commit
 commands =
    pre-commit run --all-files

--- a/project_templates/technote_rst_early_adopter/testn-000/tox.ini
+++ b/project_templates/technote_rst_early_adopter/testn-000/tox.ini
@@ -19,3 +19,12 @@ commands =
 deps = pre-commit
 commands =
    pre-commit run --all-files
+
+[testenv:add-author]
+commands =
+   documenteer technote add-author
+
+[testenv:sync-authors]
+commands =
+   documenteer technote sync-authors
+

--- a/project_templates/technote_rst_early_adopter/{{cookiecutter.repo_name}}/Makefile
+++ b/project_templates/technote_rst_early_adopter/{{cookiecutter.repo_name}}/Makefile
@@ -12,6 +12,14 @@ lint:
 	tox run -e lint,link-check
 
 .PHONY:
+add-author:
+	tox run -e add-author
+
+.PHONY:
+sync-authors:
+	tox run -e sync-authors
+
+.PHONY:
 clean:
 	rm -rf _build
 	rm -rf .technote

--- a/project_templates/technote_rst_early_adopter/{{cookiecutter.repo_name}}/tox.ini
+++ b/project_templates/technote_rst_early_adopter/{{cookiecutter.repo_name}}/tox.ini
@@ -16,5 +16,6 @@ commands =
    sphinx-build --keep-going -n -W -T -b linkcheck -d _build/doctrees . _build/linkcheck
 
 [testenv:lint]
+deps = pre-commit
 commands =
    pre-commit run --all-files

--- a/project_templates/technote_rst_early_adopter/{{cookiecutter.repo_name}}/tox.ini
+++ b/project_templates/technote_rst_early_adopter/{{cookiecutter.repo_name}}/tox.ini
@@ -19,3 +19,12 @@ commands =
 deps = pre-commit
 commands =
    pre-commit run --all-files
+
+[testenv:add-author]
+commands =
+   documenteer technote add-author
+
+[testenv:sync-authors]
+commands =
+   documenteer technote sync-authors
+


### PR DESCRIPTION
These tox environments and corresponding make targets make it possible to run these documenteer commands through the isolated tox environment.