### PR TITLE
DM-55493: Add safir to square_pypi_package dev dependencies

### DIFF
--- a/project_templates/square_pypi_package/example/pyproject.toml
+++ b/project_templates/square_pypi_package/example/pyproject.toml
@@ -32,6 +32,7 @@ dev = [
     "pytest",
     "pytest-asyncio",
     "mypy",
+    "safir>=14.2.0",
     # Documentation
     "documenteer[guide]>=2,<3",
     "scriv",

--- a/project_templates/square_pypi_package/{{cookiecutter.name}}/pyproject.toml
+++ b/project_templates/square_pypi_package/{{cookiecutter.name}}/pyproject.toml
@@ -32,6 +32,7 @@ dev = [
     "pytest",
     "pytest-asyncio",
     "mypy",
+    "safir>=14.2.0",
     # Documentation
     "documenteer[guide]>=2,<3",
     "scriv",


### PR DESCRIPTION
## Summary

The `data` fixture added to both templates in 9f67f2b imports
`safir.testing.data.Data` in the generated `tests/conftest.py`, but
`square_pypi_package`'s `dev` extra lists only coverage, pytest,
pytest-asyncio, mypy, documenteer, and scriv — no safir.

A freshly generated package therefore fails at test collection:

```
ImportError while loading conftest '.../tests/conftest.py'.
ModuleNotFoundError: No module named 'safir'
```

`fastapi_safir_app` is unaffected, since safir is a runtime dependency there.

This adds `safir>=14.2.0` to the `dev` extra — 14.2.0 is the release that
introduced `safir.testing.data`.

## Alternative worth considering

The minimal fix preserves the intent of 9f67f2b, but it does mean every
generated pure-Python package pulls safir into its dev environment purely
for the test-data fixture. If that isn't wanted for a generic PyPI package
template, the other option is to drop the fixture from
`square_pypi_package` instead and keep it in `fastapi_safir_app` only.
Happy to switch this PR to that approach — I picked the one that keeps
the fixture working.

## Validation

- `scons` re-rendered the example; the regenerated
  `square_pypi_package/example/pyproject.toml` is included.
- `templatekit check` (with the two `technote.toml` ignores CI uses)
  passes: `✅ Passed!`

## References

Found while scanning template changes for the lsst-sqre maintenance
catalog. Ticket: DM-55493.