### PR TITLE
DM-55493: Import pytest unconditionally in fastapi_safir_app conftest

### DIFF
--- a/project_templates/fastapi_safir_app/example/tests/conftest.py
+++ b/project_templates/fastapi_safir_app/example/tests/conftest.py
@@ -3,6 +3,7 @@
 from collections.abc import AsyncGenerator
 from pathlib import Path
 
+import pytest
 import pytest_asyncio
 from asgi_lifespan import LifespanManager
 from fastapi import FastAPI

--- a/project_templates/fastapi_safir_app/{{cookiecutter.name}}/tests/conftest.py
+++ b/project_templates/fastapi_safir_app/{{cookiecutter.name}}/tests/conftest.py
@@ -5,9 +5,7 @@ from datetime import timedelta
 {%- endif %}
 from pathlib import Path
 
-{% if cookiecutter.flavor == "UWS" -%}
 import pytest
-{% endif -%}
 import pytest_asyncio
 {%- if cookiecutter.flavor == "UWS" %}
 import structlog


### PR DESCRIPTION
## Summary

In `fastapi_safir_app/{{cookiecutter.name}}/tests/conftest.py` the pytest
import sits inside a UWS-only Jinja conditional:

```jinja
{% if cookiecutter.flavor == "UWS" -%}
import pytest
{% endif -%}
import pytest_asyncio
```

Since 9f67f2b, though, `pytest` is used in **every** flavor —
`pytest_addoption(parser: pytest.Parser)`, `@pytest.fixture def data(...)`,
and `pytest.FixtureRequest`. The committed non-UWS example shows the
result: `example/tests/conftest.py` calls `pytest.Parser` and
`@pytest.fixture` with no `import pytest` anywhere in the file.

A freshly generated non-UWS app fails at collection:

```
NameError: name 'pytest' is not defined
```

This moves the import out of the conditional.

## Validation

- `scons` re-rendered the examples. The diff is exactly what it should be:
  `example/tests/conftest.py` gains `import pytest`, and
  `example-uws/tests/conftest.py` is **unchanged** — the UWS rendering
  stays byte-identical.
- `templatekit check` (with the two `technote.toml` ignores CI uses)
  passes: `✅ Passed!`

## References

Found while scanning template changes for the lsst-sqre maintenance
catalog. Ticket: DM-55493.

Companion PR: #353 fixes the sibling problem in `square_pypi_package`
(conftest imports safir, but the dev extra doesn't include it). The two
are independent.