### PR TITLE
DM-42144: Add license.id fields to technote.toml files in early-adopter technote templates

### DIFF
--- a/project_templates/technote_md_early_adopter/testn-000/technote.toml
+++ b/project_templates/technote_md_early_adopter/testn-000/technote.toml
@@ -4,9 +4,10 @@ series_id = "TESTN"
 canonical_url = "https://testn-000.lsst.io"
 github_url = "https://github.com/lsst/testn-000"
 github_default_branch = "main"
-date_created = 2023-12-12T20:30:05Z
+date_created = 2023-12-12T21:55:58Z
 organization.name = "Vera C. Rubin Observatory"
 organization.ror = "https://ror.org/048g3cy84"
+license.id = "CC-BY-4.0"
 
 [technote.status]
 state = "draft"

--- a/project_templates/technote_md_early_adopter/{{cookiecutter.repo_name}}/technote.toml
+++ b/project_templates/technote_md_early_adopter/{{cookiecutter.repo_name}}/technote.toml
@@ -7,6 +7,7 @@ github_default_branch = "main"
 date_created = {% now 'utc', '%Y-%m-%dT%H:%M:%SZ' %}
 organization.name = "Vera C. Rubin Observatory"
 organization.ror = "https://ror.org/048g3cy84"
+license.id = "CC-BY-4.0"
 
 [technote.status]
 state = "draft"

--- a/project_templates/technote_rst_early_adopter/testn-000/technote.toml
+++ b/project_templates/technote_rst_early_adopter/testn-000/technote.toml
@@ -4,9 +4,10 @@ series_id = "TESTN"
 canonical_url = "https://testn-000.lsst.io"
 github_url = "https://github.com/lsst/testn-000"
 github_default_branch = "main"
-date_created = 2023-12-12T20:30:05Z
+date_created = 2023-12-12T21:55:58Z
 organization.name = "Vera C. Rubin Observatory"
 organization.ror = "https://ror.org/048g3cy84"
+license.id = "CC-BY-4.0"
 
 [technote.status]
 state = "draft"

--- a/project_templates/technote_rst_early_adopter/{{cookiecutter.repo_name}}/technote.toml
+++ b/project_templates/technote_rst_early_adopter/{{cookiecutter.repo_name}}/technote.toml
@@ -7,6 +7,7 @@ github_default_branch = "main"
 date_created = {% now 'utc', '%Y-%m-%dT%H:%M:%SZ' %}
 organization.name = "Vera C. Rubin Observatory"
 organization.ror = "https://ror.org/048g3cy84"
+license.id = "CC-BY-4.0"
 
 [technote.status]
 state = "draft"


### PR DESCRIPTION
This metadata corresponds to the existing LICENSE files