### PR TITLE
DM-42586: Fix whitespace issues in conditional ORCiD

### DIFF
--- a/project_templates/technote_md/testn-000/technote.toml
+++ b/project_templates/technote_md/testn-000/technote.toml
@@ -4,7 +4,7 @@ series_id = "TESTN"
 canonical_url = "https://testn-000.lsst.io"
 github_url = "https://github.com/lsst/testn-000"
 github_default_branch = "main"
-date_created = 2024-01-22T14:59:46Z
+date_created = 2024-01-22T16:44:03Z
 organization.name = "Vera C. Rubin Observatory"
 organization.ror = "https://ror.org/048g3cy84"
 license.id = "CC-BY-4.0"
@@ -15,9 +15,9 @@ state = "draft"
 [[technote.authors]]
 name.given = "First"
 name.family = "Author"
-orcid = "https://orcid.org/0000-0003-3001-676X"
 internal_id = "ID from lsst-texmf/etc/authordb.yaml"
+orcid = "https://orcid.org/0000-0003-3001-676X"
 [[technote.authors.affiliations]]
 name = "Rubin Observatory"
 internal_id = "RubinObs"
-address = "('950 N. Cherry Ave., Tucson, AZ 85719, USA',)"
+address = "950 N. Cherry Ave., Tucson, AZ 85719, USA"

--- a/project_templates/technote_md/{{cookiecutter.repo_name}}/technote.toml
+++ b/project_templates/technote_md/{{cookiecutter.repo_name}}/technote.toml
@@ -15,9 +15,9 @@ state = "draft"
 [[technote.authors]]
 name.given = "{{ cookiecutter.first_author_given }}"
 name.family = "{{ cookiecutter.first_author_family }}"
-{%- if cookiecutter.first_author_orcid %}orcid = "{{ cookiecutter.first_author_orcid }}"{% endif %}
 internal_id = "{{ cookiecutter.author_id }}"
+{% if cookiecutter.first_author_orcid %}orcid = "{{ cookiecutter.first_author_orcid }}"{% endif %}
 [[technote.authors.affiliations]]
 name = "{{ cookiecutter.first_author_affil_name }}"
 internal_id = "{{ cookiecutter.first_author_affil_internal_id }}"
-{%- if cookiecutter.first_author_affil_address %}address = "{{ cookiecutter.first_author_affil_address }}"{% endif %}
+address = "{{ cookiecutter.first_author_affil_address }}"

--- a/project_templates/technote_rst/testn-000/technote.toml
+++ b/project_templates/technote_rst/testn-000/technote.toml
@@ -4,7 +4,7 @@ series_id = "TESTN"
 canonical_url = "https://testn-000.lsst.io"
 github_url = "https://github.com/lsst/testn-000"
 github_default_branch = "main"
-date_created = 2024-01-22T14:59:46Z
+date_created = 2024-01-22T16:44:03Z
 organization.name = "Vera C. Rubin Observatory"
 organization.ror = "https://ror.org/048g3cy84"
 license.id = "CC-BY-4.0"
@@ -16,6 +16,7 @@ state = "draft"
 name.given = "First"
 name.family = "Author"
 internal_id = "ID from lsst-texmf/etc/authordb.yaml"
+
 [[technote.authors.affiliations]]
 name = "Rubin Observatory"
 internal_id = "RubinObs"

--- a/project_templates/technote_rst/{{cookiecutter.repo_name}}/technote.toml
+++ b/project_templates/technote_rst/{{cookiecutter.repo_name}}/technote.toml
@@ -15,9 +15,9 @@ state = "draft"
 [[technote.authors]]
 name.given = "{{ cookiecutter.first_author_given }}"
 name.family = "{{ cookiecutter.first_author_family }}"
-{%- if cookiecutter.first_author_orcid %}orcid = "{{ cookiecutter.first_author_orcid }}"{% endif %}
 internal_id = "{{ cookiecutter.author_id }}"
+{% if cookiecutter.first_author_orcid %}orcid = "{{ cookiecutter.first_author_orcid }}"{% endif %}
 [[technote.authors.affiliations]]
 name = "{{ cookiecutter.first_author_affil_name }}"
 internal_id = "{{ cookiecutter.first_author_affil_internal_id }}"
-{%- if cookiecutter.first_author_affil_address %}address = "{{ cookiecutter.first_author_affil_address }}"{% endif %}
+address = "{{ cookiecutter.first_author_affil_address }}"


### PR DESCRIPTION
The "%-" operator was actually deleting the newline of the previous line too and putting e.g. orcid on the same line as `name.family`. This behaviour didn't show up in testing. We'll revert that and instead just leave the blank line.