### PR TITLE
DM-42142: Rename the rst technote template

### DIFF
--- a/project_templates/technote_rst/templatekit.yaml
+++ b/project_templates/technote_rst/templatekit.yaml
@@ -1,4 +1,4 @@
-name: "Technote (reStructuredText) Early Adopter"
+name: "Technote (reStructuredText)"
 group: "Documents"
 dialog_title: "Create an rst technote"
 dialog_fields:


### PR DESCRIPTION
This is a fixup from the migration of the early-adopter template.