### PR TITLE
Bump GitHub Actions versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python }}
 
@@ -50,7 +50,7 @@ jobs:
       # Test TeX builds only with the latest Python version, since they're
       # fairly heavy-weight and the Python version shouldn't matter.
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: sqrereadonly
           password: ${{ secrets.DOCKERHUB_SQREREADONLY_TOKEN }}


### PR DESCRIPTION
Update `docker/login-action` and `actions/setup-python`. We cannot easily merge the dependabot PRs currently because the TeX build test requires authentication and thus won't run for dependabot PRs.