### PR TITLE
Add RTN support for SPIE, ADASS, AASTeX templates

### DIFF
--- a/project_templates/technote_aastex/cookiecutter.json
+++ b/project_templates/technote_aastex/cookiecutter.json
@@ -1,18 +1,21 @@
 {
   "org": [
     "DM",
+    "OPS",
     "PST",
     "SE"
   ],
   "series": [
     "DMTN",
     "PSTN",
+    "RTN",
     "SMTN",
     "TSTN",
     "TESTN"
   ],
   "serial_number": "000",
   "github_org": [
+    "lsst",
     "lsst-dm",
     "lsst-pst",
     "lsst-sims",

--- a/project_templates/technote_aastex/templatekit.yaml
+++ b/project_templates/technote_aastex/templatekit.yaml
@@ -32,6 +32,12 @@ dialog_fields:
           series: "PSTN"
           github_org: "lsst-pst"
           org: "PST"
+      - label: "RTN"
+        value: "RTN"
+        presets:
+          series: "RTN"
+          github_org: "lsst"
+          org: "OPS"
       - label: "SMTN"
         value: "smtn"
         presets:

--- a/project_templates/technote_adasstex/cookiecutter.json
+++ b/project_templates/technote_adasstex/cookiecutter.json
@@ -1,12 +1,14 @@
 {
   "org": [
     "DM",
+    "OPS",
     "PST",
     "SE"
   ],
   "series": [
     "DMTN",
     "PSTN",
+    "RTN",
     "SMTN",
     "SQR",
     "TSTN",
@@ -15,6 +17,7 @@
   ],
   "serial_number": "000",
   "github_org": [
+    "lsst",
     "lsst-dm",
     "lsst-pst",
     "lsst-sims",

--- a/project_templates/technote_adasstex/templatekit.yaml
+++ b/project_templates/technote_adasstex/templatekit.yaml
@@ -32,6 +32,12 @@ dialog_fields:
           series: "PSTN"
           github_org: "lsst-pst"
           org: "PST"
+      - label: "RTN"
+        value: "RTN"
+        presets:
+          series: "RTN"
+          github_org: "lsst"
+          org: "OPS"
       - label: "SMTN"
         value: "smtn"
         presets:

--- a/project_templates/technote_spietex/cookiecutter.json
+++ b/project_templates/technote_spietex/cookiecutter.json
@@ -1,12 +1,14 @@
 {
   "org": [
     "DM",
+    "OPS",
     "PST",
     "SE"
   ],
   "series": [
     "DMTN",
     "PSTN",
+    "RTN",
     "SMTN",
     "TSTN",
     "ITTN",
@@ -14,6 +16,7 @@
   ],
   "serial_number": "000",
   "github_org": [
+    "lsst",
     "lsst-dm",
     "lsst-pst",
     "lsst-sims",

--- a/project_templates/technote_spietex/templatekit.yaml
+++ b/project_templates/technote_spietex/templatekit.yaml
@@ -32,6 +32,12 @@ dialog_fields:
           series: "PSTN"
           github_org: "lsst-pst"
           org: "PST"
+      - label: "RTN"
+        value: "RTN"
+        presets:
+          series: "RTN"
+          github_org: "lsst"
+          org: "OPS"
       - label: "SMTN"
         value: "smtn"
         presets:


### PR DESCRIPTION
Now we can create proceedings for SPIE and ADASS and write for AAS journals as an RTN (Rubin technote) document, rather than a subsystem technote.