### PR TITLE
DM-49410: Update github orgs for ASCOMTeX and ADASSTeX templates

### DIFF
--- a/project_templates/technote_aastex/cookiecutter.json
+++ b/project_templates/technote_aastex/cookiecutter.json
@@ -11,6 +11,7 @@
     "PSTN",
     "RTN",
     "SMTN",
+    "SQR",
     "TSTN",
     "TESTN"
   ],
@@ -20,6 +21,8 @@
     "lsst-dm",
     "lsst-pst",
     "lsst-sims",
+    "lsst-sqre",
+    "lsst-tstn",
     "lsst-sqre-testing"
 
   ],

--- a/project_templates/technote_aastex/templatekit.yaml
+++ b/project_templates/technote_aastex/templatekit.yaml
@@ -50,6 +50,12 @@ dialog_fields:
           series: "SMTN"
           github_org: "lsst-sims"
           org: "SE"
+      - label: "SQR"
+        value: "sqr"
+        presets:
+          series: "SQR"
+          github_org: "lsst-sqre"
+          org: "DM"
       - label: "TSTN"
         value: "tstn"
         presets:

--- a/project_templates/technote_adasstex/cookiecutter.json
+++ b/project_templates/technote_adasstex/cookiecutter.json
@@ -22,6 +22,8 @@
     "lsst-dm",
     "lsst-pst",
     "lsst-sims",
+    "lsst-sqre",
+    "lsst-tstn",
     "lsst-sqre-testing"
 
   ],

--- a/project_templates/technote_ascomtex/cookiecutter.json
+++ b/project_templates/technote_ascomtex/cookiecutter.json
@@ -22,6 +22,7 @@
     "lsst-pst",
     "lsst-sims",
     "lsst-sitcom",
+    "lsst-tstn",
     "lsst-sqre-testing"
 
   ],

--- a/project_templates/technote_ascomtex/cookiecutter.json
+++ b/project_templates/technote_ascomtex/cookiecutter.json
@@ -12,6 +12,7 @@
     "RTN",
     "SITCOMTN",
     "SMTN",
+    "SQR",
     "TSTN",
     "TESTN"
   ],
@@ -22,6 +23,7 @@
     "lsst-pst",
     "lsst-sims",
     "lsst-sitcom",
+    "lsst-sqre",
     "lsst-tstn",
     "lsst-sqre-testing"
 

--- a/project_templates/technote_ascomtex/templatekit.yaml
+++ b/project_templates/technote_ascomtex/templatekit.yaml
@@ -50,6 +50,12 @@ dialog_fields:
           series: "SMTN"
           github_org: "lsst-sims"
           org: "SE"
+      - label: "SQR"
+        value: "sqr"
+        presets:
+          series: "SQR"
+          github_org: "lsst-sqre"
+          org: "DM"
       - label: "TSTN"
         value: "tstn"
         presets:


### PR DESCRIPTION
This fixes a situation we ran into for TSTN-050 where the `lsst-tstn` org was not in the cookiecutter.json for the technote_ascomtex template. While I'm at it, I also added SQR to the ASCOMTeX and ADASSTeX templates.